### PR TITLE
fix: make dashboard items clickable (Critique #1)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/dashboard/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/dashboard/page.tsx
@@ -1,12 +1,13 @@
 import { createClient } from "@/lib/supabase/server";
 import { getWorkspaceBySlug, getWorkspaceProjects } from "@/lib/queries/workspaces";
 import { enrichIssues } from "@/lib/queries/issues";
+import type { IssueWithDetails } from "@/lib/queries/issues";
 import { getRecentActivities } from "@/lib/queries/activities";
+import { getWorkspaceMembers } from "@/lib/queries/members";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { DashboardGreeting } from "@/components/dashboard/dashboard-greeting";
 import { SprintStrip } from "@/components/dashboard/sprint-strip";
-import { MyFocusCard } from "@/components/dashboard/my-focus-card";
-import { RecentActivityCard } from "@/components/dashboard/recent-activity-card";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import type { IssueStatus } from "@/lib/types";
 
 export default async function DashboardPage({
@@ -96,8 +97,33 @@ export default async function DashboardPage({
 
   const focusIssues = await enrichIssues(focusIssuesRaw ?? [], supabase);
 
-  // Fetch recent activities
-  const recentActivities = await getRecentActivities(workspace.id, 6);
+  // Fetch recent activities and workspace members
+  const [recentActivities, members] = await Promise.all([
+    getRecentActivities(workspace.id, 6),
+    getWorkspaceMembers(workspace.id),
+  ]);
+
+  // Fetch full issue details for issue-type activities (needed by IssueDetailModal)
+  const issueActivityIds = [
+    ...new Set(
+      recentActivities
+        .filter((a) => a.entity_type === "issue" && a.action !== "deleted")
+        .map((a) => a.entity_id)
+    ),
+  ];
+  const activityIssueMap: Record<string, IssueWithDetails> = {};
+  if (issueActivityIds.length > 0) {
+    const { data: rawIssues } = await supabase
+      .from("issues")
+      .select("*")
+      .in("id", issueActivityIds);
+    if (rawIssues && rawIssues.length > 0) {
+      const enriched = await enrichIssues(rawIssues, supabase);
+      for (const issue of enriched) {
+        activityIssueMap[issue.id] = issue;
+      }
+    }
+  }
 
   return (
     <div className="flex flex-col flex-1">
@@ -123,17 +149,13 @@ export default async function DashboardPage({
       )}
 
       {/* Main columns */}
-      <div className="flex flex-1 gap-6 px-4 md:px-10 pt-6 pb-8">
-        <div className="flex flex-col" style={{ flexGrow: 1.6, flexBasis: 0 }}>
-          <MyFocusCard issues={focusIssues} workspaceSlug={workspaceSlug} />
-        </div>
-        <div className="flex flex-col flex-1" style={{ flexBasis: 0 }}>
-          <RecentActivityCard
-            activities={recentActivities}
-            workspaceSlug={workspaceSlug}
-          />
-        </div>
-      </div>
+      <DashboardContent
+        issues={focusIssues}
+        activities={recentActivities}
+        activityIssueMap={activityIssueMap}
+        members={members}
+        workspaceSlug={workspaceSlug}
+      />
     </div>
   );
 }

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { MyFocusCard } from "./my-focus-card";
+import { RecentActivityCard } from "./recent-activity-card";
+import { IssueDetailModal } from "@/components/issues/issue-detail-modal";
+import type { IssueWithDetails } from "@/lib/queries/issues";
+import type { ActivityWithActor } from "@/lib/utils/activities";
+
+interface DashboardContentProps {
+  issues: IssueWithDetails[];
+  activities: ActivityWithActor[];
+  activityIssueMap: Record<string, IssueWithDetails>;
+  members: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  workspaceSlug: string;
+}
+
+export function DashboardContent({
+  issues,
+  activities,
+  activityIssueMap,
+  members,
+  workspaceSlug,
+}: DashboardContentProps) {
+  const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+
+  const handleIssueClick = useCallback(
+    (id: string) => {
+      const issue = issues.find((i) => i.id === id) ?? activityIssueMap[id] ?? null;
+      if (issue) {
+        setSelectedIssue(issue);
+        setDetailOpen(true);
+      }
+    },
+    [issues, activityIssueMap]
+  );
+
+  return (
+    <>
+      <div className="flex flex-1 gap-6 px-4 md:px-10 pt-6 pb-8">
+        <div className="flex flex-col" style={{ flexGrow: 1.6, flexBasis: 0 }}>
+          <MyFocusCard
+            issues={issues}
+            workspaceSlug={workspaceSlug}
+            onIssueClick={handleIssueClick}
+          />
+        </div>
+        <div className="flex flex-col flex-1" style={{ flexBasis: 0 }}>
+          <RecentActivityCard
+            activities={activities}
+            workspaceSlug={workspaceSlug}
+            onIssueClick={handleIssueClick}
+          />
+        </div>
+      </div>
+      <IssueDetailModal
+        issue={selectedIssue}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        members={members}
+      />
+    </>
+  );
+}

--- a/src/components/dashboard/my-focus-card.tsx
+++ b/src/components/dashboard/my-focus-card.tsx
@@ -7,9 +7,10 @@ import { formatDate } from "@/lib/utils/dates";
 interface MyFocusCardProps {
   issues: IssueWithDetails[];
   workspaceSlug: string;
+  onIssueClick?: (id: string) => void;
 }
 
-export function MyFocusCard({ issues, workspaceSlug }: MyFocusCardProps) {
+export function MyFocusCard({ issues, workspaceSlug, onIssueClick }: MyFocusCardProps) {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
@@ -35,7 +36,16 @@ export function MyFocusCard({ issues, workspaceSlug }: MyFocusCardProps) {
             return (
               <div
                 key={issue.id}
-                className="flex items-center gap-3 py-3.5 px-4 bg-surface"
+                role={onIssueClick ? "button" : undefined}
+                tabIndex={onIssueClick ? 0 : undefined}
+                onClick={() => onIssueClick?.(issue.id)}
+                onKeyDown={(e) => {
+                  if (onIssueClick && (e.key === "Enter" || e.key === " ")) {
+                    e.preventDefault();
+                    onIssueClick(issue.id);
+                  }
+                }}
+                className={`flex items-center gap-3 py-3.5 px-4 bg-surface${onIssueClick ? " cursor-pointer hover:bg-surface-hover transition-colors" : ""}`}
               >
                 {/* Priority dot */}
                 <span

--- a/src/components/dashboard/recent-activity-card.tsx
+++ b/src/components/dashboard/recent-activity-card.tsx
@@ -35,11 +35,13 @@ function getActivityIcon(activity: ActivityWithActor) {
 interface RecentActivityCardProps {
   activities: ActivityWithActor[];
   workspaceSlug: string;
+  onIssueClick?: (id: string) => void;
 }
 
 export function RecentActivityCard({
   activities,
   workspaceSlug,
+  onIssueClick,
 }: RecentActivityCardProps) {
   return (
     <div>
@@ -59,10 +61,24 @@ export function RecentActivityCard({
         </div>
       ) : (
         <div className="rounded-[10px] overflow-clip flex flex-col gap-px bg-border">
-          {activities.map((activity) => (
+          {activities.map((activity) => {
+            const isClickable =
+              onIssueClick &&
+              activity.entity_type === "issue" &&
+              activity.action !== "deleted";
+            return (
             <div
               key={activity.id}
-              className="flex items-start gap-2.5 py-3.5 px-4 bg-surface"
+              role={isClickable ? "button" : undefined}
+              tabIndex={isClickable ? 0 : undefined}
+              onClick={isClickable ? () => onIssueClick(activity.entity_id) : undefined}
+              onKeyDown={isClickable ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onIssueClick(activity.entity_id);
+                }
+              } : undefined}
+              className={`flex items-start gap-2.5 py-3.5 px-4 bg-surface${isClickable ? " cursor-pointer hover:bg-surface-hover transition-colors" : ""}`}
             >
               {/* Avatar */}
               <div className="shrink-0 size-7 rounded-[14px] bg-[#E8E4DE] flex items-center justify-center text-[10px] font-medium text-text-secondary">
@@ -89,7 +105,8 @@ export function RecentActivityCard({
                 </p>
               </div>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- **My Focus** issue rows and **Recent Activity** items on the dashboard are now clickable, opening the `IssueDetailModal` — matching the existing pattern on Board and My Issues views
- Non-issue activities (sprint/project) remain non-interactive; deleted-issue activities are also excluded
- Adds hover states (`surface-hover`) and keyboard accessibility (`Enter`/`Space`) to clickable rows

## Test plan
- [ ] Open dashboard, click a "My Focus" issue row — modal opens with full issue details
- [ ] Click an issue-type "Recent Activity" item — modal opens for that issue
- [ ] Click a sprint/project activity — nothing happens, no cursor change
- [ ] Verify hover background appears on clickable rows
- [ ] Close modal and reopen — state resets cleanly
- [ ] "View all →" and "Inbox →" links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)