### PR TITLE
fix: inbox is no longer a dead-end notification dump

### DIFF
--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -18,9 +18,7 @@ interface InboxClientProps {
 
 const TABS = [
   { value: "all", label: "All" },
-  { value: "mentions", label: "Mentions", type: "mention" as const },
   { value: "assigned", label: "Assigned", type: "assigned" as const },
-  { value: "comments", label: "Comments", type: "comment" as const },
 ] as const;
 
 export function InboxClient({
@@ -32,7 +30,7 @@ export function InboxClient({
   const [isPending, startTransition] = useTransition();
   const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
-  const [loadingIssue, setLoadingIssue] = useState(false);
+  const [loadingIssueId, setLoadingIssueId] = useState<string | null>(null);
 
   const handleMarkAllRead = () => {
     startTransition(async () => {
@@ -52,7 +50,7 @@ export function InboxClient({
   }, []);
 
   const handleIssueClick = useCallback(async (issueId: string) => {
-    setLoadingIssue(true);
+    setLoadingIssueId(issueId);
     try {
       const supabase = createClient();
       const { data: issue } = await supabase
@@ -69,7 +67,7 @@ export function InboxClient({
         }
       }
     } finally {
-      setLoadingIssue(false);
+      setLoadingIssueId(null);
     }
   }, []);
 
@@ -121,6 +119,7 @@ export function InboxClient({
                   notifications={filtered}
                   onMarkedRead={handleMarkedRead}
                   onIssueClick={handleIssueClick}
+                  loadingIssueId={loadingIssueId}
                 />
               </TabsContent>
             );

--- a/src/components/inbox/notification-list.tsx
+++ b/src/components/inbox/notification-list.tsx
@@ -8,6 +8,7 @@ interface NotificationListProps {
   notifications: NotificationWithActivity[];
   onMarkedRead?: (id: string) => void;
   onIssueClick?: (issueId: string) => void;
+  loadingIssueId?: string | null;
 }
 
 type TimeBucket = "TODAY" | "YESTERDAY" | "THIS WEEK" | "EARLIER";
@@ -42,6 +43,7 @@ export function NotificationList({
   notifications,
   onMarkedRead,
   onIssueClick,
+  loadingIssueId,
 }: NotificationListProps) {
   if (notifications.length === 0) {
     return (
@@ -73,9 +75,9 @@ export function NotificationList({
                 <NotificationRow
                   key={notification.id}
                   notification={notification}
-                  isRecent={bucket === "TODAY"}
                   onMarkedRead={onMarkedRead}
                   onIssueClick={onIssueClick}
+                  isLoading={notification.activity?.entity_id === loadingIssueId}
                 />
               ))}
             </div>

--- a/src/components/inbox/notification-row.tsx
+++ b/src/components/inbox/notification-row.tsx
@@ -5,23 +5,23 @@ import type { NotificationWithActivity } from "@/lib/utils/activities";
 import { formatActivityAction } from "@/lib/utils/activities";
 import { formatRelative } from "@/lib/utils/dates";
 import { markNotificationRead } from "@/lib/actions/notifications";
-import { Check } from "lucide-react";
+import { Check, LoaderCircle } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { getInitials } from "@/lib/utils/format";
 
 interface NotificationRowProps {
   notification: NotificationWithActivity;
-  isRecent?: boolean;
   onMarkedRead?: (id: string) => void;
   onIssueClick?: (issueId: string) => void;
+  isLoading?: boolean;
 }
 
 export function NotificationRow({
   notification,
-  isRecent,
   onMarkedRead,
   onIssueClick,
+  isLoading,
 }: NotificationRowProps) {
   const [isPending, startTransition] = useTransition();
 
@@ -52,10 +52,10 @@ export function NotificationRow({
   return (
     <button
       onClick={handleClick}
-      disabled={isPending}
+      disabled={isPending || isLoading}
       className={cn(
         "group w-full flex items-start gap-3 py-3.5 px-4 text-left transition-colors",
-        isRecent && isUnread
+        isUnread
           ? "bg-[#2E2E2C0A] border-l-[3px] border-l-primary rounded-r-lg"
           : "rounded-lg hover:bg-background/50"
       )}
@@ -91,18 +91,33 @@ export function NotificationRow({
         )}
       </div>
 
-      {/* Timestamp + mark-as-read */}
+      {/* Timestamp + mark-as-read / loading spinner */}
       <div className="shrink-0 flex items-center gap-2">
-        <span className="text-xs text-text-muted whitespace-nowrap">
-          {formatRelative(notification.created_at)}
-        </span>
-        {isUnread && (
-          <span
-            className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded hover:bg-surface-hover"
-            title="Mark as read"
-          >
-            <Check className="size-3.5 text-text-muted" />
-          </span>
+        {isLoading ? (
+          <LoaderCircle className="size-4 animate-spin text-text-muted" />
+        ) : (
+          <>
+            <span className="text-xs text-text-muted whitespace-nowrap">
+              {formatRelative(notification.created_at)}
+            </span>
+            {isUnread && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (isPending) return;
+                  startTransition(async () => {
+                    await markNotificationRead(notification.id);
+                    onMarkedRead?.(notification.id);
+                  });
+                }}
+                className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-surface-hover"
+                title="Mark as read"
+              >
+                <Check className="size-3.5 text-text-muted" />
+              </button>
+            )}
+          </>
         )}
       </div>
     </button>


### PR DESCRIPTION
## Summary

Addresses **Critique #2** — the inbox was a dead-end notification dump where clicking did nothing visible, unread styling was broken outside the TODAY bucket, phantom tabs cluttered the UI, and the mark-as-read icon was non-functional.

- **Loading feedback**: replaced boolean `loadingIssue` with `loadingIssueId` so the clicked notification row shows a spinner while the issue is fetched
- **Unread styling**: removed `isRecent` guard so background/border unread styling applies across all time buckets (TODAY, YESTERDAY, THIS WEEK, EARLIER)
- **Mark-as-read button**: converted the decorative `<span>` to a `<button>` with `stopPropagation()` — users can now mark a notification as read without opening the issue
- **Phantom tabs removed**: trimmed tabs from 4 (All, Mentions, Assigned, Comments) to 2 (All, Assigned) since no commenting or @mention system exists

## Test plan

- [ ] Open `/pw-workspace/inbox` with seed data
- [ ] Click a notification → verify spinner appears, then issue detail modal opens
- [ ] Hover an unread notification → click the check icon → verify it marks as read without opening the modal
- [ ] Verify unread notifications in YESTERDAY/THIS WEEK/EARLIER buckets have the same background/border styling as TODAY
- [ ] Verify only "All" and "Assigned" tabs are visible
- [ ] `npx next build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)