### PR TITLE
feat: implement card CRUD operations

### DIFF
--- a/src/actions/cards.ts
+++ b/src/actions/cards.ts
@@ -1,0 +1,193 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { requireAuthenticatedUser } from "@/lib/auth";
+import {
+  normalizeCardDescription,
+  parseCardDueDate,
+  parseCardTitle,
+} from "@/lib/cards";
+import { generateLastPosition } from "@/lib/fractional-index";
+import type { Card, MoveCardValues, UpdateCardValues } from "@/types";
+import type { Database } from "@/types/database";
+
+type AccessibleListRow = Pick<Database["public"]["Tables"]["lists"]["Row"], "id" | "board_id">;
+
+type AccessibleCardRelation = { board_id: string } | Array<{ board_id: string }>;
+
+type AccessibleCardRow = Pick<Database["public"]["Tables"]["cards"]["Row"], "id" | "list_id"> & {
+  lists: AccessibleCardRelation;
+};
+
+function revalidateCardViews(boardId: string) {
+  revalidatePath(`/boards/${boardId}`);
+  revalidatePath("/boards");
+}
+
+function getBoardIdFromRelation(relation: AccessibleCardRelation) {
+  if (Array.isArray(relation)) {
+    return relation[0]?.board_id ?? null;
+  }
+
+  return relation.board_id;
+}
+
+async function getAccessibleList(
+  supabase: SupabaseClient<Database>,
+  listId: string
+): Promise<AccessibleListRow> {
+  const { data, error } = await supabase
+    .from("lists")
+    .select("id, board_id")
+    .eq("id", listId)
+    .single();
+
+  if (error || !data) {
+    throw new Error("List not found or access denied.");
+  }
+
+  return data as AccessibleListRow;
+}
+
+async function getAccessibleCard(
+  supabase: SupabaseClient<Database>,
+  cardId: string
+): Promise<{ boardId: string }> {
+  const { data, error } = await supabase
+    .from("cards")
+    .select("id, list_id, lists!inner(board_id)")
+    .eq("id", cardId)
+    .single();
+
+  if (error || !data) {
+    throw new Error("Card not found or access denied.");
+  }
+
+  const card = data as AccessibleCardRow;
+  const boardId = getBoardIdFromRelation(card.lists);
+
+  if (!boardId) {
+    throw new Error("Card board could not be determined.");
+  }
+
+  return { boardId };
+}
+
+export async function createCard(listId: string, title: string): Promise<Card> {
+  const { supabase } = await requireAuthenticatedUser();
+  const list = await getAccessibleList(supabase, listId);
+  const parsedTitle = parseCardTitle(title);
+
+  const { data: lastCard } = await supabase
+    .from("cards")
+    .select("position")
+    .eq("list_id", listId)
+    .order("position", { ascending: false })
+    .limit(1)
+    .single();
+
+  const position = generateLastPosition(lastCard?.position ?? null);
+
+  const { data, error } = await supabase
+    .from("cards")
+    .insert({
+      list_id: listId,
+      title: parsedTitle,
+      position,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidateCardViews(list.board_id);
+
+  return data as Card;
+}
+
+export async function updateCard(input: UpdateCardValues): Promise<Card> {
+  const { supabase } = await requireAuthenticatedUser();
+  const existingCard = await getAccessibleCard(supabase, input.cardId);
+  const updates: Database["public"]["Tables"]["cards"]["Update"] = {};
+
+  if (input.title !== undefined) {
+    updates.title = parseCardTitle(input.title);
+  }
+
+  if (input.description !== undefined) {
+    updates.description = normalizeCardDescription(input.description);
+  }
+
+  if (input.dueDate !== undefined) {
+    updates.due_date = parseCardDueDate(input.dueDate);
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw new Error("No card changes were provided.");
+  }
+
+  const { data, error } = await supabase
+    .from("cards")
+    .update(updates)
+    .eq("id", input.cardId)
+    .select("*")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidateCardViews(existingCard.boardId);
+
+  return data as Card;
+}
+
+export async function deleteCard(cardId: string): Promise<void> {
+  const { supabase } = await requireAuthenticatedUser();
+  const existingCard = await getAccessibleCard(supabase, cardId);
+
+  const { error } = await supabase.from("cards").delete().eq("id", cardId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidateCardViews(existingCard.boardId);
+}
+
+export async function moveCard(input: MoveCardValues): Promise<Card> {
+  const { supabase } = await requireAuthenticatedUser();
+  const existingCard = await getAccessibleCard(supabase, input.cardId);
+  const targetList = await getAccessibleList(supabase, input.listId);
+  const nextPosition = input.position.trim();
+
+  if (!nextPosition) {
+    throw new Error("A valid card position is required.");
+  }
+
+  if (existingCard.boardId !== targetList.board_id) {
+    throw new Error("Cards can only be moved within the same board.");
+  }
+
+  const { data, error } = await supabase
+    .from("cards")
+    .update({
+      list_id: input.listId,
+      position: nextPosition,
+    })
+    .eq("id", input.cardId)
+    .select("*")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidateCardViews(existingCard.boardId);
+
+  return data as Card;
+}

--- a/src/components/board/BoardDetailClient.tsx
+++ b/src/components/board/BoardDetailClient.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 
 import { getBoardBackground } from "@/lib/backgrounds";
 import { sortByPosition } from "@/lib/fractional-index";
-import type { BoardWithDetails } from "@/types";
+import type { BoardWithDetails, CardUpdatePatch } from "@/types";
 import AddListButton from "@/components/list/AddListButton";
 import ListColumn from "@/components/list/ListColumn";
 import BoardHeader from "@/components/board/BoardHeader";
@@ -32,6 +32,9 @@ export default function BoardDetailClient({ initialBoard }: BoardDetailClientPro
   const addList = useBoardStore((state) => state.addList);
   const updateListTitle = useBoardStore((state) => state.updateListTitle);
   const removeList = useBoardStore((state) => state.removeList);
+  const addCard = useBoardStore((state) => state.addCard);
+  const updateCard = useBoardStore((state) => state.updateCard);
+  const removeCard = useBoardStore((state) => state.removeCard);
 
   const initialLists = useMemo(
     () =>
@@ -96,6 +99,37 @@ export default function BoardDetailClient({ initialBoard }: BoardDetailClientPro
     }
   };
 
+  const handleAddCard = async (listId: string, title: string) => {
+    try {
+      const card = await addCard(listId, title);
+      toast.success(`Created card "${card.title}".`);
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+      throw error;
+    }
+  };
+
+  const handleUpdateCard = async (cardId: string, input: CardUpdatePatch) => {
+    try {
+      await updateCard({ cardId, ...input });
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+      throw error;
+    }
+  };
+
+  const handleDeleteCard = async (cardId: string) => {
+    const card = lists.flatMap((list) => list.cards).find((item) => item.id === cardId);
+
+    try {
+      await removeCard(cardId);
+      toast.success(`Deleted card "${card?.title ?? "Untitled"}".`);
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+      throw error;
+    }
+  };
+
   return (
     <div
       className="flex min-h-[calc(100vh-4rem)] flex-col rounded-xl"
@@ -110,6 +144,9 @@ export default function BoardDetailClient({ initialBoard }: BoardDetailClientPro
             list={list}
             onUpdateTitle={(title) => handleUpdateListTitle(list.id, title)}
             onDelete={() => handleDeleteList(list.id)}
+            onAddCard={(title) => handleAddCard(list.id, title)}
+            onUpdateCard={handleUpdateCard}
+            onDeleteCard={handleDeleteCard}
           />
         ))}
         <AddListButton onAdd={handleAddList} />

--- a/src/components/card/AddCardInput.tsx
+++ b/src/components/card/AddCardInput.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Plus, X } from "lucide-react";
+
+import { getCardTitleError } from "@/lib/cards";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface AddCardInputProps {
+  onAdd: (title: string) => Promise<void>;
+}
+
+export default function AddCardInput({ onAdd }: AddCardInputProps) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [title, setTitle] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSubmit = async () => {
+    const trimmedTitle = title.trim();
+
+    if (!trimmedTitle || getCardTitleError(trimmedTitle)) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await onAdd(trimmedTitle);
+      setTitle("");
+      setTimeout(() => inputRef.current?.focus(), 0);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setIsAdding(false);
+    setTitle("");
+  };
+
+  if (!isAdding) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setIsAdding(true);
+          setTimeout(() => inputRef.current?.focus(), 0);
+        }}
+        className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium text-muted-foreground transition hover:bg-muted"
+      >
+        <Plus className="size-4" />
+        Add a card
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-lg border bg-background p-2 shadow-sm">
+      <Input
+        ref={inputRef}
+        type="text"
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            void handleSubmit();
+          } else if (event.key === "Escape") {
+            handleClose();
+          }
+        }}
+        placeholder="Enter a title for this card..."
+        autoFocus
+      />
+      <div className="flex items-center gap-2">
+        <Button size="sm" disabled={isSubmitting} onClick={() => void handleSubmit()}>
+          Add card
+        </Button>
+        <Button variant="ghost" size="icon" className="size-8" onClick={handleClose}>
+          <X className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { CalendarDays } from "lucide-react";
+
+import { formatCardDueDateLabel } from "@/lib/cards";
+import type { Card as CardRecord } from "@/types";
+
+interface TaskCardProps {
+  card: CardRecord;
+  onOpen: () => void;
+}
+
+export default function TaskCard({ card, onOpen }: TaskCardProps) {
+  const dueDateLabel = formatCardDueDateLabel(card.due_date);
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="w-full rounded-lg border bg-card px-3 py-2 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+    >
+      <p className="text-sm font-medium text-foreground">{card.title}</p>
+      {dueDateLabel ? (
+        <div className="mt-2 inline-flex items-center gap-1 rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground">
+          <CalendarDays className="size-3.5" />
+          {dueDateLabel}
+        </div>
+      ) : null}
+    </button>
+  );
+}

--- a/src/components/card/CardModal.tsx
+++ b/src/components/card/CardModal.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState } from "react";
+
+import {
+  formatCardDueDateInputValue,
+  getCardTitleError,
+} from "@/lib/cards";
+import type { Card as CardRecord, CardUpdatePatch } from "@/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+interface CardModalProps {
+  card: CardRecord | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpdate: (cardId: string, input: CardUpdatePatch) => Promise<void>;
+  onDelete: (cardId: string) => Promise<void>;
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Something went wrong.";
+}
+
+export default function CardModal({
+  card,
+  open,
+  onOpenChange,
+  onUpdate,
+  onDelete,
+}: CardModalProps) {
+  const [titleValue, setTitleValue] = useState("");
+  const [descriptionValue, setDescriptionValue] = useState("");
+  const [dueDateValue, setDueDateValue] = useState("");
+  const [titleError, setTitleError] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSavingTitle, setIsSavingTitle] = useState(false);
+  const [isSavingDescription, setIsSavingDescription] = useState(false);
+  const [isSavingDueDate, setIsSavingDueDate] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const titleId = useId();
+  const descriptionId = useId();
+  const dueDateId = useId();
+
+  useEffect(() => {
+    if (!card) {
+      return;
+    }
+
+    setTitleValue(card.title);
+    setDescriptionValue(card.description ?? "");
+    setDueDateValue(formatCardDueDateInputValue(card.due_date));
+    setTitleError(null);
+    setErrorMessage(null);
+  }, [card]);
+
+  const isBusy = useMemo(
+    () => isSavingTitle || isSavingDescription || isSavingDueDate || isDeleting,
+    [isDeleting, isSavingDescription, isSavingDueDate, isSavingTitle]
+  );
+
+  if (!card) {
+    return null;
+  }
+
+  const saveTitle = async () => {
+    const nextTitle = titleValue.trim();
+
+    if (nextTitle === card.title) {
+      setTitleError(null);
+      return;
+    }
+
+    const nextTitleError = getCardTitleError(nextTitle);
+
+    if (nextTitleError) {
+      setTitleError(nextTitleError);
+      return;
+    }
+
+    setIsSavingTitle(true);
+    setTitleError(null);
+    setErrorMessage(null);
+
+    try {
+      await onUpdate(card.id, { title: nextTitle });
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setIsSavingTitle(false);
+    }
+  };
+
+  const saveDescription = async () => {
+    if (descriptionValue === (card.description ?? "")) {
+      return;
+    }
+
+    setIsSavingDescription(true);
+    setErrorMessage(null);
+
+    try {
+      await onUpdate(card.id, { description: descriptionValue });
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setIsSavingDescription(false);
+    }
+  };
+
+  const saveDueDate = async (nextDueDate: string) => {
+    if (nextDueDate === formatCardDueDateInputValue(card.due_date)) {
+      return;
+    }
+
+    setIsSavingDueDate(true);
+    setErrorMessage(null);
+
+    try {
+      await onUpdate(card.id, { dueDate: nextDueDate || null });
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+      setDueDateValue(formatCardDueDateInputValue(card.due_date));
+    } finally {
+      setIsSavingDueDate(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    setErrorMessage(null);
+
+    try {
+      await onDelete(card.id);
+      onOpenChange(false);
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Edit card</DialogTitle>
+          <DialogDescription>Changes are saved automatically as you edit.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div className="space-y-2">
+            <label htmlFor={titleId} className="text-sm font-medium text-foreground">
+              Title
+            </label>
+            <Input
+              id={titleId}
+              type="text"
+              value={titleValue}
+              onChange={(event) => {
+                setTitleValue(event.target.value);
+                if (titleError) {
+                  setTitleError(null);
+                }
+              }}
+              onBlur={() => void saveTitle()}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  void saveTitle();
+                } else if (event.key === "Escape") {
+                  setTitleValue(card.title);
+                  setTitleError(null);
+                }
+              }}
+              disabled={isDeleting}
+              aria-invalid={Boolean(titleError)}
+            />
+            {titleError ? <p className="text-sm text-destructive">{titleError}</p> : null}
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor={descriptionId} className="text-sm font-medium text-foreground">
+              Description
+            </label>
+            <textarea
+              id={descriptionId}
+              value={descriptionValue}
+              onChange={(event) => setDescriptionValue(event.target.value)}
+              onBlur={() => void saveDescription()}
+              rows={6}
+              disabled={isDeleting}
+              className="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 flex min-h-32 w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder="Add a more detailed description..."
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor={dueDateId} className="text-sm font-medium text-foreground">
+              Due date
+            </label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                id={dueDateId}
+                type="date"
+                value={dueDateValue}
+                onChange={(event) => {
+                  const nextDueDate = event.target.value;
+
+                  setDueDateValue(nextDueDate);
+                  void saveDueDate(nextDueDate);
+                }}
+                disabled={isDeleting || isSavingDueDate}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                disabled={!dueDateValue || isDeleting || isSavingDueDate}
+                onClick={() => {
+                  setDueDateValue("");
+                  void saveDueDate("");
+                }}
+              >
+                Clear date
+              </Button>
+            </div>
+          </div>
+
+          {errorMessage ? <p className="text-sm text-destructive">{errorMessage}</p> : null}
+
+          <div className="flex items-center justify-between border-t pt-4">
+            <p className="text-sm text-muted-foreground">{isBusy ? "Saving changes..." : "Saved."}</p>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={isDeleting}
+              onClick={() => void handleDelete()}
+            >
+              {isDeleting ? "Deleting..." : "Delete card"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/list/ListColumn.tsx
+++ b/src/components/list/ListColumn.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ListWithCards } from "@/types";
+import type { CardUpdatePatch, ListWithCards } from "@/types";
 import ListContainer from "@/components/list/ListContainer";
 import ListHeader from "@/components/list/ListHeader";
 
@@ -8,13 +8,28 @@ interface ListColumnProps {
   list: ListWithCards;
   onUpdateTitle: (title: string) => Promise<void>;
   onDelete: () => Promise<void>;
+  onAddCard: (title: string) => Promise<void>;
+  onUpdateCard: (cardId: string, input: CardUpdatePatch) => Promise<void>;
+  onDeleteCard: (cardId: string) => Promise<void>;
 }
 
-export default function ListColumn({ list, onUpdateTitle, onDelete }: ListColumnProps) {
+export default function ListColumn({
+  list,
+  onUpdateTitle,
+  onDelete,
+  onAddCard,
+  onUpdateCard,
+  onDeleteCard,
+}: ListColumnProps) {
   return (
     <div className="flex w-72 shrink-0 flex-col rounded-xl border bg-muted/50">
       <ListHeader list={list} onUpdateTitle={onUpdateTitle} onDelete={onDelete} />
-      <ListContainer cards={list.cards} />
+      <ListContainer
+        cards={list.cards}
+        onAddCard={onAddCard}
+        onUpdateCard={onUpdateCard}
+        onDeleteCard={onDeleteCard}
+      />
     </div>
   );
 }

--- a/src/components/list/ListContainer.tsx
+++ b/src/components/list/ListContainer.tsx
@@ -1,31 +1,56 @@
 "use client";
 
-import type { Card } from "@/types";
+import { useMemo, useState } from "react";
+
+import type { Card as CardRecord, CardUpdatePatch } from "@/types";
+import AddCardInput from "@/components/card/AddCardInput";
+import CardModal from "@/components/card/CardModal";
+import TaskCard from "@/components/card/Card";
 
 interface ListContainerProps {
-  cards: Card[];
+  cards: CardRecord[];
+  onAddCard: (title: string) => Promise<void>;
+  onUpdateCard: (cardId: string, input: CardUpdatePatch) => Promise<void>;
+  onDeleteCard: (cardId: string) => Promise<void>;
 }
 
-export default function ListContainer({ cards }: ListContainerProps) {
-  if (cards.length === 0) {
-    return (
-      <div className="flex-1 px-2 py-1">
-        <p className="py-3 text-center text-sm text-muted-foreground">No cards yet</p>
-      </div>
-    );
-  }
+export default function ListContainer({
+  cards,
+  onAddCard,
+  onUpdateCard,
+  onDeleteCard,
+}: ListContainerProps) {
+  const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
+
+  const selectedCard = useMemo(
+    () => cards.find((card) => card.id === selectedCardId) ?? null,
+    [cards, selectedCardId]
+  );
 
   return (
-    <div className="flex-1 space-y-2 overflow-y-auto px-2 py-1">
-      {cards.map((card) => (
-        <div
-          key={card.id}
-          className="rounded-lg border bg-card px-3 py-2 text-sm shadow-sm"
-        >
-          {card.title}
-        </div>
-      ))}
-      <p className="px-1 py-1 text-sm text-muted-foreground">Add a card...</p>
-    </div>
+    <>
+      <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-2 py-1">
+        {cards.length === 0 ? (
+          <p className="py-3 text-center text-sm text-muted-foreground">No cards yet</p>
+        ) : (
+          cards.map((card) => (
+            <TaskCard key={card.id} card={card} onOpen={() => setSelectedCardId(card.id)} />
+          ))
+        )}
+        <AddCardInput onAdd={onAddCard} />
+      </div>
+
+      <CardModal
+        card={selectedCard}
+        open={Boolean(selectedCard)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedCardId(null);
+          }
+        }}
+        onUpdate={onUpdateCard}
+        onDelete={onDeleteCard}
+      />
+    </>
   );
 }

--- a/src/lib/cards.ts
+++ b/src/lib/cards.ts
@@ -1,0 +1,105 @@
+export const CARD_TITLE_MAX_LENGTH = 160;
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface CardFormErrors {
+  title?: string;
+  dueDate?: string;
+}
+
+export class CardValidationError extends Error {
+  fieldErrors: CardFormErrors;
+
+  constructor(fieldErrors: CardFormErrors) {
+    const firstError = fieldErrors.title ?? fieldErrors.dueDate ?? "Card details are invalid.";
+
+    super(firstError);
+    this.name = "CardValidationError";
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+export function normalizeCardTitle(title: string) {
+  return title.trim().replace(/\s+/g, " ");
+}
+
+export function getCardTitleError(title: string) {
+  const normalizedTitle = normalizeCardTitle(title);
+
+  if (!normalizedTitle) {
+    return "Card title is required.";
+  }
+
+  if (normalizedTitle.length > CARD_TITLE_MAX_LENGTH) {
+    return `Card title must be ${CARD_TITLE_MAX_LENGTH} characters or fewer.`;
+  }
+
+  return null;
+}
+
+export function parseCardTitle(title: string): string {
+  const normalizedTitle = normalizeCardTitle(title);
+  const titleError = getCardTitleError(title);
+
+  if (titleError) {
+    throw new CardValidationError({ title: titleError });
+  }
+
+  return normalizedTitle;
+}
+
+export function normalizeCardDescription(description: string | null | undefined) {
+  const normalizedDescription = (description ?? "").replace(/\r\n/g, "\n").trim();
+
+  return normalizedDescription || null;
+}
+
+export function parseCardDueDate(dueDate: string | null | undefined): string | null {
+  const normalizedDueDate = dueDate?.trim() ?? "";
+
+  if (!normalizedDueDate) {
+    return null;
+  }
+
+  if (DATE_ONLY_PATTERN.test(normalizedDueDate)) {
+    return `${normalizedDueDate}T12:00:00.000Z`;
+  }
+
+  const parsedDate = new Date(normalizedDueDate);
+
+  if (Number.isNaN(parsedDate.valueOf())) {
+    throw new CardValidationError({ dueDate: "Due date is invalid." });
+  }
+
+  return parsedDate.toISOString();
+}
+
+export function formatCardDueDateInputValue(dueDate: string | null) {
+  if (!dueDate) {
+    return "";
+  }
+
+  return dueDate.slice(0, 10);
+}
+
+export function formatCardDueDateLabel(dueDate: string | null) {
+  if (!dueDate) {
+    return null;
+  }
+
+  const parsedDate = new Date(dueDate);
+
+  if (Number.isNaN(parsedDate.valueOf())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(parsedDate);
+}
+
+export function isCardValidationError(error: unknown): error is CardValidationError {
+  return error instanceof CardValidationError;
+}

--- a/src/store/boardStore.ts
+++ b/src/store/boardStore.ts
@@ -10,13 +10,29 @@ import {
   updateBoard as updateBoardAction,
 } from "@/actions/boards";
 import {
+  createCard as createCardAction,
+  deleteCard as deleteCardAction,
+  moveCard as moveCardAction,
+  updateCard as updateCardAction,
+} from "@/actions/cards";
+import {
   createList as createListAction,
   deleteList as deleteListAction,
   updateListTitle as updateListTitleAction,
 } from "@/actions/lists";
 import { splitBoards, upsertBoard } from "@/lib/boards";
 import { sortByPosition } from "@/lib/fractional-index";
-import type { Board, BoardFormValues, BoardWithDetails, List, ListWithCards, UpdateBoardValues } from "@/types";
+import type {
+  Board,
+  BoardFormValues,
+  BoardWithDetails,
+  Card,
+  List,
+  ListWithCards,
+  MoveCardValues,
+  UpdateBoardValues,
+  UpdateCardValues,
+} from "@/types";
 
 interface BoardState {
   boards: Board[];
@@ -38,6 +54,13 @@ interface BoardState {
   addList: (boardId: string, title: string) => Promise<List>;
   updateListTitle: (listId: string, title: string) => Promise<void>;
   removeList: (listId: string) => Promise<void>;
+  addCard: (listId: string, title: string) => Promise<Card>;
+  updateCard: (input: UpdateCardValues) => Promise<Card>;
+  updateCardLocal: (card: Card) => void;
+  removeCard: (cardId: string) => Promise<void>;
+  removeCardLocal: (cardId: string) => void;
+  moveCard: (input: MoveCardValues) => Promise<Card>;
+  moveCardLocal: (cardId: string, listId: string, position: string) => void;
   clearError: () => void;
 }
 
@@ -46,7 +69,90 @@ function getErrorMessage(error: unknown) {
     return error.message;
   }
 
-  return "Something went wrong while managing boards.";
+  return "Something went wrong while managing your workspace.";
+}
+
+function sortBoardLists(lists: ListWithCards[]) {
+  return sortByPosition(lists).map((list) => ({
+    ...list,
+    cards: sortByPosition(list.cards),
+  }));
+}
+
+function findCard(lists: ListWithCards[], cardId: string) {
+  for (const list of lists) {
+    const card = list.cards.find((item) => item.id === cardId);
+
+    if (card) {
+      return card;
+    }
+  }
+
+  return null;
+}
+
+function upsertCardInLists(lists: ListWithCards[], card: Card) {
+  let hasTargetList = false;
+  let hasChanged = false;
+
+  const nextLists = lists.map((list) => {
+    const existingCard = list.cards.find((item) => item.id === card.id);
+    const remainingCards = list.cards.filter((item) => item.id !== card.id);
+
+    if (existingCard) {
+      hasChanged = true;
+    }
+
+    if (list.id === card.list_id) {
+      hasTargetList = true;
+      hasChanged = true;
+
+      return {
+        ...list,
+        cards: sortByPosition([...remainingCards, card]),
+      };
+    }
+
+    if (existingCard) {
+      return {
+        ...list,
+        cards: remainingCards,
+      };
+    }
+
+    return list;
+  });
+
+  if (!hasTargetList || !hasChanged) {
+    return lists;
+  }
+
+  return nextLists;
+}
+
+function removeCardFromLists(lists: ListWithCards[], cardId: string) {
+  let hasChanged = false;
+
+  const nextLists = lists.map((list) => {
+    const nextCards = list.cards.filter((card) => card.id !== cardId);
+
+    if (nextCards.length === list.cards.length) {
+      return list;
+    }
+
+    hasChanged = true;
+
+    return {
+      ...list,
+      cards: nextCards,
+    };
+  });
+
+  if (!hasChanged) {
+    return lists;
+  }
+
+  return nextLists;
 }
 
 export const useBoardStore = create<BoardState>((set, get) => ({
@@ -176,10 +282,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
 
     set({
       currentBoard: boardData,
-      currentBoardLists: sortByPosition(lists).map((list) => ({
-        ...list,
-        cards: sortByPosition(list.cards),
-      })),
+      currentBoardLists: sortBoardLists(lists),
     });
   },
   clearCurrentBoardDetail() {
@@ -191,7 +294,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       const listWithCards: ListWithCards = { ...list, cards: [] };
 
       set({
-        currentBoardLists: [...get().currentBoardLists, listWithCards],
+        currentBoardLists: sortBoardLists([...get().currentBoardLists, listWithCards]),
       });
 
       return list;
@@ -225,6 +328,75 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       set({ error: getErrorMessage(error) });
       throw error;
     }
+  },
+  async addCard(listId, title) {
+    try {
+      const card = await createCardAction(listId, title);
+
+      get().updateCardLocal(card);
+
+      return card;
+    } catch (error) {
+      set({ error: getErrorMessage(error) });
+      throw error;
+    }
+  },
+  async updateCard(input) {
+    try {
+      const updatedCard = await updateCardAction(input);
+
+      get().updateCardLocal(updatedCard);
+
+      return updatedCard;
+    } catch (error) {
+      set({ error: getErrorMessage(error) });
+      throw error;
+    }
+  },
+  updateCardLocal(card) {
+    set({
+      currentBoardLists: upsertCardInLists(get().currentBoardLists, card),
+    });
+  },
+  async removeCard(cardId) {
+    try {
+      await deleteCardAction(cardId);
+
+      get().removeCardLocal(cardId);
+    } catch (error) {
+      set({ error: getErrorMessage(error) });
+      throw error;
+    }
+  },
+  removeCardLocal(cardId) {
+    set({
+      currentBoardLists: removeCardFromLists(get().currentBoardLists, cardId),
+    });
+  },
+  async moveCard(input) {
+    try {
+      const movedCard = await moveCardAction(input);
+
+      get().updateCardLocal(movedCard);
+
+      return movedCard;
+    } catch (error) {
+      set({ error: getErrorMessage(error) });
+      throw error;
+    }
+  },
+  moveCardLocal(cardId, listId, position) {
+    const existingCard = findCard(get().currentBoardLists, cardId);
+
+    if (!existingCard) {
+      return;
+    }
+
+    get().updateCardLocal({
+      ...existingCard,
+      list_id: listId,
+      position,
+    });
   },
   clearError() {
     set({ error: null });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,22 @@ export type List = Database["public"]["Tables"]["lists"]["Row"];
 // Card type
 export type Card = Database["public"]["Tables"]["cards"]["Row"];
 
+export interface CardUpdatePatch {
+  title?: string;
+  description?: string | null;
+  dueDate?: string | null;
+}
+
+export interface UpdateCardValues extends CardUpdatePatch {
+  cardId: string;
+}
+
+export interface MoveCardValues {
+  cardId: string;
+  listId: string;
+  position: string;
+}
+
 // Board with nested lists and cards
 export interface BoardWithDetails extends Board {
   lists: ListWithCards[];


### PR DESCRIPTION
## Summary
- add card validation helpers and server actions for create, update, delete, and move
- extend the board store with card CRUD state updates for board detail pages
- add card UI for inline creation, card display, and modal editing with due dates

