### PR TITLE
Add workspace switching to account menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
+/tests/.auth
+/tests/screenshots
 
 # next.js
 /.next/

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,0 +1,57 @@
+# Flow Project Overview
+
+## What This Project Is
+
+Flow is a multi-tenant project management and issue tracking app. The product is positioned as a calmer, lower-ceremony alternative to heavier PM tools: teams capture work, organize it into projects and sprints, track progress visually, and stay aligned through activity and notifications.
+
+Public users see a marketing landing page at `/`. Signed-in users are pushed into onboarding or into a workspace-scoped app at `/{workspaceSlug}/...`.
+
+## Core Product Shape
+
+- Work happens inside a workspace.
+- A workspace contains members, teams, projects, sprints, issues, labels, saved views, comments, activities, and notifications.
+- Main app areas are:
+  - dashboard
+  - inbox
+  - my issues
+  - projects
+  - views
+  - teams
+  - analytics
+  - settings
+- Project pages support multiple planning surfaces, especially board and list views, plus sprint planning, timeline, and project settings.
+- Issues are a first-class object with assignee, priority, status, due date, story points, labels, checklist items, rich-text description, comment thread, and permalinkable detail panel state.
+- The UI is intentionally polished and product-led, not just admin CRUD.
+
+## Architecture
+
+- Framework: Next.js 16 App Router with React 19.
+- Styling/UI: Tailwind CSS v4, Radix primitives, custom component library in `src/components/ui`.
+- Backend: Supabase for auth, database, and realtime.
+- Auth/session handling lives in `src/middleware.ts` and `src/lib/supabase/*`.
+- Most reads are done through server-side query helpers in `src/lib/queries/*`.
+- Most writes happen through server actions in `src/lib/actions/*`.
+- The workspace shell is assembled in `src/app/(app)/[workspaceSlug]/layout.tsx`.
+- Realtime hooks exist for issues, comments, and notification counts.
+
+## Important User Flows
+
+1. Authenticated users without a workspace go through a 3-step onboarding flow:
+   create workspace -> invite teammates -> create first project.
+2. Authenticated users with a workspace are redirected to `/{workspaceSlug}/dashboard`.
+3. Daily use is centered on project board/list views, issue detail editing, sprint context, inbox notifications, saved views, and analytics.
+
+## Where To Read First
+
+- `src/app/page.tsx`: landing page vs authenticated redirect.
+- `src/app/(app)/[workspaceSlug]/layout.tsx`: workspace bootstrapping and shell.
+- `src/lib/queries/*`: how server data is fetched.
+- `src/lib/actions/*`: how mutations are performed.
+- `tests/phase1-auth-flow.spec.ts`: best single file for understanding the core auth/onboarding/dashboard flow.
+
+## Testing Notes
+
+- Playwright is the main E2E harness.
+- `tests/auth.setup.ts` creates/saves auth state for the seeded workspace flow.
+- `tests/phase1-auth-flow.spec.ts` creates a fresh user and unique workspace, so it is useful when you want an end-to-end auth/onboarding check without relying on existing seeded state.
+- Seeded authenticated workspace slug for app tests: `pw-workspace`.

--- a/src/app/(app)/[workspaceSlug]/layout.tsx
+++ b/src/app/(app)/[workspaceSlug]/layout.tsx
@@ -6,6 +6,7 @@ import { getWorkspaceMembers } from "@/lib/queries/members";
 import { WorkspaceProvider } from "@/providers/workspace-provider";
 import { WorkspaceShell } from "@/components/layout/workspace-shell";
 import { LayoutShell } from "@/components/layout/layout-shell";
+import type { Tables } from "@/lib/types";
 
 export default async function WorkspaceLayout({
   children,
@@ -30,12 +31,36 @@ export default async function WorkspaceLayout({
     data: { user },
   } = await supabase.auth.getUser();
 
+  const profilePromise = user
+    ? supabase
+        .from("profiles")
+        .select("full_name, email, avatar_url")
+        .eq("id", user.id)
+        .maybeSingle()
+    : null;
+  const userWorkspacesPromise = user
+    ? supabase
+        .from("workspace_members")
+        .select("role, workspace:workspaces!inner(id, name, slug)")
+        .eq("user_id", user.id)
+    : null;
+
+  const [unreadCount, members, profileResult, userWorkspacesResult] = await Promise.all([
+    user ? getUnreadNotificationCount(workspace.id, user.id) : 0,
+    getWorkspaceMembers(workspace.id),
+    profilePromise,
+    userWorkspacesPromise,
+  ]);
+
+  const profile = profileResult?.data ?? null;
   const userName =
-    typeof user?.user_metadata?.full_name === "string" &&
+    profile?.full_name?.trim() ||
+    (typeof user?.user_metadata?.full_name === "string" &&
     user.user_metadata.full_name.trim().length > 0
       ? user.user_metadata.full_name.trim()
-      : null;
-  const userEmail = user?.email ?? null;
+      : null);
+  const userEmail = profile?.email ?? user?.email ?? null;
+  const userAvatarUrl = profile?.avatar_url ?? null;
   const initials =
     userName
       ?.split(" ")
@@ -46,10 +71,18 @@ export default async function WorkspaceLayout({
     userEmail?.slice(0, 2).toUpperCase() ??
     "U";
 
-  const [unreadCount, members] = await Promise.all([
-    user ? getUnreadNotificationCount(workspace.id, user.id) : 0,
-    getWorkspaceMembers(workspace.id),
-  ]);
+  const workspaces = (
+    (userWorkspacesResult?.data ?? []) as Array<{
+      role: Tables<"workspace_members">["role"];
+      workspace: Pick<Tables<"workspaces">, "id" | "name" | "slug"> | null;
+    }>
+  )
+    .flatMap((membership) =>
+      membership.workspace
+        ? [{ role: membership.role, workspace: membership.workspace }]
+        : []
+    )
+    .sort((a, b) => a.workspace.name.localeCompare(b.workspace.name));
 
   const memberList = members.map((m) => ({
     user_id: m.user_id,
@@ -78,6 +111,8 @@ export default async function WorkspaceLayout({
           userInitials={initials}
           userName={userName}
           userEmail={userEmail}
+          userAvatarUrl={userAvatarUrl}
+          workspaces={workspaces}
         >
           {children}
         </LayoutShell>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { CircleUser, LogOut, Menu, Search, Settings } from "lucide-react";
 import { signOut } from "@/lib/actions/auth";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,12 +14,18 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useShell } from "@/components/layout/workspace-shell";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
+import type { WorkspaceRole } from "@/lib/types";
 
 interface HeaderProps {
   workspaceSlug: string;
   userInitials: string;
   userName: string | null;
   userEmail: string | null;
+  userAvatarUrl: string | null;
+  workspaces: {
+    role: WorkspaceRole;
+    workspace: { id: string; name: string; slug: string };
+  }[];
 }
 
 export function Header({
@@ -27,9 +33,20 @@ export function Header({
   userInitials,
   userName,
   userEmail,
+  userAvatarUrl,
+  workspaces,
 }: HeaderProps) {
   const shell = useShell();
   const accountLabel = userName ?? userEmail ?? "Account";
+  const currentWorkspace =
+    workspaces.find((entry) => entry.workspace.slug === workspaceSlug)?.workspace ?? null;
+  const orderedWorkspaces = [...workspaces].sort((a, b) => {
+    const aCurrent = a.workspace.slug === workspaceSlug ? 0 : 1;
+    const bCurrent = b.workspace.slug === workspaceSlug ? 0 : 1;
+
+    if (aCurrent !== bCurrent) return aCurrent - bCurrent;
+    return a.workspace.name.localeCompare(b.workspace.name);
+  });
 
   return (
     <header className="flex items-center justify-between gap-3 px-4 md:px-10 pt-6">
@@ -68,21 +85,66 @@ export function Header({
             className="rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2"
           >
             <Avatar size="sm">
+              {userAvatarUrl && (
+                <AvatarImage src={userAvatarUrl} alt={accountLabel} />
+              )}
               <AvatarFallback>{userInitials}</AvatarFallback>
             </Avatar>
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuContent align="end" className="w-72">
           <DropdownMenuLabel className="normal-case tracking-normal">
-            <div className="flex flex-col gap-0.5">
-              <span className="text-sm font-medium text-text">{accountLabel}</span>
-              {userEmail && (
-                <span className="text-xs font-normal text-text-muted">
-                  {userEmail}
+            <div className="flex items-center gap-3">
+              <Avatar>
+                {userAvatarUrl && (
+                  <AvatarImage src={userAvatarUrl} alt={accountLabel} />
+                )}
+                <AvatarFallback>{userInitials}</AvatarFallback>
+              </Avatar>
+              <div className="min-w-0 flex flex-col gap-0.5">
+                <span className="truncate text-sm font-medium text-text">
+                  {accountLabel}
                 </span>
-              )}
+                {userEmail && (
+                  <span className="truncate text-xs font-normal text-text-muted">
+                    {userEmail}
+                  </span>
+                )}
+                {currentWorkspace && (
+                  <span className="truncate text-xs font-normal text-text-muted">
+                    {currentWorkspace.name}
+                  </span>
+                )}
+              </div>
             </div>
           </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>Workspaces</DropdownMenuLabel>
+          <div className="max-h-64 overflow-y-auto">
+            {orderedWorkspaces.map(({ role, workspace }) => {
+              const isCurrent = workspace.slug === workspaceSlug;
+
+              return (
+                <DropdownMenuItem key={workspace.id} asChild>
+                  <Link href={`/${workspace.slug}/dashboard`}>
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="truncate text-sm text-text">
+                        {workspace.name}
+                      </span>
+                      <span className="truncate text-xs text-text-muted">
+                        {formatWorkspaceRole(role)}
+                      </span>
+                    </div>
+                    {isCurrent && (
+                      <span className="rounded-full bg-[#EDEAE4] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-text-muted">
+                        Current
+                      </span>
+                    )}
+                  </Link>
+                </DropdownMenuItem>
+              );
+            })}
+          </div>
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild>
             <Link href={`/${workspaceSlug}/settings/profile`}>
@@ -110,4 +172,15 @@ export function Header({
       </DropdownMenu>
     </header>
   );
+}
+
+function formatWorkspaceRole(role: WorkspaceRole) {
+  switch (role) {
+    case "owner":
+      return "Owner";
+    case "admin":
+      return "Admin";
+    default:
+      return "Member";
+  }
 }

--- a/src/components/layout/layout-shell.tsx
+++ b/src/components/layout/layout-shell.tsx
@@ -17,6 +17,11 @@ interface LayoutShellProps {
   userInitials: string;
   userName: string | null;
   userEmail: string | null;
+  userAvatarUrl: string | null;
+  workspaces: {
+    role: "owner" | "admin" | "member";
+    workspace: { id: string; name: string; slug: string };
+  }[];
   children: React.ReactNode;
 }
 
@@ -26,6 +31,8 @@ export function LayoutShell({
   userInitials,
   userName,
   userEmail,
+  userAvatarUrl,
+  workspaces,
   children,
 }: LayoutShellProps) {
   const shell = useShell();
@@ -44,6 +51,8 @@ export function LayoutShell({
             userInitials={userInitials}
             userName={userName}
             userEmail={userEmail}
+            userAvatarUrl={userAvatarUrl}
+            workspaces={workspaces}
           />
           {children}
         </main>

--- a/src/components/settings/profile-settings-form.tsx
+++ b/src/components/settings/profile-settings-form.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { updateProfile } from "@/lib/actions/profile";
 import { Switch } from "@/components/ui/switch";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { Tables } from "@/lib/types";
 
 interface ProfileSettingsFormProps {
@@ -69,6 +69,12 @@ export function ProfileSettingsForm({ profile }: ProfileSettingsFormProps) {
         {/* Avatar */}
         <div className="flex items-center gap-4">
           <Avatar className="size-16">
+            {profile.avatar_url && (
+              <AvatarImage
+                src={profile.avatar_url}
+                alt={profile.full_name ?? profile.email}
+              />
+            )}
             <AvatarFallback className="text-lg">{initials}</AvatarFallback>
           </Avatar>
           <div>

--- a/tests/account-menu.spec.ts
+++ b/tests/account-menu.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../src/lib/types";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const TEST_EMAIL = "playwright@test.flow.dev";
+const SWITCH_WORKSPACE_NAME = "Playwright Switch Workspace";
+const SWITCH_WORKSPACE_SLUG = "pw-workspace-switch";
+
+let admin: SupabaseClient<Database>;
+let testUserId: string | null = null;
+let switchWorkspaceId: string | null = null;
+
+test.describe.serial("account menu", () => {
+  test.beforeAll(async () => {
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+      throw new Error("Missing Supabase env for account menu test");
+    }
+
+    admin = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+    const { data: users, error: usersError } = await admin.auth.admin.listUsers();
+    if (usersError) {
+      throw new Error(`Failed to load test user: ${usersError.message}`);
+    }
+
+    testUserId = users.users.find((user) => user.email === TEST_EMAIL)?.id ?? null;
+    if (!testUserId) {
+      throw new Error(`Test user ${TEST_EMAIL} was not found`);
+    }
+
+    const { data: existingWorkspace, error: existingWorkspaceError } = await admin
+      .from("workspaces")
+      .select("id")
+      .eq("slug", SWITCH_WORKSPACE_SLUG)
+      .maybeSingle();
+
+    if (existingWorkspaceError) {
+      throw new Error(
+        `Failed to load switch workspace: ${existingWorkspaceError.message}`
+      );
+    }
+
+    if (existingWorkspace) {
+      switchWorkspaceId = existingWorkspace.id;
+    } else {
+      const { data: createdWorkspace, error: createWorkspaceError } = await admin
+        .from("workspaces")
+        .insert({
+          name: SWITCH_WORKSPACE_NAME,
+          slug: SWITCH_WORKSPACE_SLUG,
+        })
+        .select("id")
+        .single();
+
+      if (createWorkspaceError) {
+        throw new Error(
+          `Failed to create switch workspace: ${createWorkspaceError.message}`
+        );
+      }
+
+      switchWorkspaceId = createdWorkspace.id;
+    }
+
+    const { error: membershipError } = await admin.from("workspace_members").upsert(
+      {
+        workspace_id: switchWorkspaceId,
+        user_id: testUserId,
+        role: "admin",
+      },
+      { onConflict: "workspace_id,user_id" }
+    );
+
+    if (membershipError) {
+      throw new Error(
+        `Failed to attach test user to switch workspace: ${membershipError.message}`
+      );
+    }
+  });
+
+  test.afterAll(async () => {
+    if (!switchWorkspaceId) return;
+
+    if (testUserId) {
+      await admin
+        .from("workspace_members")
+        .delete()
+        .eq("workspace_id", switchWorkspaceId)
+        .eq("user_id", testUserId);
+    }
+
+    await admin.from("workspaces").delete().eq("id", switchWorkspaceId);
+  });
+
+  test("shows account details and switches workspaces", async ({ page }) => {
+    await page.goto("/pw-workspace/dashboard");
+    await expect(page).not.toHaveURL(/\/login/, { timeout: 10000 });
+
+    await page.getByRole("button", { name: "Open account menu" }).click();
+
+    await expect(page.getByText(TEST_EMAIL)).toBeVisible();
+    await expect(page.getByRole("link", { name: /Profile settings/i })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Playwright Switch Workspace/i })
+    ).toBeVisible();
+    await expect(page.getByText("Current", { exact: true })).toBeVisible();
+
+    await page.getByRole("link", { name: /Playwright Switch Workspace/i }).click();
+
+    await expect(page).toHaveURL(`/${SWITCH_WORKSPACE_SLUG}/dashboard`);
+    await expect(page.locator("aside")).toContainText(SWITCH_WORKSPACE_NAME);
+  });
+});

--- a/tests/account-menu.spec.ts
+++ b/tests/account-menu.spec.ts
@@ -100,13 +100,13 @@ test.describe.serial("account menu", () => {
     await page.getByRole("button", { name: "Open account menu" }).click();
 
     await expect(page.getByText(TEST_EMAIL)).toBeVisible();
-    await expect(page.getByRole("link", { name: /Profile settings/i })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: /Profile settings/i })).toBeVisible();
     await expect(
-      page.getByRole("link", { name: /Playwright Switch Workspace/i })
+      page.getByRole("menuitem", { name: /Playwright Switch Workspace/i })
     ).toBeVisible();
     await expect(page.getByText("Current", { exact: true })).toBeVisible();
 
-    await page.getByRole("link", { name: /Playwright Switch Workspace/i }).click();
+    await page.getByRole("menuitem", { name: /Playwright Switch Workspace/i }).click();
 
     await expect(page).toHaveURL(`/${SWITCH_WORKSPACE_SLUG}/dashboard`);
     await expect(page.locator("aside")).toContainText(SWITCH_WORKSPACE_NAME);

--- a/tests/phase1-auth-flow.spec.ts
+++ b/tests/phase1-auth-flow.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../src/lib/types";
 
 /**
  * Phase 1 Verification #1 (from issue #3):
@@ -17,7 +18,7 @@ const TEST_FULL_NAME = "E2E Tester";
 const TEST_WORKSPACE_NAME = `Test Workspace ${Date.now()}`;
 const TEST_WORKSPACE_SLUG = `test-ws-${Date.now()}`;
 
-let adminClient: ReturnType<typeof createClient>;
+let adminClient: SupabaseClient<Database>;
 let testUserId: string | null = null;
 
 test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {


### PR DESCRIPTION
## Summary
- load the signed-in profile and all workspace memberships into the workspace shell
- expand the account dropdown to show real account details, avatar rendering, and workspace switching while keeping logout in place
- add account-menu coverage and type the existing admin Playwright test client so the repo stays type-clean

## Testing
- npx eslint src/app/'(app)'/'[workspaceSlug]'/layout.tsx src/components/layout/header.tsx src/components/layout/layout-shell.tsx src/components/settings/profile-settings-form.tsx tests/account-menu.spec.ts tests/logout.spec.ts tests/phase1-auth-flow.spec.ts
- npx tsc --noEmit
- set -a; source ../.env.local; set +a; npx playwright test tests/auth.setup.ts --project=setup
- manual playwright-cli verification on http://localhost:3010 for account menu, workspace switching, logout, and post-logout redirect
