### PR TITLE
rename: Flowboard → Flow

### DIFF
--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -48,15 +48,15 @@ function dateOnly(daysOffset: number): string {
 // ---------------------------------------------------------------------------
 
 const MEMBERS: Record<string, { email: string; full_name: string }> = {
-  elena:  { email: "elena@test.flowboard.dev",  full_name: "Elena Vasquez" },
-  marcus: { email: "marcus@test.flowboard.dev", full_name: "Marcus Chen" },
-  james:  { email: "james@test.flowboard.dev",  full_name: "James Park" },
-  alex:   { email: "alex@test.flowboard.dev",   full_name: "Alex Rivera" },
-  sarah:  { email: "sarah@test.flowboard.dev",  full_name: "Sarah Kim" },
-  tom:    { email: "tom@test.flowboard.dev",     full_name: "Tom Andersen" },
-  mia:    { email: "mia@test.flowboard.dev",     full_name: "Mia Torres" },
-  lina:   { email: "lina@test.flowboard.dev",    full_name: "Lina Moreau" },
-  david:  { email: "david@test.flowboard.dev",   full_name: "David Okonkwo" },
+  elena:  { email: "elena@test.flow.dev",  full_name: "Elena Vasquez" },
+  marcus: { email: "marcus@test.flow.dev", full_name: "Marcus Chen" },
+  james:  { email: "james@test.flow.dev",  full_name: "James Park" },
+  alex:   { email: "alex@test.flow.dev",   full_name: "Alex Rivera" },
+  sarah:  { email: "sarah@test.flow.dev",  full_name: "Sarah Kim" },
+  tom:    { email: "tom@test.flow.dev",     full_name: "Tom Andersen" },
+  mia:    { email: "mia@test.flow.dev",     full_name: "Mia Torres" },
+  lina:   { email: "lina@test.flow.dev",    full_name: "Lina Moreau" },
+  david:  { email: "david@test.flow.dev",   full_name: "David Okonkwo" },
 };
 
 // ---------------------------------------------------------------------------

--- a/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
@@ -32,8 +32,8 @@ const SORT_OPTIONS: { key: SortKey; label: string }[] = [
   { key: "status", label: "Status" },
 ];
 
-const VIEW_STORAGE_KEY = "flowboard-my-issues-view";
-const SORT_STORAGE_KEY = "flowboard-my-issues-sort";
+const VIEW_STORAGE_KEY = "flow-my-issues-view";
+const SORT_STORAGE_KEY = "flow-my-issues-sort";
 
 interface MyIssuesContentProps {
   issues: IssueWithDetails[];

--- a/src/app/(app)/onboarding/onboarding-wizard.tsx
+++ b/src/app/(app)/onboarding/onboarding-wizard.tsx
@@ -60,7 +60,7 @@ function ProgressBar({ step }: { step: number }) {
 function TopBar({ step }: { step: number }) {
   return (
     <header className="flex items-center justify-between px-8 py-5">
-      <span className="font-serif text-xl text-text">Flowboard</span>
+      <span className="font-serif text-xl text-text">Flow</span>
       <ProgressBar step={step} />
       <span className="uppercase tracking-wider text-xs font-medium text-text-secondary">
         Step {step} of 3
@@ -132,7 +132,7 @@ function StepWorkspace({
         <Label htmlFor="slug">Workspace URL</Label>
         <div className="flex h-12 w-full rounded-lg border border-border bg-surface overflow-hidden focus-within:ring-2 focus-within:ring-primary/10 focus-within:border-border-strong transition-colors">
           <span className="flex items-center pl-3 pr-1 text-sm text-text-muted select-none whitespace-nowrap">
-            flowboard.app/
+            flow.app/
           </span>
           <input
             id="slug"

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -22,7 +22,7 @@ export default function ForgotPasswordPage() {
         <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-white font-bold">
           F
         </div>
-        <span className="font-medium text-text text-lg">Flowboard</span>
+        <span className="font-medium text-text text-lg">Flow</span>
       </div>
 
       {/* Heading */}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
         <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-white font-bold">
           F
         </div>
-        <span className="font-medium text-text text-lg">Flowboard</span>
+        <span className="font-medium text-text text-lg">Flow</span>
       </div>
 
       {/* Heading */}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -30,7 +30,7 @@ export default function ResetPasswordPage() {
         <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-white font-bold">
           F
         </div>
-        <span className="font-medium text-text text-lg">Flowboard</span>
+        <span className="font-medium text-text text-lg">Flow</span>
       </div>
 
       {/* Heading */}

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -21,7 +21,7 @@ export default function SignUpPage() {
         <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-white font-bold">
           F
         </div>
-        <span className="font-medium text-text text-lg">Flowboard</span>
+        <span className="font-medium text-text text-lg">Flow</span>
       </div>
 
       {/* Heading */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ const instrumentSerif = Instrument_Serif({
 });
 
 export const metadata: Metadata = {
-  title: "Flowboard",
+  title: "Flow",
   description: "Project management for engineering and product teams",
 };
 

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -9,7 +9,7 @@ export function Footer() {
         <div className="grid grid-cols-1 gap-12 md:grid-cols-[1.5fr_1fr_1fr_1fr]">
           {/* Brand */}
           <div>
-            <span className="font-serif text-xl text-white">Flowboard</span>
+            <span className="font-serif text-xl text-white">Flow</span>
             <p className="mt-3 max-w-[240px] text-sm leading-relaxed">
               Project management that moves at the speed of your team.
             </p>
@@ -66,7 +66,7 @@ export function Footer() {
 
         {/* Bottom bar */}
         <div className="mt-16 flex flex-col items-center justify-between gap-4 border-t border-white/10 pt-6 sm:flex-row">
-          <p className="text-xs">&copy; 2026 Flowboard. All rights reserved.</p>
+          <p className="text-xs">&copy; 2026 Flow. All rights reserved.</p>
           <div className="flex items-center gap-2 text-xs">
             <span className="relative flex h-2 w-2">
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />

--- a/src/components/landing/manifesto.tsx
+++ b/src/components/landing/manifesto.tsx
@@ -86,7 +86,7 @@ export function Manifesto() {
         <div data-manifesto="label" className="mt-12 opacity-0">
           <div className="mx-auto h-px w-12 bg-white/20" />
           <p className="mt-4 font-mono text-[11px] tracking-[0.25em] text-white/30 uppercase">
-            The Flowboard Manifesto
+            The Flow Manifesto
           </p>
         </div>
       </div>

--- a/src/components/landing/navbar.tsx
+++ b/src/components/landing/navbar.tsx
@@ -31,7 +31,7 @@ export function Navbar() {
         )}
       >
         <a href="/" className="font-serif text-xl text-text">
-          Flowboard
+          Flow
         </a>
 
         <div className="hidden items-center gap-8 md:flex">

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -46,7 +46,7 @@ const navItems = [
   { label: "Analytics", icon: BarChart3, href: "/analytics" },
 ];
 
-const STORAGE_KEY = "flowboard-sidebar-collapsed";
+const STORAGE_KEY = "flow-sidebar-collapsed";
 
 export function Sidebar({
   workspaceName,
@@ -97,7 +97,7 @@ export function Sidebar({
           </div>
           {!isCollapsed && (
             <div className="flex flex-col gap-px min-w-0 flex-1">
-              <span className="text-[15px] font-semibold text-text leading-[18px]">Flowboard</span>
+              <span className="text-[15px] font-semibold text-text leading-[18px]">Flow</span>
               <p className="text-[11px] font-mono text-text-muted opacity-30 leading-[14px] truncate">
                 {workspaceName}
               </p>

--- a/src/components/settings/workspace-general-form.tsx
+++ b/src/components/settings/workspace-general-form.tsx
@@ -94,7 +94,7 @@ export function WorkspaceGeneralForm({ workspace }: WorkspaceGeneralFormProps) {
             Workspace URL
           </label>
           <div className="flex items-center h-11 rounded-[10px] px-3.5 bg-[#F6F5F1] border border-[#2E2E2C14] text-sm text-text-muted">
-            flowboard.app/{workspace.slug}
+            flow.app/{workspace.slug}
           </div>
           <p className="text-[11px] text-text-muted opacity-60">
             Workspace URL cannot be changed after creation.

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -5,7 +5,7 @@ const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 // Stable test user — reused across runs so storageState stays valid
-const TEST_EMAIL = "playwright@test.flowboard.dev";
+const TEST_EMAIL = "playwright@test.flow.dev";
 const TEST_PASSWORD = "playwrightTest!2026";
 const TEST_FULL_NAME = "Playwright Bot";
 const AUTH_FILE = "tests/.auth/user.json";

--- a/tests/phase1-auth-flow.spec.ts
+++ b/tests/phase1-auth-flow.spec.ts
@@ -11,7 +11,7 @@ import { createClient } from "@supabase/supabase-js";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-const TEST_EMAIL = `e2e-${Date.now()}@test.flowboard.dev`;
+const TEST_EMAIL = `e2e-${Date.now()}@test.flow.dev`;
 const TEST_PASSWORD = "testpassword123";
 const TEST_FULL_NAME = "E2E Tester";
 const TEST_WORKSPACE_NAME = `Test Workspace ${Date.now()}`;
@@ -167,7 +167,7 @@ test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {
 
     // Sidebar elements
     const sidebar = page.locator("aside");
-    await expect(sidebar.getByText("Flowboard")).toBeVisible();
+    await expect(sidebar.getByText("Flow")).toBeVisible();
     await expect(sidebar.getByText(TEST_WORKSPACE_NAME)).toBeVisible();
     await expect(sidebar.getByText("Dashboard")).toBeVisible();
     await expect(sidebar.getByText("Inbox")).toBeVisible();

--- a/tests/phase7-polish.spec.ts
+++ b/tests/phase7-polish.spec.ts
@@ -160,7 +160,7 @@ test.describe("Phase 7: Settings Pages", () => {
     await expect(page.getByLabel("Display name")).toBeVisible();
 
     // Email read-only field
-    await expect(page.getByText("playwright@test.flowboard.dev")).toBeVisible();
+    await expect(page.getByText("playwright@test.flow.dev")).toBeVisible();
 
     // Notification toggles
     await expect(page.getByText("Email notifications")).toBeVisible();
@@ -285,23 +285,23 @@ test.describe("Phase 7: Collapsible Sidebar", () => {
     // Ensure clean state
     await page.goto(`${WS}/dashboard`);
     await page.evaluate(() =>
-      localStorage.removeItem("flowboard-sidebar-collapsed")
+      localStorage.removeItem("flow-sidebar-collapsed")
     );
     await page.reload();
     await expect(page.locator("aside")).toBeVisible({ timeout: 10000 });
 
-    // Sidebar should start expanded — "Flowboard" text visible
-    await expect(page.getByText("Flowboard")).toBeVisible();
+    // Sidebar should start expanded — "Flow" text visible
+    await expect(page.getByText("Flow", { exact: true })).toBeVisible();
 
     // Collapse via localStorage + reload (avoids dev overlay blocking clicks)
     await page.evaluate(() =>
-      localStorage.setItem("flowboard-sidebar-collapsed", "true")
+      localStorage.setItem("flow-sidebar-collapsed", "true")
     );
     await page.reload();
     await expect(page.locator("aside")).toBeVisible({ timeout: 10000 });
 
-    // After collapse, "Flowboard" text should be hidden
-    await expect(page.getByText("Flowboard")).not.toBeVisible({
+    // After collapse, "Flow" text should be hidden
+    await expect(page.getByText("Flow", { exact: true })).not.toBeVisible({
       timeout: 3000,
     });
 
@@ -313,10 +313,10 @@ test.describe("Phase 7: Collapsible Sidebar", () => {
 
     // Expand via localStorage + reload
     await page.evaluate(() =>
-      localStorage.setItem("flowboard-sidebar-collapsed", "false")
+      localStorage.setItem("flow-sidebar-collapsed", "false")
     );
     await page.reload();
-    await expect(page.getByText("Flowboard")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Flow", { exact: true })).toBeVisible({ timeout: 5000 });
   });
 
   test("sidebar collapse state persists across navigation", async ({
@@ -324,22 +324,22 @@ test.describe("Phase 7: Collapsible Sidebar", () => {
   }) => {
     await page.goto(`${WS}/dashboard`);
     await page.evaluate(() =>
-      localStorage.setItem("flowboard-sidebar-collapsed", "true")
+      localStorage.setItem("flow-sidebar-collapsed", "true")
     );
     await page.reload();
     await expect(page.locator("aside")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("Flowboard")).not.toBeVisible({
+    await expect(page.getByText("Flow", { exact: true })).not.toBeVisible({
       timeout: 3000,
     });
 
     // Navigate to another page — sidebar should still be collapsed
     await page.goto(`${WS}/inbox`);
     await expect(page.locator("aside")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("Flowboard")).not.toBeVisible();
+    await expect(page.getByText("Flow", { exact: true })).not.toBeVisible();
 
     // Clean up
     await page.evaluate(() =>
-      localStorage.removeItem("flowboard-sidebar-collapsed")
+      localStorage.removeItem("flow-sidebar-collapsed")
     );
   });
 });


### PR DESCRIPTION
## Summary
- Renames all "Flowboard" branding to "Flow" across 16 files
- Updates UI text (auth pages, sidebar, landing page, onboarding, settings)
- Updates domain references: `flowboard.app` → `flow.app`
- Updates localStorage keys: `flowboard-*` → `flow-*`
- Updates test email domain: `test.flowboard.dev` → `test.flow.dev`
- Updates test assertions to match new brand name

## Post-merge
Re-seed database and refresh auth after merging:
```bash
npx tsx scripts/seed-test-data.ts --force
npx playwright test tests/auth.setup.ts --project=setup
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)