### PR TITLE
feat: issue comments, @mentions, and activity timeline

### DIFF
--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -154,6 +154,10 @@ async function main() {
   await createActivities(workspace.id, userIds, ownerId, issues, projects);
   console.log("  activities + notifications");
 
+  // 12 — Comments
+  await createComments(workspace.id, userIds, ownerId, issues);
+  console.log("  comments");
+
   console.log("\nDone — workspace seeded with test data.\n");
 }
 
@@ -164,6 +168,7 @@ async function main() {
 async function clearWorkspaceData(workspaceId: string) {
   // Cascade handles join tables (issue_labels, team_members, etc.)
   await admin.from("notifications").delete().eq("workspace_id", workspaceId);
+  await admin.from("comments").delete().eq("workspace_id", workspaceId);
   await admin.from("activities").delete().eq("workspace_id", workspaceId);
   await admin.from("issues").delete().eq("workspace_id", workspaceId);
   await admin.from("sprints").delete().eq("workspace_id", workspaceId);
@@ -837,6 +842,114 @@ async function createActivities(
       created_at: activities![4].created_at,
     },
   ]);
+}
+
+// ---------------------------------------------------------------------------
+// Comments
+// ---------------------------------------------------------------------------
+
+async function createComments(
+  workspaceId: string,
+  userIds: Record<string, string>,
+  ownerId: string,
+  issues: any[]
+) {
+  // Comments on "Dashboard redesign" (issues[0])
+  // and "Fix auth token refresh on expired sessions" (issues[7])
+  const { data: comments, error } = await admin
+    .from("comments")
+    .insert([
+      {
+        workspace_id: workspaceId,
+        issue_id: issues[0].id,
+        author_id: userIds.elena,
+        body: "The new layout is looking great. Can we add a sprint progress widget to the top section?",
+        mentions: [],
+        created_at: daysAgo(4),
+      },
+      {
+        workspace_id: workspaceId,
+        issue_id: issues[0].id,
+        author_id: userIds.alex,
+        body: `Good idea. @[Elena Vasquez](${userIds.elena}) I'll add that in the next iteration — need to finalize the KPI card design first.`,
+        mentions: [userIds.elena],
+        created_at: daysAgo(3),
+      },
+      {
+        workspace_id: workspaceId,
+        issue_id: issues[0].id,
+        author_id: userIds.sarah,
+        body: "Design mockups for the sprint widget are in Paper. Let me know if the spacing feels off once it's implemented.",
+        mentions: [],
+        created_at: daysAgo(2),
+      },
+      {
+        workspace_id: workspaceId,
+        issue_id: issues[7].id,
+        author_id: userIds.marcus,
+        body: "This is happening because the middleware doesn't check token expiry before forwarding. The refresh logic only triggers on 401 responses, but by then the session cookie is already cleared.",
+        mentions: [],
+        created_at: daysAgo(2),
+      },
+      {
+        workspace_id: workspaceId,
+        issue_id: issues[7].id,
+        author_id: ownerId,
+        body: `@[Marcus Chen](${userIds.marcus}) Thanks for the context. I'm going to add a pre-emptive refresh check — if the token expires within 5 minutes, refresh it before the request goes out.`,
+        mentions: [userIds.marcus],
+        created_at: daysAgo(1),
+      },
+      {
+        workspace_id: workspaceId,
+        issue_id: issues[7].id,
+        author_id: userIds.marcus,
+        body: "That approach should work. Make sure to handle the race condition where two tabs try to refresh simultaneously — use a lock or deduplicate.",
+        mentions: [],
+        created_at: hoursAgo(6),
+      },
+    ])
+    .select();
+  if (error) throw error;
+
+  // Create activity records for the comments
+  const commentActivities = comments!.map((c: any) => ({
+    workspace_id: workspaceId,
+    actor_id: c.author_id,
+    action: "commented",
+    entity_type: "issue",
+    entity_id: c.issue_id,
+    metadata: {
+      issue_key: issues.find((i: any) => i.id === c.issue_id)?.issue_key,
+      title: issues.find((i: any) => i.id === c.issue_id)?.title,
+      comment_id: c.id,
+      comment_preview: c.body.slice(0, 100),
+    },
+    created_at: c.created_at,
+  }));
+
+  const { data: activities } = await admin
+    .from("activities")
+    .insert(commentActivities)
+    .select();
+
+  // Notify the owner about comments on their assigned issues
+  if (activities && activities.length > 0) {
+    const ownerNotifications = activities
+      .filter((a: any) => a.actor_id !== ownerId)
+      .slice(0, 2)
+      .map((a: any) => ({
+        workspace_id: workspaceId,
+        user_id: ownerId,
+        activity_id: a.id,
+        type: "comment",
+        is_read: false,
+        created_at: a.created_at,
+      }));
+
+    if (ownerNotifications.length > 0) {
+      await admin.from("notifications").insert(ownerNotifications);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
@@ -34,7 +34,7 @@ const SORT_STORAGE_KEY = "flowboard-my-issues-sort";
 
 interface MyIssuesContentProps {
   issues: IssueWithDetails[];
-  members?: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  members?: { user_id: string; profile: { id: string; full_name: string | null; email: string; avatar_url: string | null } }[];
 }
 
 export function MyIssuesContent({ issues, members = [] }: MyIssuesContentProps) {

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/board-with-detail.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/board-with-detail.tsx
@@ -8,7 +8,7 @@ import type { IssueWithDetails } from "@/lib/queries/issues";
 interface BoardWithDetailProps {
   initialIssues: IssueWithDetails[];
   projectId: string;
-  members?: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  members?: { user_id: string; profile: { id: string; full_name: string | null; email: string; avatar_url: string | null } }[];
 }
 
 export function BoardWithDetail({

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -11,7 +11,7 @@ interface DashboardContentProps {
   issues: IssueWithDetails[];
   activities: ActivityWithActor[];
   activityIssueMap: Record<string, IssueWithDetails>;
-  members: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  members: { user_id: string; profile: { id: string; full_name: string | null; email: string; avatar_url: string | null } }[];
   workspaceSlug: string;
 }
 

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -13,7 +13,7 @@ import type { IssueWithDetails } from "@/lib/queries/issues";
 interface InboxClientProps {
   notifications: NotificationWithActivity[];
   workspaceId: string;
-  members?: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  members?: { user_id: string; profile: { id: string; full_name: string | null; email: string; avatar_url: string | null } }[];
 }
 
 const TABS = [

--- a/src/components/issues/comment-thread.tsx
+++ b/src/components/issues/comment-thread.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { toast } from "sonner";
+import {
+  ArrowRight,
+  UserCheck,
+  Pencil,
+  Trash2,
+  Plus,
+  MessageSquare,
+} from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { MentionInput } from "@/components/issues/mention-input";
+import { useRealtimeComments } from "@/lib/hooks/use-realtime-comments";
+import { createComment, updateComment, deleteComment } from "@/lib/actions/comments";
+import { renderCommentBody } from "@/lib/utils/mentions";
+import { formatRelative } from "@/lib/utils/dates";
+import { getInitials } from "@/lib/utils/format";
+import { formatActivityAction } from "@/lib/utils/activities";
+import type { CommentWithAuthor } from "@/lib/queries/comments";
+import type { ActivityWithActor } from "@/lib/utils/activities";
+import type { Tables } from "@/lib/types";
+
+interface CommentThreadProps {
+  issueId: string;
+  workspaceId: string;
+  members: {
+    user_id: string;
+    profile: {
+      id: string;
+      full_name: string | null;
+      email: string;
+      avatar_url: string | null;
+    };
+  }[];
+}
+
+type TimelineEntry =
+  | { type: "comment"; data: CommentWithAuthor }
+  | { type: "activity"; data: ActivityWithActor };
+
+function getActivityIcon(activity: ActivityWithActor) {
+  const meta = activity.metadata as Record<string, unknown>;
+  const field = meta?.field as string | undefined;
+  const changes = meta?.changes as Record<string, unknown> | undefined;
+
+  if (activity.action === "created") return Plus;
+  if (activity.action === "commented") return MessageSquare;
+  if (field === "status" || changes?.status) return ArrowRight;
+  if (field === "assignee" || changes?.assignee_id) return UserCheck;
+  return Pencil;
+}
+
+export function CommentThread({
+  issueId,
+  workspaceId,
+  members,
+}: CommentThreadProps) {
+  const [fetchedComments, setFetchedComments] = useState<CommentWithAuthor[]>([]);
+  const [activities, setActivities] = useState<ActivityWithActor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  // Get current user ID client-side
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) setCurrentUserId(user.id);
+    });
+  }, []);
+
+  // Fetch comments and activities client-side
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      const supabase = createClient();
+
+      const [commentsRes, activitiesRes] = await Promise.all([
+        supabase
+          .from("comments")
+          .select("*")
+          .eq("issue_id", issueId)
+          .order("created_at", { ascending: true }),
+        supabase
+          .from("activities")
+          .select("*")
+          .eq("entity_type", "issue")
+          .eq("entity_id", issueId)
+          .order("created_at", { ascending: true }),
+      ]);
+
+      if (cancelled) return;
+
+      // Enrich comments with author profiles
+      const rawComments = (commentsRes.data ?? []) as Tables<"comments">[];
+      const rawActivities = (activitiesRes.data ?? []) as Tables<"activities">[];
+
+      // Batch fetch all needed profiles
+      const profileIds = [
+        ...new Set([
+          ...rawComments.map((c) => c.author_id),
+          ...rawActivities.map((a) => a.actor_id),
+        ]),
+      ];
+
+      const profileMap = new Map<
+        string,
+        { id: string; full_name: string | null; email: string; avatar_url: string | null }
+      >();
+
+      if (profileIds.length > 0) {
+        const { data: profiles } = await supabase
+          .from("profiles")
+          .select("id, full_name, email, avatar_url")
+          .in("id", profileIds);
+        for (const p of profiles ?? []) {
+          profileMap.set(p.id, p);
+        }
+      }
+
+      if (cancelled) return;
+
+      setFetchedComments(
+        rawComments.map((c) => ({
+          ...c,
+          author: profileMap.get(c.author_id) ?? null,
+        }))
+      );
+
+      setActivities(
+        rawActivities.map((a) => ({
+          ...a,
+          actor: profileMap.get(a.actor_id) ?? null,
+          project_name: null,
+        }))
+      );
+
+      setLoading(false);
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [issueId]);
+
+  // Real-time comments
+  const { comments, setComments } = useRealtimeComments({
+    issueId,
+    initialComments: fetchedComments,
+  });
+
+  // Build interleaved timeline
+  const timeline = useMemo<TimelineEntry[]>(() => {
+    const entries: TimelineEntry[] = [
+      // Filter out "commented" activities — they're redundant with actual comments
+      ...activities
+        .filter((a) => a.action !== "commented")
+        .map((a) => ({ type: "activity" as const, data: a })),
+      ...comments.map((c) => ({ type: "comment" as const, data: c })),
+    ];
+    entries.sort(
+      (a, b) =>
+        new Date(a.type === "comment" ? a.data.created_at : a.data.created_at).getTime() -
+        new Date(b.type === "comment" ? b.data.created_at : b.data.created_at).getTime()
+    );
+    return entries;
+  }, [activities, comments]);
+
+  const handleCreateComment = useCallback(
+    async (body: string) => {
+      // Optimistic insert with current user's profile
+      const currentMember = currentUserId
+        ? members.find((m) => m.user_id === currentUserId)
+        : null;
+      const optimisticId = crypto.randomUUID();
+      const optimistic: CommentWithAuthor = {
+        id: optimisticId,
+        workspace_id: workspaceId,
+        issue_id: issueId,
+        author_id: currentUserId ?? "",
+        body,
+        mentions: [],
+        is_edited: false,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        author: currentMember?.profile ?? null,
+      };
+      setComments((prev) => [...prev, optimistic]);
+
+      requestAnimationFrame(() => {
+        endRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      });
+
+      const result = await createComment({ issueId, workspaceId, body });
+      if (result.error) {
+        toast.error(result.error);
+        // Remove optimistic comment on error
+        setComments((prev) => prev.filter((c) => c.id !== optimisticId));
+      } else {
+        // Replace optimistic with real comment (realtime may also deliver it)
+        setComments((prev) =>
+          prev.map((c) =>
+            c.id === optimisticId ? { ...optimistic, ...result.data, author: optimistic.author } : c
+          )
+        );
+      }
+    },
+    [issueId, workspaceId, currentUserId, members, setComments]
+  );
+
+  const handleUpdateComment = useCallback(
+    async (commentId: string, body: string) => {
+      const result = await updateComment(commentId, body);
+      if (result.error) {
+        toast.error(result.error);
+      }
+      setEditingId(null);
+    },
+    []
+  );
+
+  const handleDeleteComment = useCallback(
+    async (commentId: string) => {
+      const result = await deleteComment(commentId);
+      if (result.error) {
+        toast.error(result.error);
+      }
+    },
+    []
+  );
+
+  if (loading) {
+    return (
+      <div className="py-4 text-center text-xs text-text-muted">
+        Loading activity...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Timeline */}
+      {timeline.length > 0 && (
+        <div className="space-y-0.5">
+          {timeline.map((entry) => {
+            if (entry.type === "activity") {
+              const activity = entry.data;
+              const Icon = getActivityIcon(activity);
+              return (
+                <div
+                  key={`a-${activity.id}`}
+                  className="flex items-center gap-2 py-1.5 text-[12px] text-text-muted"
+                >
+                  <Icon className="shrink-0 size-3 text-text-muted" />
+                  <span className="truncate">
+                    {formatActivityAction(activity)}
+                  </span>
+                  <span className="shrink-0 ml-auto text-[11px]">
+                    {formatRelative(activity.created_at)}
+                  </span>
+                </div>
+              );
+            }
+
+            const comment = entry.data;
+            const isAuthor = currentUserId != null && comment.author_id === currentUserId;
+            const authorName =
+              comment.author?.full_name ??
+              comment.author?.email ??
+              "Unknown";
+
+            if (editingId === comment.id) {
+              return (
+                <div key={`c-${comment.id}`} className="py-2">
+                  <MentionInput
+                    members={members}
+                    initialValue={comment.body}
+                    autoFocus
+                    onSubmit={(body) =>
+                      handleUpdateComment(comment.id, body)
+                    }
+                    onCancel={() => setEditingId(null)}
+                    placeholder="Edit comment..."
+                    submitLabel="Save"
+                  />
+                </div>
+              );
+            }
+
+            return (
+              <div
+                key={`c-${comment.id}`}
+                className="group flex gap-2.5 py-2.5"
+              >
+                <Avatar size="sm" className="shrink-0 mt-0.5">
+                  <AvatarImage
+                    src={comment.author?.avatar_url ?? undefined}
+                    alt={authorName}
+                  />
+                  <AvatarFallback>
+                    {getInitials(
+                      comment.author?.full_name,
+                      comment.author?.email
+                    )}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[13px] font-medium text-text">
+                      {authorName}
+                    </span>
+                    <span className="text-[11px] text-text-muted">
+                      {formatRelative(comment.created_at)}
+                    </span>
+                    {comment.is_edited && (
+                      <span className="text-[11px] text-text-muted italic">
+                        (edited)
+                      </span>
+                    )}
+                    {isAuthor && (
+                      <div className="ml-auto flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <button
+                          type="button"
+                          onClick={() => setEditingId(comment.id)}
+                          className="p-1 rounded text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+                        >
+                          <Pencil className="size-3" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteComment(comment.id)}
+                          className="p-1 rounded text-text-muted hover:text-danger hover:bg-surface-hover transition-colors"
+                        >
+                          <Trash2 className="size-3" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div className="text-sm text-text mt-0.5 whitespace-pre-wrap break-words">
+                    {renderCommentBody(comment.body)}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div ref={endRef} />
+
+      {/* New comment input */}
+      <MentionInput
+        members={members}
+        onSubmit={handleCreateComment}
+        placeholder="Leave a comment... (@ to mention)"
+      />
+    </div>
+  );
+}

--- a/src/components/issues/issue-detail-modal.tsx
+++ b/src/components/issues/issue-detail-modal.tsx
@@ -16,6 +16,7 @@ import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { STATUS_CONFIG, STATUS_ORDER } from "@/lib/utils/statuses";
 import { formatDate } from "@/lib/utils/dates";
 import { updateIssue } from "@/lib/actions/issues";
+import { CommentThread } from "@/components/issues/comment-thread";
 import type { IssueWithDetails } from "@/lib/queries/issues";
 import type { IssuePriority, IssueStatus } from "@/lib/types";
 
@@ -23,7 +24,7 @@ interface IssueDetailModalProps {
   issue: IssueWithDetails | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  members?: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  members?: { user_id: string; profile: { id: string; full_name: string | null; email: string; avatar_url: string | null } }[];
 }
 
 export function IssueDetailModal({
@@ -74,7 +75,7 @@ export function IssueDetailModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-[700px] max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-center gap-2">
             <span className="text-xs font-mono text-text-muted bg-surface-hover px-2 py-0.5 rounded">
@@ -263,6 +264,19 @@ export function IssueDetailModal({
               </div>
             </div>
           )}
+
+          {/* Activity & Comments */}
+          <div className="space-y-1.5">
+            <Label className="text-text-secondary">Activity</Label>
+            <CommentThread
+              issueId={issue.id}
+              workspaceId={issue.workspace_id}
+              members={members.map((m) => ({
+                user_id: m.user_id,
+                profile: m.profile,
+              }))}
+            />
+          </div>
 
           {/* Footer metadata */}
           <div className="flex items-center gap-4 pt-2 border-t border-border text-xs text-text-muted">

--- a/src/components/issues/mention-input.tsx
+++ b/src/components/issues/mention-input.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import * as Popover from "@radix-ui/react-popover";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils/format";
+import { parseMentions } from "@/lib/utils/mentions";
+import { Send } from "lucide-react";
+
+interface MentionMember {
+  user_id: string;
+  profile: {
+    id: string;
+    full_name: string | null;
+    email: string;
+    avatar_url: string | null;
+  };
+}
+
+interface MentionInputProps {
+  members: MentionMember[];
+  onSubmit: (body: string, mentionIds: string[]) => void;
+  placeholder?: string;
+  initialValue?: string;
+  autoFocus?: boolean;
+  onCancel?: () => void;
+  submitLabel?: string;
+}
+
+export function MentionInput({
+  members,
+  onSubmit,
+  placeholder = "Leave a comment...",
+  initialValue = "",
+  autoFocus = false,
+  onCancel,
+  submitLabel = "Comment",
+}: MentionInputProps) {
+  const [body, setBody] = useState(initialValue);
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [mentionStartIndex, setMentionStartIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const popoverOpen = mentionQuery !== null;
+
+  const filteredMembers = popoverOpen
+    ? members.filter((m) => {
+        const q = mentionQuery!.toLowerCase();
+        const name = m.profile.full_name?.toLowerCase() ?? "";
+        const email = m.profile.email.toLowerCase();
+        return name.includes(q) || email.includes(q);
+      })
+    : [];
+
+  // Reset selected index when filtered list changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [mentionQuery]);
+
+  const closeMention = useCallback(() => {
+    setMentionQuery(null);
+    setMentionStartIndex(0);
+  }, []);
+
+  const insertMention = useCallback(
+    (member: MentionMember) => {
+      const name = member.profile.full_name ?? member.profile.email;
+      const markup = `@[${name}](${member.user_id}) `;
+      const before = body.slice(0, mentionStartIndex);
+      const after = body.slice(
+        mentionStartIndex + 1 + (mentionQuery?.length ?? 0)
+      );
+      const newBody = before + markup + after;
+      setBody(newBody);
+      closeMention();
+
+      // Restore focus and cursor position
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (ta) {
+          ta.focus();
+          const cursorPos = before.length + markup.length;
+          ta.setSelectionRange(cursorPos, cursorPos);
+        }
+      });
+    },
+    [body, mentionStartIndex, mentionQuery, closeMention]
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value;
+      setBody(value);
+
+      const cursorPos = e.target.selectionStart;
+
+      // Check if we should open/update mention popover
+      // Find the last @ before cursor that is preceded by whitespace or start of string
+      let atIndex = -1;
+      for (let i = cursorPos - 1; i >= 0; i--) {
+        if (value[i] === "@") {
+          if (i === 0 || /\s/.test(value[i - 1])) {
+            atIndex = i;
+          }
+          break;
+        }
+        // Stop if we hit whitespace before finding @
+        if (/\s/.test(value[i])) break;
+      }
+
+      if (atIndex >= 0) {
+        const query = value.slice(atIndex + 1, cursorPos);
+        // Don't open if query contains a closing paren (already completed mention)
+        if (!query.includes(")")) {
+          setMentionStartIndex(atIndex);
+          setMentionQuery(query);
+          return;
+        }
+      }
+
+      closeMention();
+    },
+    [closeMention]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (popoverOpen && filteredMembers.length > 0) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            prev < filteredMembers.length - 1 ? prev + 1 : 0
+          );
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            prev > 0 ? prev - 1 : filteredMembers.length - 1
+          );
+          return;
+        }
+        if (e.key === "Enter" || e.key === "Tab") {
+          e.preventDefault();
+          insertMention(filteredMembers[selectedIndex]);
+          return;
+        }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          closeMention();
+          return;
+        }
+      }
+
+      // Submit on Enter (without Shift)
+      if (e.key === "Enter" && !e.shiftKey && !popoverOpen) {
+        e.preventDefault();
+        handleSubmit();
+        return;
+      }
+
+      // Cancel on Escape when not in mention mode
+      if (e.key === "Escape" && !popoverOpen && onCancel) {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [popoverOpen, filteredMembers, selectedIndex, insertMention, closeMention, onCancel]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = body.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    const mentionIds = parseMentions(trimmed);
+    await onSubmit(trimmed, mentionIds);
+    setBody("");
+    setSubmitting(false);
+  }, [body, submitting, onSubmit]);
+
+  return (
+    <Popover.Root open={popoverOpen}>
+      <Popover.Anchor asChild>
+        <div className="relative">
+          <textarea
+            ref={textareaRef}
+            value={body}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            rows={2}
+            autoFocus={autoFocus}
+            className="flex w-full rounded-lg border border-border bg-surface px-3 py-2 pr-10 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/10 focus:border-border-strong transition-colors resize-none"
+          />
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!body.trim() || submitting}
+            className="absolute right-2 bottom-2 p-1 rounded-md text-text-muted hover:text-text hover:bg-surface-hover disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+            title={submitLabel}
+          >
+            <Send className="size-4" />
+          </button>
+        </div>
+      </Popover.Anchor>
+
+      <Popover.Portal>
+        <Popover.Content
+          side="top"
+          align="start"
+          sideOffset={4}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          className="z-50 w-64 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg"
+        >
+          {filteredMembers.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-text-muted">
+              No members found
+            </div>
+          ) : (
+            <div className="py-1">
+              {filteredMembers.map((member, index) => (
+                <button
+                  key={member.user_id}
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    insertMention(member);
+                  }}
+                  className={`flex items-center gap-2 w-full px-3 py-1.5 text-left text-sm transition-colors ${
+                    index === selectedIndex
+                      ? "bg-surface-hover"
+                      : "hover:bg-surface-hover"
+                  }`}
+                >
+                  <Avatar size="sm">
+                    <AvatarImage
+                      src={member.profile.avatar_url ?? undefined}
+                      alt={member.profile.full_name ?? ""}
+                    />
+                    <AvatarFallback>
+                      {getInitials(
+                        member.profile.full_name,
+                        member.profile.email
+                      )}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-text font-medium truncate text-[13px]">
+                      {member.profile.full_name ?? member.profile.email}
+                    </div>
+                    {member.profile.full_name && (
+                      <div className="text-text-muted truncate text-[11px]">
+                        {member.profile.email}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/src/lib/actions/comments.ts
+++ b/src/lib/actions/comments.ts
@@ -1,0 +1,160 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import type { ActionResponse, Tables } from "@/lib/types";
+import {
+  createActivity,
+  createNotificationsForActivity,
+} from "@/lib/actions/activities";
+import { parseMentions } from "@/lib/utils/mentions";
+
+export async function createComment({
+  issueId,
+  workspaceId,
+  body,
+}: {
+  issueId: string;
+  workspaceId: string;
+  body: string;
+}): Promise<ActionResponse<Tables<"comments">>> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const trimmed = body.trim();
+  if (!trimmed) return { error: "Comment body is required" };
+
+  const mentions = parseMentions(trimmed);
+
+  const { data: comment, error } = await supabase
+    .from("comments")
+    .insert({
+      workspace_id: workspaceId,
+      issue_id: issueId,
+      author_id: user.id,
+      body: trimmed,
+      mentions,
+    })
+    .select()
+    .single();
+
+  if (error) return { error: error.message };
+
+  try {
+    // Fetch issue metadata for activity/notification context
+    const { data: issue } = await supabase
+      .from("issues")
+      .select("title, issue_key, project_id, assignee_id, created_by")
+      .eq("id", issueId)
+      .single();
+
+    const activity = await createActivity({
+      supabase,
+      workspaceId,
+      actorId: user.id,
+      action: "commented",
+      entityType: "issue",
+      entityId: issueId,
+      metadata: {
+        title: issue?.title,
+        issue_key: issue?.issue_key,
+        project_id: issue?.project_id,
+        comment_id: comment.id,
+        comment_preview: trimmed.slice(0, 100),
+      },
+    });
+
+    // Notify assignee + issue creator
+    const commentRecipients: string[] = [];
+    if (issue?.assignee_id) commentRecipients.push(issue.assignee_id);
+    if (issue?.created_by) commentRecipients.push(issue.created_by);
+
+    if (commentRecipients.length > 0) {
+      await createNotificationsForActivity({
+        supabase,
+        workspaceId,
+        actorId: user.id,
+        activityId: activity.id,
+        recipientIds: commentRecipients,
+        type: "comment",
+      });
+    }
+
+    // Notify mentioned users separately
+    if (mentions.length > 0) {
+      await createNotificationsForActivity({
+        supabase,
+        workspaceId,
+        actorId: user.id,
+        activityId: activity.id,
+        recipientIds: mentions,
+        type: "mention",
+      });
+    }
+  } catch {
+    // Activity/notification logging should not block the primary operation
+  }
+
+  revalidatePath("/", "layout");
+  return { data: comment };
+}
+
+export async function updateComment(
+  commentId: string,
+  body: string
+): Promise<ActionResponse<Tables<"comments">>> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const trimmed = body.trim();
+  if (!trimmed) return { error: "Comment body is required" };
+
+  const mentions = parseMentions(trimmed);
+
+  const { data, error } = await supabase
+    .from("comments")
+    .update({
+      body: trimmed,
+      mentions,
+      is_edited: true,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", commentId)
+    .eq("author_id", user.id)
+    .select()
+    .single();
+
+  if (error) return { error: error.message };
+
+  revalidatePath("/", "layout");
+  return { data };
+}
+
+export async function deleteComment(
+  commentId: string
+): Promise<ActionResponse<void>> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const { error } = await supabase
+    .from("comments")
+    .delete()
+    .eq("id", commentId);
+
+  if (error) return { error: error.message };
+
+  revalidatePath("/", "layout");
+  return { data: undefined };
+}

--- a/src/lib/hooks/use-realtime-comments.ts
+++ b/src/lib/hooks/use-realtime-comments.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { CommentWithAuthor } from "@/lib/queries/comments";
+import type { Tables } from "@/lib/types";
+
+interface UseRealtimeCommentsOptions {
+  issueId: string | null;
+  initialComments: CommentWithAuthor[];
+}
+
+export function useRealtimeComments({
+  issueId,
+  initialComments,
+}: UseRealtimeCommentsOptions) {
+  const [comments, setComments] =
+    useState<CommentWithAuthor[]>(initialComments);
+
+  // Sync with server data when initialComments changes
+  useEffect(() => {
+    setComments(initialComments);
+  }, [initialComments]);
+
+  const handleInsert = useCallback(
+    (payload: { new: Tables<"comments"> }) => {
+      const row = payload.new;
+      setComments((prev) => {
+        if (prev.some((c) => c.id === row.id)) return prev;
+        const stub: CommentWithAuthor = {
+          ...row,
+          author: null,
+        };
+        return [...prev, stub];
+      });
+    },
+    []
+  );
+
+  const handleUpdate = useCallback(
+    (payload: { new: Tables<"comments"> }) => {
+      const row = payload.new;
+      setComments((prev) =>
+        prev.map((comment) => {
+          if (comment.id !== row.id) return comment;
+          return {
+            ...comment,
+            body: row.body,
+            mentions: row.mentions,
+            is_edited: row.is_edited,
+            updated_at: row.updated_at,
+          };
+        })
+      );
+    },
+    []
+  );
+
+  const handleDelete = useCallback(
+    (payload: { old: { id: string } }) => {
+      const id = payload.old.id;
+      setComments((prev) => prev.filter((c) => c.id !== id));
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!issueId) return;
+
+    const supabase = createClient();
+    const channel = supabase
+      .channel(`comments:${issueId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "comments",
+          filter: `issue_id=eq.${issueId}`,
+        },
+        handleInsert as (payload: unknown) => void
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "comments",
+          filter: `issue_id=eq.${issueId}`,
+        },
+        handleUpdate as (payload: unknown) => void
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "DELETE",
+          schema: "public",
+          table: "comments",
+          filter: `issue_id=eq.${issueId}`,
+        },
+        handleDelete as (payload: unknown) => void
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [issueId, handleInsert, handleUpdate, handleDelete]);
+
+  return { comments, setComments };
+}

--- a/src/lib/queries/comments.ts
+++ b/src/lib/queries/comments.ts
@@ -1,0 +1,110 @@
+import { createClient } from "@/lib/supabase/server";
+import type { Tables } from "@/lib/types";
+import type { ActivityWithActor } from "@/lib/utils/activities";
+
+export type CommentWithAuthor = Tables<"comments"> & {
+  author: {
+    id: string;
+    full_name: string | null;
+    email: string;
+    avatar_url: string | null;
+  } | null;
+};
+
+export async function getIssueComments(
+  issueId: string
+): Promise<CommentWithAuthor[]> {
+  const supabase = await createClient();
+
+  const { data: comments } = await supabase
+    .from("comments")
+    .select("*")
+    .eq("issue_id", issueId)
+    .order("created_at", { ascending: true });
+
+  if (!comments || comments.length === 0) return [];
+
+  // Batch-fetch author profiles
+  const authorIds = [...new Set(comments.map((c) => c.author_id))];
+  const authorMap = new Map<
+    string,
+    { id: string; full_name: string | null; email: string; avatar_url: string | null }
+  >();
+
+  if (authorIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, full_name, email, avatar_url")
+      .in("id", authorIds);
+    for (const p of profiles ?? []) {
+      authorMap.set(p.id, p);
+    }
+  }
+
+  return comments.map((comment) => ({
+    ...comment,
+    author: authorMap.get(comment.author_id) ?? null,
+  }));
+}
+
+export async function getIssueActivity(
+  issueId: string
+): Promise<ActivityWithActor[]> {
+  const supabase = await createClient();
+
+  const { data: activities } = await supabase
+    .from("activities")
+    .select("*")
+    .eq("entity_type", "issue")
+    .eq("entity_id", issueId)
+    .order("created_at", { ascending: true });
+
+  if (!activities || activities.length === 0) return [];
+
+  // Batch-fetch actor profiles
+  const actorIds = [...new Set(activities.map((a) => a.actor_id))];
+  const actorMap = new Map<
+    string,
+    { id: string; full_name: string | null; email: string; avatar_url: string | null }
+  >();
+
+  if (actorIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, full_name, email, avatar_url")
+      .in("id", actorIds);
+    for (const p of profiles ?? []) {
+      actorMap.set(p.id, p);
+    }
+  }
+
+  // Batch-fetch project names from metadata
+  const projectIds = [
+    ...new Set(
+      activities
+        .map((a) => (a.metadata as Record<string, unknown>)?.project_id)
+        .filter(Boolean)
+    ),
+  ] as string[];
+  const projectMap = new Map<string, string>();
+
+  if (projectIds.length > 0) {
+    const { data: projects } = await supabase
+      .from("projects")
+      .select("id, name")
+      .in("id", projectIds);
+    for (const p of projects ?? []) {
+      projectMap.set(p.id, p.name);
+    }
+  }
+
+  return activities.map((activity) => {
+    const meta = activity.metadata as Record<string, unknown>;
+    const projectId = meta?.project_id as string | undefined;
+    return {
+      ...activity,
+      actor: actorMap.get(activity.actor_id) ?? null,
+      project_name: projectId ? projectMap.get(projectId) ?? null : null,
+    };
+  });
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -558,6 +558,64 @@ export type Database = {
           },
         ];
       };
+      comments: {
+        Row: {
+          id: string;
+          workspace_id: string;
+          issue_id: string;
+          author_id: string;
+          body: string;
+          mentions: string[];
+          is_edited: boolean;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          workspace_id: string;
+          issue_id: string;
+          author_id: string;
+          body: string;
+          mentions?: string[];
+          is_edited?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          workspace_id?: string;
+          issue_id?: string;
+          author_id?: string;
+          body?: string;
+          mentions?: string[];
+          is_edited?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "comments_workspace_id_fkey";
+            columns: ["workspace_id"];
+            isOneToOne: false;
+            referencedRelation: "workspaces";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "comments_issue_id_fkey";
+            columns: ["issue_id"];
+            isOneToOne: false;
+            referencedRelation: "issues";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "comments_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       notifications: {
         Row: {
           id: string;

--- a/src/lib/utils/activities.ts
+++ b/src/lib/utils/activities.ts
@@ -26,6 +26,9 @@ export function formatActivityAction(activity: ActivityWithActor): string {
       const title = (meta.title as string) ?? "";
       const label = issueKey ? `${issueKey}` : title;
 
+      if (activity.action === "commented") {
+        return `${actorName} commented on ${label}`;
+      }
       if (activity.action === "created") {
         return `${actorName} created ${label}`;
       }

--- a/src/lib/utils/mentions.ts
+++ b/src/lib/utils/mentions.ts
@@ -1,0 +1,52 @@
+import { createElement, Fragment } from "react";
+
+const MENTION_REGEX = /@\[([^\]]+)\]\(([a-f0-9-]{36})\)/g;
+
+/**
+ * Extract user IDs from mention markup in a comment body.
+ * Mention format: @[Display Name](user-uuid)
+ */
+export function parseMentions(body: string): string[] {
+  const ids: string[] = [];
+  let match: RegExpExecArray | null;
+  const re = new RegExp(MENTION_REGEX.source, "g");
+  while ((match = re.exec(body)) !== null) {
+    ids.push(match[2]);
+  }
+  return [...new Set(ids)];
+}
+
+/**
+ * Render a comment body string into React elements,
+ * converting @[Name](uuid) patterns into styled mention spans.
+ */
+export function renderCommentBody(body: string) {
+  const parts: (string | ReturnType<typeof createElement>)[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+  const re = new RegExp(MENTION_REGEX.source, "g");
+
+  while ((match = re.exec(body)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(body.slice(lastIndex, match.index));
+    }
+    parts.push(
+      createElement(
+        "span",
+        {
+          key: key++,
+          className: "text-primary font-medium",
+        },
+        `@${match[1]}`
+      )
+    );
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < body.length) {
+    parts.push(body.slice(lastIndex));
+  }
+
+  return createElement(Fragment, null, ...parts);
+}

--- a/supabase/migrations/00020_comments.sql
+++ b/supabase/migrations/00020_comments.sql
@@ -1,0 +1,52 @@
+-- 00020_comments.sql
+-- Issue comments with @mention support
+
+create table comments (
+  id           uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces on delete cascade,
+  issue_id     uuid not null references issues on delete cascade,
+  author_id    uuid not null references profiles(id) on delete cascade,
+  body         text not null,
+  mentions     uuid[] not null default '{}',
+  is_edited    boolean not null default false,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+create index idx_comments_issue on comments (issue_id, created_at);
+create index idx_comments_workspace on comments (workspace_id);
+create index idx_comments_author on comments (author_id);
+
+-- RLS
+alter table comments enable row level security;
+
+create policy "comments: workspace members can read"
+  on comments for select
+  to authenticated
+  using (public.is_workspace_member(workspace_id));
+
+create policy "comments: workspace members can insert"
+  on comments for insert
+  to authenticated
+  with check (
+    public.is_workspace_member(workspace_id)
+    and author_id = auth.uid()
+  );
+
+create policy "comments: author can update"
+  on comments for update
+  to authenticated
+  using (author_id = auth.uid())
+  with check (author_id = auth.uid());
+
+create policy "comments: author or admin can delete"
+  on comments for delete
+  to authenticated
+  using (
+    author_id = auth.uid()
+    or public.get_user_workspace_role(workspace_id) in ('owner', 'admin')
+  );
+
+-- Realtime
+alter publication supabase_realtime add table comments;
+alter table comments replica identity full;


### PR DESCRIPTION
## Summary

- Adds a **comments system** to the issue detail modal — users can post, edit, and delete comments on any issue
- **@mention autocomplete** — type `@` to get a popover listing workspace members, inserts mention markup that renders as styled spans and triggers notifications
- **Activity timeline** — interleaves comments with field-change events (status, assignee, priority) in chronological order, matching Linear's issue sidebar pattern
- Full **notification support** — comments notify the assignee + issue creator (`type: "comment"`), mentions notify mentioned users (`type: "mention"`)
- **Real-time sync** via Supabase postgres_changes subscription on the comments table
- **Optimistic updates** for instant feedback when posting comments

## Test plan

- [ ] Open any issue from the board view — Activity section shows interleaved comments and status changes
- [ ] Post a new comment — appears instantly with correct author name/avatar
- [ ] Type `@` in the comment input — member autocomplete popover opens, filterable by name/email
- [ ] Select a member from the popover — mention markup inserted, renders as styled `@Name` span
- [ ] Edit own comment — shows "(edited)" badge after saving
- [ ] Delete own comment — removed from timeline
- [ ] Verify comments load from dashboard, my-issues, and inbox issue modals
- [ ] Check notifications table for `comment` and `mention` type entries after commenting

🤖 Generated with [Claude Code](https://claude.com/claude-code)