### PR TITLE
feat: add filter bar to board, list, and My Issues views

### DIFF
--- a/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, Suspense } from "react";
 import { ChevronDown } from "lucide-react";
 import { IssueList } from "@/components/issues/issue-list";
 import { BoardView } from "@/components/board/board-view";
 import { IssueDetailModal } from "@/components/issues/issue-detail-modal";
+import { FilterBar } from "@/components/filters/filter-bar";
+import { useIssueFilters } from "@/lib/hooks/use-issue-filters";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -35,13 +37,36 @@ const SORT_STORAGE_KEY = "flowboard-my-issues-sort";
 interface MyIssuesContentProps {
   issues: IssueWithDetails[];
   members?: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  labels?: { id: string; name: string; color: string }[];
+  projects?: { id: string; name: string; color: string }[];
 }
 
-export function MyIssuesContent({ issues, members = [] }: MyIssuesContentProps) {
+function MyIssuesContentInner({
+  issues,
+  members = [],
+  labels = [],
+  projects = [],
+}: MyIssuesContentProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [sortKey, setSortKey] = useState<SortKey>("priority");
   const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
+
+  const {
+    filters,
+    searchQuery,
+    setSearchQuery,
+    toggleFilter,
+    clearFilter,
+    clearAll,
+    filteredIssues,
+    hasActiveFilters,
+    issueFilterFn,
+    searchInputRef,
+  } = useIssueFilters({
+    issues,
+    enabledFilters: ["status", "priority", "assignee", "label", "project"],
+  });
 
   // Load persisted state from localStorage
   useEffect(() => {
@@ -75,7 +100,7 @@ export function MyIssuesContent({ issues, members = [] }: MyIssuesContentProps) 
   );
 
   const sortedIssues = useMemo(() => {
-    const sorted = [...issues];
+    const sorted = [...filteredIssues];
     switch (sortKey) {
       case "priority":
         sorted.sort((a, b) => a.priority - b.priority);
@@ -106,13 +131,29 @@ export function MyIssuesContent({ issues, members = [] }: MyIssuesContentProps) 
         break;
     }
     return sorted;
-  }, [issues, sortKey]);
+  }, [filteredIssues, sortKey]);
 
   const activeSortLabel =
     SORT_OPTIONS.find((o) => o.key === sortKey)?.label ?? "Priority";
 
   return (
     <>
+      {/* Filter bar */}
+      <FilterBar
+        filters={filters}
+        searchQuery={searchQuery}
+        searchInputRef={searchInputRef}
+        onSearchChange={setSearchQuery}
+        onToggleFilter={toggleFilter}
+        onClearFilter={clearFilter}
+        onClearAll={clearAll}
+        hasActiveFilters={hasActiveFilters}
+        enabledFilters={["status", "priority", "assignee", "label", "project"]}
+        members={members}
+        labels={labels}
+        projects={projects}
+      />
+
       {/* Controls row */}
       <div className="flex items-center gap-3">
         {/* View toggle */}
@@ -175,12 +216,22 @@ export function MyIssuesContent({ issues, members = [] }: MyIssuesContentProps) 
           />
         ) : (
           <BoardView
-            initialIssues={sortedIssues}
+            initialIssues={issues}
             projectId=""
             showProject={true}
             onIssueClick={handleIssueClick}
+            issueFilter={issueFilterFn}
           />
         )
+      ) : hasActiveFilters ? (
+        <div className="flex flex-col items-center justify-center py-24">
+          <h3 className="text-lg font-medium text-text mb-1">
+            No matching issues
+          </h3>
+          <p className="text-sm text-text-muted">
+            Try adjusting your filters to find what you&apos;re looking for.
+          </p>
+        </div>
       ) : (
         <div className="flex flex-col items-center justify-center py-24">
           <h3 className="text-lg font-medium text-text mb-1">
@@ -200,5 +251,13 @@ export function MyIssuesContent({ issues, members = [] }: MyIssuesContentProps) 
         members={members}
       />
     </>
+  );
+}
+
+export function MyIssuesContent(props: MyIssuesContentProps) {
+  return (
+    <Suspense>
+      <MyIssuesContentInner {...props} />
+    </Suspense>
   );
 }

--- a/src/app/(app)/[workspaceSlug]/my-issues/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/page.tsx
@@ -70,7 +70,7 @@ export default async function MyIssuesPage({
       </div>
 
       {/* View toggle, sort dropdown, and issue list/board */}
-      <MyIssuesContent issues={issues} members={members} />
+      <MyIssuesContent issues={issues} members={members} labels={labels} projects={projects} />
     </div>
   );
 }

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/page.tsx
@@ -62,6 +62,7 @@ export default async function BoardPage({
           initialIssues={issues}
           projectId={projectId}
           members={members}
+          labels={labels}
         />
       </div>
     </div>

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/list-view-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/list-view-content.tsx
@@ -1,25 +1,19 @@
 "use client";
 
 import { useState, useCallback, Suspense } from "react";
-import { BoardView } from "@/components/board/board-view";
+import { IssueList } from "@/components/issues/issue-list";
 import { IssueDetailModal } from "@/components/issues/issue-detail-modal";
 import { FilterBar } from "@/components/filters/filter-bar";
 import { useIssueFilters } from "@/lib/hooks/use-issue-filters";
 import type { IssueWithDetails } from "@/lib/queries/issues";
 
-interface BoardWithDetailProps {
-  initialIssues: IssueWithDetails[];
-  projectId: string;
-  members?: { user_id: string; profile: { full_name: string | null; email: string } }[];
-  labels?: { id: string; name: string; color: string }[];
+interface ListViewContentProps {
+  issues: IssueWithDetails[];
+  members: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  labels: { id: string; name: string; color: string }[];
 }
 
-function BoardWithDetailInner({
-  initialIssues,
-  projectId,
-  members = [],
-  labels = [],
-}: BoardWithDetailProps) {
+function ListViewContentInner({ issues, members, labels }: ListViewContentProps) {
   const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
@@ -30,28 +24,28 @@ function BoardWithDetailInner({
     toggleFilter,
     clearFilter,
     clearAll,
+    filteredIssues,
     hasActiveFilters,
-    issueFilterFn,
     searchInputRef,
   } = useIssueFilters({
-    issues: initialIssues,
+    issues,
     enabledFilters: ["status", "priority", "assignee", "label"],
   });
 
   const handleIssueClick = useCallback(
     (id: string) => {
-      const issue = initialIssues.find((i) => i.id === id);
+      const issue = issues.find((i) => i.id === id);
       if (issue) {
         setSelectedIssue(issue);
         setDetailOpen(true);
       }
     },
-    [initialIssues]
+    [issues]
   );
 
   return (
     <>
-      <div className="px-6 pt-4">
+      <div className="px-6 pb-2">
         <FilterBar
           filters={filters}
           searchQuery={searchQuery}
@@ -66,11 +60,10 @@ function BoardWithDetailInner({
           labels={labels}
         />
       </div>
-      <BoardView
-        initialIssues={initialIssues}
-        projectId={projectId}
+      <IssueList
+        issues={filteredIssues}
+        showProject={false}
         onIssueClick={handleIssueClick}
-        issueFilter={issueFilterFn}
       />
       <IssueDetailModal
         issue={selectedIssue}
@@ -82,10 +75,10 @@ function BoardWithDetailInner({
   );
 }
 
-export function BoardWithDetail(props: BoardWithDetailProps) {
+export function ListViewContent(props: ListViewContentProps) {
   return (
     <Suspense>
-      <BoardWithDetailInner {...props} />
+      <ListViewContentInner {...props} />
     </Suspense>
   );
 }

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/page.tsx
@@ -2,9 +2,9 @@ import { notFound } from "next/navigation";
 import { getProjectIssues } from "@/lib/queries/issues";
 import { getProjectById, getProjectLabels, getProjectSprints } from "@/lib/queries/projects";
 import { getWorkspaceMembers } from "@/lib/queries/members";
-import { IssueList } from "@/components/issues/issue-list";
 import { SprintHeader } from "@/components/sprints/sprint-header";
 import { ListPageClient } from "./list-client";
+import { ListViewContent } from "./list-view-content";
 
 export default async function ListPage({
   params,
@@ -56,7 +56,7 @@ export default async function ListPage({
       />
 
       {hasIssues && (
-        <IssueList issues={issues} showProject={false} />
+        <ListViewContent issues={issues} members={members} labels={labels} />
       )}
     </div>
   );

--- a/src/components/board/board-view.tsx
+++ b/src/components/board/board-view.tsx
@@ -27,6 +27,7 @@ interface BoardViewProps {
   projectId: string;
   showProject?: boolean;
   onIssueClick?: (id: string) => void;
+  issueFilter?: (issue: IssueWithDetails) => boolean;
 }
 
 function calculateSortOrder(
@@ -83,6 +84,7 @@ export function BoardView({
   projectId,
   showProject = false,
   onIssueClick,
+  issueFilter,
 }: BoardViewProps) {
   const { issues, setIssues } = useRealtimeIssues({
     projectId,
@@ -101,13 +103,14 @@ export function BoardView({
     }),
   );
 
-  // Group and sort issues into columns
+  // Group and sort issues into columns, applying optional filter for display
   const columns = useMemo(() => {
     const map = new Map<IssueStatus, IssueWithDetails[]>();
     for (const s of STATUS_ORDER) {
       map.set(s, []);
     }
     for (const issue of issues) {
+      if (issueFilter && !issueFilter(issue)) continue;
       const col = map.get(issue.status as IssueStatus);
       if (col) col.push(issue);
     }
@@ -115,7 +118,7 @@ export function BoardView({
       col.sort((a, b) => a.sort_order - b.sort_order);
     }
     return map;
-  }, [issues]);
+  }, [issues, issueFilter]);
 
   const activeIssue = activeId
     ? issues.find((i) => i.id === activeId) ?? null

--- a/src/components/filters/filter-bar.tsx
+++ b/src/components/filters/filter-bar.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import type { RefObject } from "react";
+import { Search, X, ChevronDown } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+} from "@/components/ui/dropdown-menu";
+import { STATUS_CONFIG, STATUS_ORDER } from "@/lib/utils/statuses";
+import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
+import { cn } from "@/lib/utils/cn";
+import type { ViewFilters, IssueStatus, IssuePriority } from "@/lib/types";
+import type { FilterCategory } from "@/lib/hooks/use-issue-filters";
+
+interface FilterBarProps {
+  filters: ViewFilters;
+  searchQuery: string;
+  searchInputRef: RefObject<HTMLInputElement | null>;
+  onSearchChange: (q: string) => void;
+  onToggleFilter: (key: keyof ViewFilters, value: string) => void;
+  onClearFilter: (key: keyof ViewFilters) => void;
+  onClearAll: () => void;
+  hasActiveFilters: boolean;
+  enabledFilters?: FilterCategory[];
+  members?: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  labels?: { id: string; name: string; color: string }[];
+  projects?: { id: string; name: string; color: string }[];
+}
+
+export function FilterBar({
+  filters,
+  searchQuery,
+  searchInputRef,
+  onSearchChange,
+  onToggleFilter,
+  onClearFilter,
+  onClearAll,
+  hasActiveFilters,
+  enabledFilters = ["status", "priority", "assignee", "label"],
+  members = [],
+  labels = [],
+  projects = [],
+}: FilterBarProps) {
+  const statusCount = filters.status?.length ?? 0;
+  const priorityCount = filters.priority?.length ?? 0;
+  const assigneeCount = filters.assignee_ids?.length ?? 0;
+  const labelCount = filters.label_ids?.length ?? 0;
+  const projectCount = filters.project_ids?.length ?? 0;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Controls row */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {/* Search input */}
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Filter issues…"
+            className="h-8 w-[200px] rounded-lg border border-border bg-surface pl-8 pr-8 text-xs text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-text/20 transition-colors"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => onSearchChange("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-text-muted hover:text-text"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          )}
+          {!searchQuery && (
+            <kbd className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-[10px] text-text-muted/60 bg-surface-hover border border-border rounded px-1 py-0.5 font-mono leading-none">
+              F
+            </kbd>
+          )}
+        </div>
+
+        {/* Status filter */}
+        {enabledFilters.includes("status") && (
+          <FilterDropdownTrigger
+            label="Status"
+            count={statusCount}
+          >
+            {STATUS_ORDER.map((s) => (
+              <DropdownMenuCheckboxItem
+                key={s}
+                checked={filters.status?.includes(s) ?? false}
+                onSelect={(e) => e.preventDefault()}
+                onCheckedChange={() => onToggleFilter("status", s)}
+              >
+                <span
+                  className="w-2 h-2 rounded-full mr-2 shrink-0"
+                  style={{ backgroundColor: STATUS_CONFIG[s].color }}
+                />
+                {STATUS_CONFIG[s].label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </FilterDropdownTrigger>
+        )}
+
+        {/* Priority filter */}
+        {enabledFilters.includes("priority") && (
+          <FilterDropdownTrigger
+            label="Priority"
+            count={priorityCount}
+          >
+            {([0, 1, 2, 3] as IssuePriority[]).map((p) => (
+              <DropdownMenuCheckboxItem
+                key={p}
+                checked={filters.priority?.includes(p) ?? false}
+                onSelect={(e) => e.preventDefault()}
+                onCheckedChange={() => onToggleFilter("priority", String(p))}
+              >
+                <span
+                  className="w-2 h-2 rounded-full mr-2 shrink-0"
+                  style={{ backgroundColor: PRIORITY_CONFIG[p].color }}
+                />
+                {PRIORITY_CONFIG[p].label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </FilterDropdownTrigger>
+        )}
+
+        {/* Assignee filter */}
+        {enabledFilters.includes("assignee") && members.length > 0 && (
+          <FilterDropdownTrigger
+            label="Assignee"
+            count={assigneeCount}
+          >
+            {members.map((m) => (
+              <DropdownMenuCheckboxItem
+                key={m.user_id}
+                checked={filters.assignee_ids?.includes(m.user_id) ?? false}
+                onSelect={(e) => e.preventDefault()}
+                onCheckedChange={() => onToggleFilter("assignee_ids", m.user_id)}
+              >
+                {m.profile.full_name ?? m.profile.email}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </FilterDropdownTrigger>
+        )}
+
+        {/* Label filter */}
+        {enabledFilters.includes("label") && labels.length > 0 && (
+          <FilterDropdownTrigger
+            label="Label"
+            count={labelCount}
+          >
+            {labels.map((l) => (
+              <DropdownMenuCheckboxItem
+                key={l.id}
+                checked={filters.label_ids?.includes(l.id) ?? false}
+                onSelect={(e) => e.preventDefault()}
+                onCheckedChange={() => onToggleFilter("label_ids", l.id)}
+              >
+                <span
+                  className="w-2 h-2 rounded-full mr-2 shrink-0"
+                  style={{ backgroundColor: l.color }}
+                />
+                {l.name}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </FilterDropdownTrigger>
+        )}
+
+        {/* Project filter (My Issues only) */}
+        {enabledFilters.includes("project") && projects.length > 0 && (
+          <FilterDropdownTrigger
+            label="Project"
+            count={projectCount}
+          >
+            {projects.map((p) => (
+              <DropdownMenuCheckboxItem
+                key={p.id}
+                checked={filters.project_ids?.includes(p.id) ?? false}
+                onSelect={(e) => e.preventDefault()}
+                onCheckedChange={() => onToggleFilter("project_ids", p.id)}
+              >
+                <span
+                  className="w-2 h-2 rounded-full mr-2 shrink-0"
+                  style={{ backgroundColor: p.color }}
+                />
+                {p.name}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </FilterDropdownTrigger>
+        )}
+      </div>
+
+      {/* Active filter chips */}
+      {hasActiveFilters && (
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {/* Status chips */}
+          {filters.status?.map((s) => (
+            <FilterChip
+              key={`status-${s}`}
+              color={STATUS_CONFIG[s].color}
+              label={STATUS_CONFIG[s].label}
+              onRemove={() => onToggleFilter("status", s)}
+            />
+          ))}
+
+          {/* Priority chips */}
+          {filters.priority?.map((p) => (
+            <FilterChip
+              key={`priority-${p}`}
+              color={PRIORITY_CONFIG[p].color}
+              label={PRIORITY_CONFIG[p].label}
+              onRemove={() => onToggleFilter("priority", String(p))}
+            />
+          ))}
+
+          {/* Assignee chips */}
+          {filters.assignee_ids?.map((id) => {
+            const m = members.find((m) => m.user_id === id);
+            return (
+              <FilterChip
+                key={`assignee-${id}`}
+                label={m?.profile.full_name ?? m?.profile.email ?? "Unknown"}
+                onRemove={() => onToggleFilter("assignee_ids", id)}
+              />
+            );
+          })}
+
+          {/* Label chips */}
+          {filters.label_ids?.map((id) => {
+            const l = labels.find((l) => l.id === id);
+            return (
+              <FilterChip
+                key={`label-${id}`}
+                color={l?.color}
+                label={l?.name ?? "Unknown"}
+                onRemove={() => onToggleFilter("label_ids", id)}
+              />
+            );
+          })}
+
+          {/* Project chips */}
+          {filters.project_ids?.map((id) => {
+            const p = projects.find((p) => p.id === id);
+            return (
+              <FilterChip
+                key={`project-${id}`}
+                color={p?.color}
+                label={p?.name ?? "Unknown"}
+                onRemove={() => onToggleFilter("project_ids", id)}
+              />
+            );
+          })}
+
+          {/* Search chip */}
+          {searchQuery && (
+            <FilterChip
+              label={`"${searchQuery}"`}
+              onRemove={() => onSearchChange("")}
+            />
+          )}
+
+          <button
+            onClick={onClearAll}
+            className="text-[11px] text-text-muted hover:text-text transition-colors px-1.5 py-0.5"
+          >
+            Clear all
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterDropdownTrigger({
+  label,
+  count,
+  children,
+}: {
+  label: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            "flex items-center gap-1 h-8 px-2.5 text-xs rounded-lg border transition-colors",
+            count > 0
+              ? "border-text/20 text-text bg-surface-hover"
+              : "border-border text-text-secondary hover:bg-surface-hover",
+          )}
+        >
+          <span>{label}</span>
+          {count > 0 && (
+            <span className="bg-text/10 text-text text-[10px] rounded-full px-1.5 py-0.5 leading-none font-medium">
+              {count}
+            </span>
+          )}
+          <ChevronDown className="w-3 h-3 opacity-50" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[200px] max-h-[280px] overflow-y-auto">
+        <DropdownMenuLabel>{label}</DropdownMenuLabel>
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function FilterChip({
+  label,
+  color,
+  onRemove,
+}: {
+  label: string;
+  color?: string;
+  onRemove: () => void;
+}) {
+  return (
+    <button
+      onClick={onRemove}
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium bg-surface-hover border border-border hover:bg-muted transition-colors group"
+    >
+      {color && (
+        <span
+          className="w-1.5 h-1.5 rounded-full shrink-0"
+          style={{ backgroundColor: color }}
+        />
+      )}
+      {label}
+      <X className="w-2.5 h-2.5 text-text-muted group-hover:text-text transition-colors" />
+    </button>
+  );
+}

--- a/src/lib/hooks/use-issue-filters.ts
+++ b/src/lib/hooks/use-issue-filters.ts
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState, useMemo, useRef, useCallback } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { parseFiltersFromParams, filtersToParams } from "@/lib/utils/filters";
+import { useHotkeys } from "./use-hotkeys";
+import type { ViewFilters, IssueStatus, IssuePriority } from "@/lib/types";
+import type { IssueWithDetails } from "@/lib/queries/issues";
+
+export type FilterCategory = "status" | "priority" | "assignee" | "label" | "project";
+
+interface UseIssueFiltersOptions {
+  issues: IssueWithDetails[];
+  enabledFilters?: FilterCategory[];
+}
+
+export function useIssueFilters({ issues, enabledFilters }: UseIssueFiltersOptions) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Parse initial filters from URL
+  const filters = useMemo(() => {
+    const raw: Record<string, string> = {};
+    searchParams.forEach((value, key) => {
+      raw[key] = value;
+    });
+    return parseFiltersFromParams(raw);
+  }, [searchParams]);
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Write filters to URL
+  const updateFilters = useCallback(
+    (next: ViewFilters) => {
+      const params = filtersToParams(next);
+      const qs = params.toString();
+      router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+    },
+    [router, pathname],
+  );
+
+  const toggleFilter = useCallback(
+    (key: keyof ViewFilters, value: string) => {
+      const next = { ...filters };
+
+      if (key === "status") {
+        const arr = [...(next.status ?? [])];
+        const v = value as IssueStatus;
+        const idx = arr.indexOf(v);
+        if (idx >= 0) arr.splice(idx, 1);
+        else arr.push(v);
+        next.status = arr.length ? arr : undefined;
+      } else if (key === "priority") {
+        const arr = [...(next.priority ?? [])];
+        const v = Number(value) as IssuePriority;
+        const idx = arr.indexOf(v);
+        if (idx >= 0) arr.splice(idx, 1);
+        else arr.push(v);
+        next.priority = arr.length ? arr : undefined;
+      } else if (key === "assignee_ids") {
+        const arr = [...(next.assignee_ids ?? [])];
+        const idx = arr.indexOf(value);
+        if (idx >= 0) arr.splice(idx, 1);
+        else arr.push(value);
+        next.assignee_ids = arr.length ? arr : undefined;
+      } else if (key === "label_ids") {
+        const arr = [...(next.label_ids ?? [])];
+        const idx = arr.indexOf(value);
+        if (idx >= 0) arr.splice(idx, 1);
+        else arr.push(value);
+        next.label_ids = arr.length ? arr : undefined;
+      } else if (key === "project_ids") {
+        const arr = [...(next.project_ids ?? [])];
+        const idx = arr.indexOf(value);
+        if (idx >= 0) arr.splice(idx, 1);
+        else arr.push(value);
+        next.project_ids = arr.length ? arr : undefined;
+      }
+
+      updateFilters(next);
+    },
+    [filters, updateFilters],
+  );
+
+  const clearFilter = useCallback(
+    (key: keyof ViewFilters) => {
+      const next = { ...filters };
+      delete next[key];
+      updateFilters(next);
+    },
+    [filters, updateFilters],
+  );
+
+  const clearAll = useCallback(() => {
+    setSearchQuery("");
+    updateFilters({});
+  }, [updateFilters]);
+
+  // Filtering logic: AND across categories, OR within each category
+  const filteredIssues = useMemo(() => {
+    let result = issues;
+
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (i) =>
+          i.title.toLowerCase().includes(q) ||
+          i.issue_key.toLowerCase().includes(q),
+      );
+    }
+
+    if (filters.status?.length) {
+      const set = new Set(filters.status);
+      result = result.filter((i) => set.has(i.status as IssueStatus));
+    }
+
+    if (filters.priority?.length) {
+      const set = new Set(filters.priority);
+      result = result.filter((i) => set.has(i.priority as IssuePriority));
+    }
+
+    if (filters.assignee_ids?.length) {
+      const set = new Set(filters.assignee_ids);
+      result = result.filter((i) => i.assignee?.id && set.has(i.assignee.id));
+    }
+
+    if (filters.label_ids?.length) {
+      const set = new Set(filters.label_ids);
+      result = result.filter((i) =>
+        i.labels.some((l) => set.has(l.id)),
+      );
+    }
+
+    if (filters.project_ids?.length) {
+      const set = new Set(filters.project_ids);
+      result = result.filter((i) => i.project?.id && set.has(i.project.id));
+    }
+
+    return result;
+  }, [issues, searchQuery, filters]);
+
+  const hasActiveFilters =
+    searchQuery !== "" ||
+    !!(filters.status?.length) ||
+    !!(filters.priority?.length) ||
+    !!(filters.assignee_ids?.length) ||
+    !!(filters.label_ids?.length) ||
+    !!(filters.project_ids?.length);
+
+  // Build a filter function for BoardView's issueFilter prop
+  const issueFilterFn = useMemo(() => {
+    if (!hasActiveFilters) return undefined;
+    return (issue: IssueWithDetails): boolean => {
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        if (
+          !issue.title.toLowerCase().includes(q) &&
+          !issue.issue_key.toLowerCase().includes(q)
+        )
+          return false;
+      }
+      if (filters.status?.length) {
+        if (!filters.status.includes(issue.status as IssueStatus)) return false;
+      }
+      if (filters.priority?.length) {
+        if (!filters.priority.includes(issue.priority as IssuePriority)) return false;
+      }
+      if (filters.assignee_ids?.length) {
+        if (!issue.assignee?.id || !filters.assignee_ids.includes(issue.assignee.id))
+          return false;
+      }
+      if (filters.label_ids?.length) {
+        if (!issue.labels.some((l) => filters.label_ids!.includes(l.id))) return false;
+      }
+      if (filters.project_ids?.length) {
+        if (!issue.project?.id || !filters.project_ids.includes(issue.project.id))
+          return false;
+      }
+      return true;
+    };
+  }, [hasActiveFilters, searchQuery, filters]);
+
+  // F hotkey to focus search
+  useHotkeys(
+    useMemo(
+      () => [
+        {
+          key: "f",
+          handler: () => {
+            searchInputRef.current?.focus();
+          },
+        },
+      ],
+      [],
+    ),
+  );
+
+  return {
+    filters,
+    searchQuery,
+    setSearchQuery,
+    toggleFilter,
+    clearFilter,
+    clearAll,
+    filteredIssues,
+    hasActiveFilters,
+    issueFilterFn,
+    searchInputRef,
+    enabledFilters,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a reusable `FilterBar` component with text search, multi-select dropdown filters (status, priority, assignee, label, project), removable filter chips, and a "Clear all" action
- Integrates the filter bar into **project board**, **project list**, and **My Issues** views
- Filters persist in URL query params (e.g. `?status=todo&priority=0,1`) for shareability and refresh survival
- Board view DnD remains fully functional — filtering is applied at the display layer only via an `issueFilter` prop, keeping the full issue set in realtime/DnD state
- `F` keyboard shortcut focuses the search input (matching Linear's pattern)
- AND logic across filter categories, OR within each category

## Test plan

- [ ] Open project board → verify filter bar appears with Status, Priority, Assignee, Label dropdowns
- [ ] Select filters → verify board cards filter correctly, chips appear, column counts update
- [ ] Drag-and-drop cards with active filters → verify DnD still works
- [ ] Open project list → verify filter bar appears and filters issue rows
- [ ] Open My Issues → verify filter bar with Project dropdown, works in both list and board modes
- [ ] Press `F` → verify search input focuses
- [ ] Apply filters, refresh page → verify filters persist via URL
- [ ] Clear all → verify all filters reset
- [ ] Run `npm run build` → passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)