### PR TITLE
feat: sprint-independent analytics with time-range overview

### DIFF
--- a/src/app/(app)/[workspaceSlug]/analytics/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/analytics/page.tsx
@@ -7,12 +7,23 @@ import {
   getSprintBurndown,
   getIssuesByLabel,
   getTeamVelocity,
+  getOverviewKPIs,
+  getThroughputSeries,
+  getCycleTimeDistribution,
+  getAssigneeBreakdown,
 } from "@/lib/queries/analytics";
+import { parseRange, computeDateRange } from "@/lib/utils/analytics";
 import { KPICards } from "@/components/analytics/kpi-cards";
 import { BurndownChart } from "@/components/analytics/burndown-chart";
 import { LabelChart } from "@/components/analytics/label-chart";
 import { VelocityChart } from "@/components/analytics/velocity-chart";
 import { SprintSelector } from "@/components/analytics/analytics-client";
+import { AnalyticsTabs } from "@/components/analytics/analytics-tabs";
+import { TimeRangeSelector } from "@/components/analytics/time-range-selector";
+import { OverviewKPICards } from "@/components/analytics/overview-kpi-cards";
+import { ThroughputChart } from "@/components/analytics/throughput-chart";
+import { CycleTimeChart } from "@/components/analytics/cycle-time-chart";
+import { AssigneeChart } from "@/components/analytics/assignee-chart";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 
 export default async function AnalyticsPage({
@@ -20,7 +31,7 @@ export default async function AnalyticsPage({
   searchParams,
 }: {
   params: Promise<{ workspaceSlug: string }>;
-  searchParams: Promise<{ sprint?: string }>;
+  searchParams: Promise<{ tab?: string; range?: string; sprint?: string }>;
 }) {
   const [{ workspaceSlug }, resolvedSearchParams] = await Promise.all([
     params,
@@ -31,8 +42,63 @@ export default async function AnalyticsPage({
   if (!result?.workspace) notFound();
 
   const sprints = await getWorkspaceSprints(result.workspace.id);
+  const hasSprints = sprints.length > 0;
 
-  // Determine selected sprint: URL param > most recent active > most recent completed
+  // Determine active tab — fall back to overview if no sprints
+  let activeTab: "overview" | "sprints" =
+    resolvedSearchParams.tab === "sprints" && hasSprints ? "sprints" : "overview";
+
+  const range = parseRange(resolvedSearchParams.range);
+
+  // --- Overview tab data ---
+  if (activeTab === "overview") {
+    const { rangeStart, rangeEnd, prevRangeStart, prevRangeEnd, days } =
+      computeDateRange(range);
+
+    const [kpiData, throughputData, cycleTimeData, assigneeData] =
+      await Promise.all([
+        getOverviewKPIs(
+          result.workspace.id,
+          rangeStart,
+          rangeEnd,
+          prevRangeStart,
+          prevRangeEnd,
+          days
+        ),
+        getThroughputSeries(result.workspace.id, rangeStart, rangeEnd),
+        getCycleTimeDistribution(result.workspace.id, rangeStart, rangeEnd),
+        getAssigneeBreakdown(result.workspace.id, rangeStart, rangeEnd),
+      ]);
+
+    return (
+      <div className="flex flex-col py-6 px-10 gap-6">
+        <Breadcrumb
+          workspaceName={result.workspace.name}
+          pageName="Analytics"
+        />
+        <div className="flex items-center justify-between">
+          <h1 className="text-[26px] font-bold text-text">Analytics</h1>
+          <TimeRangeSelector activeRange={range} />
+        </div>
+
+        <AnalyticsTabs activeTab={activeTab} hasSprints={hasSprints} />
+
+        <OverviewKPICards
+          current={kpiData.current}
+          previous={kpiData.previous}
+        />
+
+        <ThroughputChart data={throughputData} />
+
+        <div className="flex gap-4">
+          <CycleTimeChart data={cycleTimeData} />
+          <AssigneeChart data={assigneeData} />
+        </div>
+      </div>
+    );
+  }
+
+  // --- Sprints tab data ---
   let selectedSprint = resolvedSearchParams.sprint
     ? sprints.find((s) => s.id === resolvedSearchParams.sprint) ?? null
     : null;
@@ -46,16 +112,15 @@ export default async function AnalyticsPage({
   }
 
   if (!selectedSprint) {
+    // Shouldn't happen since hasSprints is true, but handle gracefully
     return (
       <div className="flex flex-col py-6 px-10 gap-6">
-        <Breadcrumb workspaceName={result.workspace.name} pageName="Analytics" />
+        <Breadcrumb
+          workspaceName={result.workspace.name}
+          pageName="Analytics"
+        />
         <h1 className="text-[26px] font-bold text-text">Analytics</h1>
-        <div className="flex flex-col items-center justify-center py-20">
-          <h2 className="text-lg font-medium text-text">No sprints yet</h2>
-          <p className="mt-1 text-sm text-text-muted">
-            Create a sprint to see analytics data.
-          </p>
-        </div>
+        <AnalyticsTabs activeTab="overview" hasSprints={false} />
       </div>
     );
   }
@@ -79,6 +144,8 @@ export default async function AnalyticsPage({
           selectedSprintId={selectedSprint.id}
         />
       </div>
+
+      <AnalyticsTabs activeTab={activeTab} hasSprints={hasSprints} />
 
       <KPICards current={currentKPIs} previous={previousKPIs} />
 

--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -16,9 +16,9 @@ export function SprintSelector({
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const sprintId = e.target.value;
     if (sprintId) {
-      router.push(`${pathname}?sprint=${sprintId}`);
+      router.push(`${pathname}?tab=sprints&sprint=${sprintId}`);
     } else {
-      router.push(pathname);
+      router.push(`${pathname}?tab=sprints`);
     }
   }
 

--- a/src/components/analytics/analytics-tabs.tsx
+++ b/src/components/analytics/analytics-tabs.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+
+const tabs = [
+  { key: "overview", label: "Overview" },
+  { key: "sprints", label: "Sprints" },
+] as const;
+
+export function AnalyticsTabs({
+  activeTab,
+  hasSprints,
+}: {
+  activeTab: "overview" | "sprints";
+  hasSprints: boolean;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function handleTabChange(tab: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", tab);
+    // Clear tab-specific params when switching
+    if (tab === "overview") params.delete("sprint");
+    if (tab === "sprints") params.delete("range");
+    router.push(`${pathname}?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex gap-6 border-b border-border/50">
+      {tabs.map(({ key, label }) => {
+        if (key === "sprints" && !hasSprints) return null;
+
+        const isActive = activeTab === key;
+        return (
+          <button
+            key={key}
+            onClick={() => handleTabChange(key)}
+            className={`pb-2.5 text-sm font-medium -mb-px transition-colors ${
+              isActive
+                ? "border-b-2 border-text text-text"
+                : "text-text-muted hover:text-text"
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/analytics/assignee-chart.tsx
+++ b/src/components/analytics/assignee-chart.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { AssigneeCount } from "@/lib/queries/analytics";
+
+export function AssigneeChart({ data }: { data: AssigneeCount[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex flex-col grow shrink basis-0 rounded-xl gap-5 bg-white border border-border/50 p-5">
+        <span className="text-sm font-semibold text-text">
+          Issues by Assignee
+        </span>
+        <div className="flex items-center justify-center h-20 text-sm text-text-muted">
+          No completed issues in this period.
+        </div>
+      </div>
+    );
+  }
+
+  const maxCount = Math.max(...data.map((d) => d.count));
+
+  return (
+    <div className="flex flex-col grow shrink basis-0 rounded-xl gap-5 bg-white border border-border/50 p-5">
+      <span className="text-sm font-semibold text-text">
+        Issues by Assignee
+      </span>
+      <div className="flex flex-col gap-3.5">
+        {data.map((item) => (
+          <div key={item.name} className="flex items-center gap-3">
+            <div className="flex items-center gap-2 w-24 shrink-0">
+              {item.avatarUrl ? (
+                <img
+                  src={item.avatarUrl}
+                  alt=""
+                  className="w-5 h-5 rounded-full object-cover"
+                />
+              ) : (
+                <div className="w-5 h-5 rounded-full bg-[#E8E4DE] flex items-center justify-center">
+                  <span className="text-[9px] font-medium text-text-muted">
+                    {item.name.charAt(0).toUpperCase()}
+                  </span>
+                </div>
+              )}
+              <span className="text-xs text-text truncate">{item.name}</span>
+            </div>
+            <div className="grow shrink basis-0 h-5 rounded-sm overflow-clip bg-[#F0EDE7]">
+              <div
+                className="h-full rounded-sm transition-all"
+                style={{
+                  width: `${(item.count / maxCount) * 100}%`,
+                  backgroundColor: "#2E2E2C",
+                }}
+              />
+            </div>
+            <span className="w-5 text-right text-[11px] font-mono text-text-muted shrink-0">
+              {item.count}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/cycle-time-chart.tsx
+++ b/src/components/analytics/cycle-time-chart.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  Cell,
+} from "recharts";
+import type { CycleTimeBucket } from "@/lib/queries/analytics";
+
+const BAR_COLORS = ["#4A7A5C", "#5C8A6E", "#7AA08A", "#9CB8A8", "#BED0C6"];
+
+export function CycleTimeChart({ data }: { data: CycleTimeBucket[] }) {
+  if (data.length === 0 || data.every((d) => d.count === 0)) {
+    return (
+      <div className="flex flex-col grow shrink basis-0 rounded-xl gap-4 bg-white border border-border/50 p-5">
+        <span className="text-sm font-semibold text-text">
+          Cycle Time Distribution
+        </span>
+        <div className="flex items-center justify-center h-40 text-sm text-text-muted">
+          No completed issues in this period.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col grow shrink basis-0 rounded-xl gap-4 bg-white border border-border/50 p-5">
+      <span className="text-sm font-semibold text-text">
+        Cycle Time Distribution
+      </span>
+      <ResponsiveContainer width="100%" height={200}>
+        <BarChart data={data} layout="vertical">
+          <CartesianGrid
+            strokeDasharray="0"
+            stroke="#F0EDE7"
+            horizontal={false}
+          />
+          <XAxis
+            type="number"
+            tick={{
+              fontSize: 10,
+              fontFamily: "JetBrains Mono",
+              fill: "#B8B3AB",
+            }}
+            axisLine={false}
+            tickLine={false}
+            allowDecimals={false}
+          />
+          <YAxis
+            type="category"
+            dataKey="bucket"
+            tick={{
+              fontSize: 11,
+              fontFamily: "JetBrains Mono",
+              fill: "#9C9689",
+            }}
+            axisLine={false}
+            tickLine={false}
+            width={50}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "#2E2E2C",
+              border: "none",
+              borderRadius: "8px",
+              fontSize: "12px",
+              color: "#F6F5F1",
+            }}
+            formatter={(value) => [`${value} issues`, "Count"]}
+          />
+          <Bar dataKey="count" radius={[0, 4, 4, 0]} maxBarSize={28}>
+            {data.map((_, index) => (
+              <Cell key={index} fill={BAR_COLORS[index % BAR_COLORS.length]} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/analytics/kpi-card.tsx
+++ b/src/components/analytics/kpi-card.tsx
@@ -1,0 +1,26 @@
+export type KPICardProps = {
+  label: string;
+  value: string;
+  delta: { text: string; isPositive: boolean } | null;
+};
+
+export function KPICard({ label, value, delta }: KPICardProps) {
+  return (
+    <div className="flex flex-col grow shrink basis-0 rounded-xl gap-1.5 bg-white border border-border/50 p-5">
+      <span className="text-xs font-medium text-text-muted">{label}</span>
+      <div className="flex items-baseline gap-2">
+        <span className="text-[32px] font-bold leading-10 text-text">
+          {value}
+        </span>
+        {delta && (
+          <span
+            className="text-[13px] font-medium"
+            style={{ color: delta.isPositive ? "#4A7A5C" : "#8B4049" }}
+          >
+            {delta.text}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/overview-kpi-cards.tsx
+++ b/src/components/analytics/overview-kpi-cards.tsx
@@ -1,13 +1,13 @@
-import type { SprintKPIs } from "@/lib/queries/analytics";
+import type { OverviewKPIs } from "@/lib/queries/analytics";
 import { formatDelta } from "@/lib/utils/analytics";
 import { KPICard } from "./kpi-card";
 
-export function KPICards({
+export function OverviewKPICards({
   current,
   previous,
 }: {
-  current: SprintKPIs;
-  previous: SprintKPIs | null;
+  current: OverviewKPIs;
+  previous: OverviewKPIs | null;
 }) {
   return (
     <div className="flex gap-4">
@@ -30,27 +30,20 @@ export function KPICards({
         }
       />
       <KPICard
-        label="Velocity"
-        value={String(current.velocity)}
+        label="Throughput"
+        value={`${current.throughput}`}
         delta={
           previous
-            ? (() => {
-                const d = formatDelta(current.velocity, previous.velocity);
-                return d ? { ...d, text: `${current.velocity} pts/sprint` } : null;
-              })()
-            : { text: "pts/sprint", isPositive: true }
+            ? formatDelta(current.throughput, previous.throughput, "/wk")
+            : { text: "/wk", isPositive: true }
         }
       />
       <KPICard
-        label="Completion Rate"
-        value={`${current.completionRate}%`}
+        label="Points Delivered"
+        value={String(current.pointsDelivered)}
         delta={
           previous
-            ? formatDelta(
-                current.completionRate,
-                previous.completionRate,
-                "%"
-              )
+            ? formatDelta(current.pointsDelivered, previous.pointsDelivered, " pts")
             : null
         }
       />

--- a/src/components/analytics/throughput-chart.tsx
+++ b/src/components/analytics/throughput-chart.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+import type { ThroughputPoint } from "@/lib/queries/analytics";
+
+export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
+  if (data.length === 0 || data.every((d) => d.count === 0)) {
+    return (
+      <div className="flex flex-col rounded-xl gap-4 bg-white border border-border/50 p-5">
+        <span className="text-sm font-semibold text-text">Throughput</span>
+        <div className="flex items-center justify-center h-40 text-sm text-text-muted">
+          No completed issues in this period.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col rounded-xl gap-4 bg-white border border-border/50 p-5">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-text">Throughput</span>
+        <span className="text-[11px] text-text-muted">issues / week</span>
+      </div>
+      <ResponsiveContainer width="100%" height={200}>
+        <BarChart data={data}>
+          <CartesianGrid
+            strokeDasharray="0"
+            stroke="#F0EDE7"
+            vertical={false}
+          />
+          <XAxis
+            dataKey="week"
+            tick={{
+              fontSize: 10,
+              fontFamily: "JetBrains Mono",
+              fill: "#B8B3AB",
+            }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            tick={{
+              fontSize: 10,
+              fontFamily: "JetBrains Mono",
+              fill: "#B8B3AB",
+            }}
+            axisLine={false}
+            tickLine={false}
+            width={30}
+            allowDecimals={false}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "#2E2E2C",
+              border: "none",
+              borderRadius: "8px",
+              fontSize: "12px",
+              color: "#F6F5F1",
+            }}
+          />
+          <Bar
+            dataKey="count"
+            fill="#2E2E2C"
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/analytics/time-range-selector.tsx
+++ b/src/components/analytics/time-range-selector.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import type { TimeRange } from "@/lib/utils/analytics";
+
+const ranges: TimeRange[] = ["7d", "14d", "30d", "90d"];
+
+export function TimeRangeSelector({ activeRange }: { activeRange: TimeRange }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function handleChange(range: TimeRange) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("range", range);
+    if (!params.has("tab")) params.set("tab", "overview");
+    router.push(`${pathname}?${params.toString()}`);
+  }
+
+  return (
+    <div className="inline-flex items-center gap-0.5 rounded-lg bg-[#F0EDE7] p-1">
+      {ranges.map((range) => {
+        const isActive = activeRange === range;
+        return (
+          <button
+            key={range}
+            onClick={() => handleChange(range)}
+            className={`rounded-md px-3 py-1 text-[13px] font-medium transition-colors ${
+              isActive
+                ? "bg-white text-text shadow-sm"
+                : "text-text-muted hover:text-text"
+            }`}
+          >
+            {range}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/queries/analytics.ts
+++ b/src/lib/queries/analytics.ts
@@ -1,6 +1,14 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Tables } from "@/lib/types";
-import { computeCycleTime, computeBurndownSeries, type BurndownPoint } from "@/lib/utils/analytics";
+import {
+  computeCycleTime,
+  computeBurndownSeries,
+  type BurndownPoint,
+  bucketCycleTime,
+  CYCLE_TIME_BUCKETS,
+  type CycleTimeBucketLabel,
+} from "@/lib/utils/analytics";
+import { differenceInDays, startOfWeek, format, addWeeks } from "date-fns";
 
 export async function getWorkspaceSprints(
   workspaceId: string
@@ -217,4 +225,218 @@ export async function getTeamVelocity(
   }
 
   return results;
+}
+
+// --- Overview (time-range-scoped, sprint-independent) ---
+
+export type OverviewKPIs = {
+  issuesCompleted: number;
+  avgCycleTime: number;
+  throughput: number;
+  pointsDelivered: number;
+};
+
+async function computeOverviewKPIsForRange(
+  workspaceId: string,
+  rangeStart: Date,
+  rangeEnd: Date,
+  days: number
+): Promise<OverviewKPIs> {
+  const supabase = await createClient();
+
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("id, status, story_points, created_at, completed_at")
+    .eq("workspace_id", workspaceId)
+    .eq("status", "done")
+    .gte("completed_at", rangeStart.toISOString())
+    .lte("completed_at", rangeEnd.toISOString());
+
+  const list = issues ?? [];
+  const issuesCompleted = list.length;
+  const avgCycleTime = computeCycleTime(list);
+  const weeks = Math.max(days / 7, 1);
+  const throughput = Number((issuesCompleted / weeks).toFixed(1));
+  const pointsDelivered = list.reduce(
+    (sum, i) => sum + (i.story_points ?? 0),
+    0
+  );
+
+  return { issuesCompleted, avgCycleTime, throughput, pointsDelivered };
+}
+
+export async function getOverviewKPIs(
+  workspaceId: string,
+  rangeStart: Date,
+  rangeEnd: Date,
+  prevRangeStart: Date,
+  prevRangeEnd: Date,
+  days: number
+): Promise<{ current: OverviewKPIs; previous: OverviewKPIs | null }> {
+  const [current, previous] = await Promise.all([
+    computeOverviewKPIsForRange(workspaceId, rangeStart, rangeEnd, days),
+    computeOverviewKPIsForRange(workspaceId, prevRangeStart, prevRangeEnd, days),
+  ]);
+
+  // Return null for previous if there was no data at all
+  const hasPrev =
+    previous.issuesCompleted > 0 || previous.pointsDelivered > 0;
+
+  return { current, previous: hasPrev ? previous : null };
+}
+
+export type ThroughputPoint = {
+  week: string;
+  count: number;
+};
+
+export async function getThroughputSeries(
+  workspaceId: string,
+  rangeStart: Date,
+  rangeEnd: Date
+): Promise<ThroughputPoint[]> {
+  const supabase = await createClient();
+
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("completed_at")
+    .eq("workspace_id", workspaceId)
+    .eq("status", "done")
+    .gte("completed_at", rangeStart.toISOString())
+    .lte("completed_at", rangeEnd.toISOString());
+
+  const list = issues ?? [];
+
+  // Bucket by week start (Monday)
+  const weekCounts = new Map<string, number>();
+  for (const issue of list) {
+    const weekStart = startOfWeek(new Date(issue.completed_at!), {
+      weekStartsOn: 1,
+    });
+    const key = format(weekStart, "yyyy-MM-dd");
+    weekCounts.set(key, (weekCounts.get(key) ?? 0) + 1);
+  }
+
+  // Generate all weeks in range, zero-fill gaps
+  const points: ThroughputPoint[] = [];
+  let cursor = startOfWeek(rangeStart, { weekStartsOn: 1 });
+  const end = rangeEnd;
+
+  while (cursor <= end) {
+    const key = format(cursor, "yyyy-MM-dd");
+    points.push({
+      week: format(cursor, "MMM d"),
+      count: weekCounts.get(key) ?? 0,
+    });
+    cursor = addWeeks(cursor, 1);
+  }
+
+  return points;
+}
+
+export type CycleTimeBucket = {
+  bucket: CycleTimeBucketLabel;
+  count: number;
+};
+
+export async function getCycleTimeDistribution(
+  workspaceId: string,
+  rangeStart: Date,
+  rangeEnd: Date
+): Promise<CycleTimeBucket[]> {
+  const supabase = await createClient();
+
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("created_at, completed_at")
+    .eq("workspace_id", workspaceId)
+    .eq("status", "done")
+    .not("completed_at", "is", null)
+    .gte("completed_at", rangeStart.toISOString())
+    .lte("completed_at", rangeEnd.toISOString());
+
+  const counts = new Map<CycleTimeBucketLabel, number>();
+  for (const b of CYCLE_TIME_BUCKETS) counts.set(b, 0);
+
+  for (const issue of issues ?? []) {
+    const days = Math.max(
+      0,
+      differenceInDays(new Date(issue.completed_at!), new Date(issue.created_at))
+    );
+    const label = bucketCycleTime(days);
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+
+  return CYCLE_TIME_BUCKETS.map((bucket) => ({
+    bucket,
+    count: counts.get(bucket) ?? 0,
+  }));
+}
+
+export type AssigneeCount = {
+  name: string;
+  avatarUrl: string | null;
+  count: number;
+};
+
+export async function getAssigneeBreakdown(
+  workspaceId: string,
+  rangeStart: Date,
+  rangeEnd: Date
+): Promise<AssigneeCount[]> {
+  const supabase = await createClient();
+
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("assignee_id")
+    .eq("workspace_id", workspaceId)
+    .eq("status", "done")
+    .gte("completed_at", rangeStart.toISOString())
+    .lte("completed_at", rangeEnd.toISOString());
+
+  const list = issues ?? [];
+  if (list.length === 0) return [];
+
+  // Group by assignee
+  const assigneeCounts = new Map<string | null, number>();
+  for (const issue of list) {
+    const key = issue.assignee_id;
+    assigneeCounts.set(key, (assigneeCounts.get(key) ?? 0) + 1);
+  }
+
+  // Fetch profile details for non-null assignees
+  const assigneeIds = [...assigneeCounts.keys()].filter(
+    (id): id is string => id !== null
+  );
+
+  const profileMap = new Map<string, { name: string; avatarUrl: string | null }>();
+  if (assigneeIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, full_name, email, avatar_url")
+      .in("id", assigneeIds);
+
+    for (const p of profiles ?? []) {
+      profileMap.set(p.id, {
+        name: p.full_name || p.email,
+        avatarUrl: p.avatar_url,
+      });
+    }
+  }
+
+  const results: AssigneeCount[] = [];
+  for (const [assigneeId, count] of assigneeCounts) {
+    if (assigneeId === null) {
+      results.push({ name: "Unassigned", avatarUrl: null, count });
+    } else {
+      const profile = profileMap.get(assigneeId);
+      results.push({
+        name: profile?.name ?? "Unknown",
+        avatarUrl: profile?.avatarUrl ?? null,
+        count,
+      });
+    }
+  }
+
+  return results.sort((a, b) => b.count - a.count);
 }

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -1,5 +1,5 @@
 import type { Tables } from "@/lib/types";
-import { differenceInDays, startOfDay, addDays, format } from "date-fns";
+import { differenceInDays, startOfDay, addDays, subDays, format } from "date-fns";
 
 export function computeCycleTime(
   issues: Pick<Tables<"issues">, "created_at" | "completed_at" | "status">[]
@@ -101,3 +101,43 @@ export function formatDelta(
 
   return { text, isPositive };
 }
+
+// --- Overview helpers ---
+
+export type TimeRange = "7d" | "14d" | "30d" | "90d";
+
+const VALID_RANGES: TimeRange[] = ["7d", "14d", "30d", "90d"];
+
+export function parseRange(raw: string | undefined): TimeRange {
+  if (raw && VALID_RANGES.includes(raw as TimeRange)) return raw as TimeRange;
+  return "30d";
+}
+
+export function computeDateRange(range: TimeRange): {
+  rangeStart: Date;
+  rangeEnd: Date;
+  prevRangeStart: Date;
+  prevRangeEnd: Date;
+  days: number;
+} {
+  const days = parseInt(range);
+  const rangeEnd = startOfDay(new Date());
+  const rangeStart = subDays(rangeEnd, days);
+  const prevRangeEnd = subDays(rangeStart, 1);
+  const prevRangeStart = subDays(prevRangeEnd, days - 1);
+
+  return { rangeStart, rangeEnd, prevRangeStart, prevRangeEnd, days };
+}
+
+const CYCLE_TIME_BUCKETS = ["< 1d", "1-3d", "3-7d", "7-14d", "14d+"] as const;
+export type CycleTimeBucketLabel = (typeof CYCLE_TIME_BUCKETS)[number];
+
+export function bucketCycleTime(days: number): CycleTimeBucketLabel {
+  if (days < 1) return "< 1d";
+  if (days < 3) return "1-3d";
+  if (days < 7) return "3-7d";
+  if (days < 14) return "7-14d";
+  return "14d+";
+}
+
+export { CYCLE_TIME_BUCKETS };


### PR DESCRIPTION
## Summary
- Add a default **Overview** tab to Analytics that works without sprints — scoped by time range (7d / 14d / 30d / 90d) with KPI cards (issues completed, avg cycle time, throughput, points delivered), a throughput bar chart, cycle time distribution histogram, and assignee breakdown
- Move existing sprint-scoped analytics (burndown, velocity, labels) into a **Sprints** tab that's hidden when no sprints exist
- Extract shared `KPICard` component for reuse across both tabs

## Test plan
- [ ] Visit `/pw-workspace/analytics` — Overview tab loads with time-range data, no sprint required
- [ ] Switch time ranges (7d, 14d, 30d, 90d) — KPIs and charts update, URL param persists
- [ ] Click "Sprints" tab — existing sprint analytics appear with sprint selector
- [ ] Switch sprints in the selector — data updates correctly
- [ ] Verify with zero sprints — Sprints tab is hidden, Overview works fine
- [ ] Verify with zero completed issues — empty states render for each chart
- [ ] Run `npm run build` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)