### PR TITLE
Integrate sprint planning with dashboard and analytics

### DIFF
--- a/src/app/(app)/[workspaceSlug]/analytics/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/analytics/page.tsx
@@ -7,6 +7,7 @@ import {
   getSprintBurndown,
   getIssuesByLabel,
   getTeamVelocity,
+  getSprintSnapshot,
   getOverviewKPIs,
   getThroughputSeries,
   getCycleTimeDistribution,
@@ -24,6 +25,7 @@ import { OverviewKPICards } from "@/components/analytics/overview-kpi-cards";
 import { ThroughputChart } from "@/components/analytics/throughput-chart";
 import { CycleTimeChart } from "@/components/analytics/cycle-time-chart";
 import { AssigneeChart } from "@/components/analytics/assignee-chart";
+import { SprintSnapshotCard } from "@/components/analytics/sprint-snapshot-card";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 
 export default async function AnalyticsPage({
@@ -45,7 +47,7 @@ export default async function AnalyticsPage({
   const hasSprints = sprints.length > 0;
 
   // Determine active tab — fall back to overview if no sprints
-  let activeTab: "overview" | "sprints" =
+  const activeTab: "overview" | "sprints" =
     resolvedSearchParams.tab === "sprints" && hasSprints ? "sprints" : "overview";
 
   const range = parseRange(resolvedSearchParams.range);
@@ -125,13 +127,14 @@ export default async function AnalyticsPage({
     );
   }
 
-  const [currentKPIs, previousKPIs, burndownData, labelData, velocityData] =
+  const [currentKPIs, previousKPIs, burndownData, labelData, velocityData, snapshot] =
     await Promise.all([
       getSprintAnalytics(selectedSprint.id),
       getPreviousSprintKPIs(selectedSprint),
       getSprintBurndown(selectedSprint.id, selectedSprint),
       getIssuesByLabel(result.workspace.id, selectedSprint.id),
       getTeamVelocity(result.workspace.id),
+      getSprintSnapshot(selectedSprint),
     ]);
 
   return (
@@ -146,6 +149,11 @@ export default async function AnalyticsPage({
       </div>
 
       <AnalyticsTabs activeTab={activeTab} hasSprints={hasSprints} />
+
+      <SprintSnapshotCard
+        snapshot={snapshot}
+        workspaceSlug={workspaceSlug}
+      />
 
       <KPICards current={currentKPIs} previous={previousKPIs} />
 

--- a/src/app/(app)/[workspaceSlug]/dashboard/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/dashboard/page.tsx
@@ -36,7 +36,7 @@ export default async function DashboardPage({
 
   // Determine active sprint for sprint context
   let activeSprint = null;
-  let issueCounts: Record<IssueStatus, number> = {
+  const issueCounts: Record<IssueStatus, number> = {
     todo: 0,
     in_progress: 0,
     in_review: 0,
@@ -98,9 +98,10 @@ export default async function DashboardPage({
   const focusIssues = await enrichIssues(focusIssuesRaw ?? [], supabase);
 
   // Fetch recent activities and workspace members
-  const [recentActivities, members] = await Promise.all([
+  const [recentActivities, members, projects] = await Promise.all([
     getRecentActivities(workspace.id, 6),
     getWorkspaceMembers(workspace.id),
+    getWorkspaceProjects(workspace.id),
   ]);
 
   // Fetch full issue details for issue-type activities (needed by IssueDetailPanel)
@@ -125,6 +126,10 @@ export default async function DashboardPage({
     }
   }
 
+  const activeSprintProject = activeSprint
+    ? projects.find((project) => project.id === activeSprint.project_id) ?? null
+    : null;
+
   return (
     <div className="flex flex-col flex-1">
       {/* Breadcrumb */}
@@ -144,6 +149,8 @@ export default async function DashboardPage({
             sprint={activeSprint}
             issueCounts={issueCounts}
             totalIssues={totalIssues}
+            workspaceSlug={workspaceSlug}
+            projectName={activeSprintProject?.name ?? null}
           />
         </div>
       )}

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/page.tsx
@@ -6,6 +6,7 @@ import {
   getProjectSprints,
 } from "@/lib/queries/projects";
 import { getWorkspaceMembers } from "@/lib/queries/members";
+import { getProjectActiveSprintSummary } from "@/lib/queries/sprints";
 import { SprintHeader } from "@/components/sprints/sprint-header";
 import { BoardPageEmpty } from "./board-empty";
 import { BoardWithDetail } from "./board-with-detail";
@@ -15,15 +16,16 @@ export default async function BoardPage({
 }: {
   params: Promise<{ workspaceSlug: string; projectId: string }>;
 }) {
-  const { projectId } = await params;
+  const { workspaceSlug, projectId } = await params;
 
   const projectData = await getProjectById(projectId);
   if (!projectData) notFound();
 
-  const [issues, labels, sprints, members] = await Promise.all([
+  const [issues, labels, sprints, activeSprintSummary, members] = await Promise.all([
     getProjectIssues(projectId),
     getProjectLabels(projectId),
     getProjectSprints(projectId),
+    getProjectActiveSprintSummary(projectId),
     getWorkspaceMembers(projectData.workspace_id),
   ]);
 
@@ -40,21 +42,17 @@ export default async function BoardPage({
     );
   }
 
-  const activeSprint = sprints.find((s) => s.status === "active");
-  const sprintIssues = activeSprint
-    ? issues.filter((i) => i.sprint_id === activeSprint.id)
-    : [];
-  const sprintDone = sprintIssues.filter((i) => i.status === "done");
-
   return (
     <div className="h-full flex flex-col">
-      {activeSprint && (
+      {activeSprintSummary && (
         <SprintHeader
-          sprint={activeSprint}
-          totalIssues={sprintIssues.length}
-          doneIssues={sprintDone.length}
-          totalPoints={sprintIssues.reduce((s, i) => s + (i.story_points ?? 0), 0)}
-          donePoints={sprintDone.reduce((s, i) => s + (i.story_points ?? 0), 0)}
+          sprint={activeSprintSummary.sprint}
+          totalIssues={activeSprintSummary.totalIssues}
+          doneIssues={activeSprintSummary.doneIssues}
+          totalPoints={activeSprintSummary.totalPoints}
+          donePoints={activeSprintSummary.donePoints}
+          workspaceSlug={workspaceSlug}
+          projectId={projectId}
         />
       )}
       <div className="flex-1">

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { getProjectIssues } from "@/lib/queries/issues";
 import { getProjectById, getProjectLabels, getProjectSprints } from "@/lib/queries/projects";
 import { getWorkspaceMembers } from "@/lib/queries/members";
+import { getProjectActiveSprintSummary } from "@/lib/queries/sprints";
 import { SprintHeader } from "@/components/sprints/sprint-header";
 import { ListPageClient } from "./list-client";
 import { ListViewContent } from "./list-view-content";
@@ -11,15 +12,16 @@ export default async function ListPage({
 }: {
   params: Promise<{ workspaceSlug: string; projectId: string }>;
 }) {
-  const { projectId } = await params;
+  const { workspaceSlug, projectId } = await params;
 
   const projectData = await getProjectById(projectId);
   if (!projectData) notFound();
 
-  const [issues, labels, sprints, members] = await Promise.all([
+  const [issues, labels, sprints, activeSprintSummary, members] = await Promise.all([
     getProjectIssues(projectId),
     getProjectLabels(projectId),
     getProjectSprints(projectId),
+    getProjectActiveSprintSummary(projectId),
     getWorkspaceMembers(projectData.workspace_id),
   ]);
 
@@ -27,21 +29,17 @@ export default async function ListPage({
   const hasIssues = issues.length > 0;
   const maxSortOrder = issues.reduce((max, i) => Math.max(max, i.sort_order), 0);
 
-  const activeSprint = sprints.find((s) => s.status === "active");
-  const sprintIssues = activeSprint
-    ? issues.filter((i) => i.sprint_id === activeSprint.id)
-    : [];
-  const sprintDone = sprintIssues.filter((i) => i.status === "done");
-
   return (
     <div className="py-2">
-      {activeSprint && (
+      {activeSprintSummary && (
         <SprintHeader
-          sprint={activeSprint}
-          totalIssues={sprintIssues.length}
-          doneIssues={sprintDone.length}
-          totalPoints={sprintIssues.reduce((s, i) => s + (i.story_points ?? 0), 0)}
-          donePoints={sprintDone.reduce((s, i) => s + (i.story_points ?? 0), 0)}
+          sprint={activeSprintSummary.sprint}
+          totalIssues={activeSprintSummary.totalIssues}
+          doneIssues={activeSprintSummary.doneIssues}
+          totalPoints={activeSprintSummary.totalPoints}
+          donePoints={activeSprintSummary.donePoints}
+          workspaceSlug={workspaceSlug}
+          projectId={projectId}
         />
       )}
 

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/sprint-planning/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/sprint-planning/page.tsx
@@ -11,7 +11,7 @@ export default async function SprintPlanningPage({
   params: Promise<{ workspaceSlug: string; projectId: string }>;
   searchParams: Promise<{ sprint?: string }>;
 }) {
-  const [{ projectId }, resolvedSearchParams] = await Promise.all([
+  const [{ workspaceSlug, projectId }, resolvedSearchParams] = await Promise.all([
     params,
     searchParams,
   ]);
@@ -47,8 +47,16 @@ export default async function SprintPlanningPage({
     selectedSprint ? getSprintIssues(selectedSprint.id) : Promise.resolve([]),
   ]);
 
+  const planningViewKey = [
+    selectedSprint?.id ?? "no-sprint",
+    backlogIssues.map((issue) => issue.id).join(","),
+    sprintIssues.map((issue) => issue.id).join(","),
+  ].join(":");
+
   return (
     <SprintPlanningView
+      key={planningViewKey}
+      workspaceSlug={workspaceSlug}
       projectId={projectData.id}
       workspaceId={projectData.workspace_id}
       sprint={selectedSprint}

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/sprint-planning/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/sprint-planning/page.tsx
@@ -25,27 +25,27 @@ export default async function SprintPlanningPage({
   ]);
 
   // Determine which sprint to show:
-  // 1. URL param ?sprint=<id> if it matches a valid sprint
+  // 1. URL param ?sprint=<id> if it matches any sprint, including completed
   // 2. First "planning" sprint
   // 3. First "active" sprint
-  const selectableSprints = sprints.filter((s) => s.status !== "completed");
-  let selectedSprint =
-    resolvedSearchParams.sprint
-      ? selectableSprints.find((s) => s.id === resolvedSearchParams.sprint) ?? null
-      : null;
-
-  if (!selectedSprint) {
-    selectedSprint =
-      selectableSprints.find((s) => s.status === "planning") ??
-      selectableSprints.find((s) => s.status === "active") ??
-      null;
-  }
+  // 4. Most recent completed sprint
+  const activeSelectableSprints = sprints.filter((s) => s.status !== "completed");
+  const selectedSprint =
+    (resolvedSearchParams.sprint
+      ? sprints.find((s) => s.id === resolvedSearchParams.sprint) ?? null
+      : null) ??
+    activeSelectableSprints.find((s) => s.status === "planning") ??
+    activeSelectableSprints.find((s) => s.status === "active") ??
+    sprints.find((s) => s.status === "completed") ??
+    null;
 
   // Fetch backlog (excluding the selected sprint) and sprint issues in parallel
-  const [backlogIssues, sprintIssues] = await Promise.all([
+  const [backlogIssuesRaw, sprintIssues] = await Promise.all([
     getBacklogIssues(projectId, selectedSprint?.id),
     selectedSprint ? getSprintIssues(selectedSprint.id) : Promise.resolve([]),
   ]);
+  const sprintIssueIds = new Set(sprintIssues.map((issue) => issue.id));
+  const backlogIssues = backlogIssuesRaw.filter((issue) => !sprintIssueIds.has(issue.id));
 
   const planningViewKey = [
     selectedSprint?.id ?? "no-sprint",

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/timeline/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/timeline/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from "next/navigation";
 import { getProjectById } from "@/lib/queries/projects";
 import { getTimelineIssues } from "@/lib/queries/timeline";
+import { getProjectActiveSprintSummary } from "@/lib/queries/sprints";
+import { SprintHeader } from "@/components/sprints/sprint-header";
 import { TimelineView } from "@/components/timeline/timeline-view";
 
 export default async function TimelinePage({
@@ -8,12 +10,32 @@ export default async function TimelinePage({
 }: {
   params: Promise<{ workspaceSlug: string; projectId: string }>;
 }) {
-  const { projectId } = await params;
+  const { workspaceSlug, projectId } = await params;
 
   const project = await getProjectById(projectId);
   if (!project) notFound();
 
-  const issues = await getTimelineIssues(projectId);
+  const [issues, activeSprintSummary] = await Promise.all([
+    getTimelineIssues(projectId),
+    getProjectActiveSprintSummary(projectId),
+  ]);
 
-  return <TimelineView issues={issues} />;
+  return (
+    <div className="flex h-full flex-col">
+      {activeSprintSummary && (
+        <SprintHeader
+          sprint={activeSprintSummary.sprint}
+          totalIssues={activeSprintSummary.totalIssues}
+          doneIssues={activeSprintSummary.doneIssues}
+          totalPoints={activeSprintSummary.totalPoints}
+          donePoints={activeSprintSummary.donePoints}
+          workspaceSlug={workspaceSlug}
+          projectId={projectId}
+        />
+      )}
+      <div className="flex-1">
+        <TimelineView issues={issues} />
+      </div>
+    </div>
+  );
 }

--- a/src/components/analytics/sprint-snapshot-card.tsx
+++ b/src/components/analytics/sprint-snapshot-card.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import type { SprintSnapshot } from "@/lib/queries/analytics";
+import { formatDateFull } from "@/lib/utils/dates";
+
+const STATUS_LABELS: Record<SprintSnapshot["status"], string> = {
+  planning: "Planning",
+  active: "Active",
+  completed: "Completed",
+};
+
+export function SprintSnapshotCard({
+  snapshot,
+  workspaceSlug,
+}: {
+  snapshot: SprintSnapshot;
+  workspaceSlug: string;
+}) {
+  const dateRange =
+    snapshot.startDate && snapshot.endDate
+      ? `${formatDateFull(snapshot.startDate)} - ${formatDateFull(snapshot.endDate)}`
+      : null;
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-white p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-border bg-surface px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-text-secondary">
+              {snapshot.status === "completed" ? "Retrospective" : "Sprint Context"}
+            </span>
+            <span className="text-sm text-text-secondary">
+              {STATUS_LABELS[snapshot.status]} sprint
+            </span>
+          </div>
+
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <h2 className="text-lg font-semibold text-text">{snapshot.sprintName}</h2>
+            <span className="text-lg text-text-secondary">·</span>
+            <span className="text-sm text-text-secondary">{snapshot.projectName}</span>
+          </div>
+
+          <p className="mt-1 text-sm font-medium text-text">
+            {snapshot.scopeIssues} issue{snapshot.scopeIssues !== 1 ? "s" : ""} in scope,{" "}
+            {snapshot.issuesCompleted} completed
+            {snapshot.rolledOverIssues > 0
+              ? `, ${snapshot.rolledOverIssues} rolled over`
+              : ""}
+            .
+          </p>
+
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-secondary">
+            <span>{STATUS_LABELS[snapshot.status]} sprint</span>
+            {dateRange && <span>{dateRange}</span>}
+            {snapshot.completedAt && (
+              <span>Completed {formatDateFull(snapshot.completedAt)}</span>
+            )}
+          </div>
+
+          {snapshot.goal && (
+            <p className="mt-3 max-w-3xl text-sm text-text-secondary">
+              Goal: {snapshot.goal}
+            </p>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <Button asChild size="sm" variant="secondary">
+            <Link
+              href={`/${workspaceSlug}/projects/${snapshot.projectId}/sprint-planning?sprint=${snapshot.sprintId}`}
+            >
+              Sprint Planning
+            </Link>
+          </Button>
+          <Button asChild size="sm" variant="ghost">
+            <Link href={`/${workspaceSlug}/projects/${snapshot.projectId}/board`}>
+              Project Board
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/sprint-strip.tsx
+++ b/src/components/dashboard/sprint-strip.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { differenceInDays, format } from "date-fns";
+import { Button } from "@/components/ui/button";
 import { ProgressRing } from "@/components/ui/progress-ring";
 import type { Tables, IssueStatus } from "@/lib/types";
 
@@ -8,6 +10,8 @@ interface SprintStripProps {
   sprint: Tables<"sprints">;
   issueCounts: Record<IssueStatus, number>;
   totalIssues: number;
+  workspaceSlug: string;
+  projectName: string | null;
 }
 
 const STATUS_BAR_ORDER: IssueStatus[] = [
@@ -35,6 +39,8 @@ export function SprintStrip({
   sprint,
   issueCounts,
   totalIssues,
+  workspaceSlug,
+  projectName,
 }: SprintStripProps) {
   const donePercent =
     totalIssues > 0 ? Math.round((issueCounts.done / totalIssues) * 100) : 0;
@@ -49,7 +55,7 @@ export function SprintStrip({
       : null;
 
   return (
-    <div className="flex items-center gap-6 rounded-xl border border-border bg-surface py-5 px-6">
+    <div className="flex flex-col gap-5 rounded-xl border border-border bg-surface px-6 py-5 lg:flex-row lg:items-center">
       {/* Progress ring */}
       <div className="relative shrink-0">
         <ProgressRing value={donePercent} size={52} strokeWidth={5}>
@@ -67,7 +73,12 @@ export function SprintStrip({
       </div>
 
       {/* Sprint info */}
-      <div className="shrink-0">
+      <div className="min-w-0 shrink-0">
+        {projectName && (
+          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-text-muted">
+            {projectName}
+          </p>
+        )}
         <p className="text-base font-semibold text-text">{sprint.name}</p>
         <p className="text-[13px] text-text-secondary">
           {daysRemaining !== null && (
@@ -78,13 +89,18 @@ export function SprintStrip({
           {daysRemaining !== null && dateRange && <span> · </span>}
           {dateRange && <span>{dateRange}</span>}
         </p>
+        {sprint.goal && (
+          <p className="mt-1 max-w-xl truncate text-[13px] text-text-secondary">
+            Goal: {sprint.goal}
+          </p>
+        )}
       </div>
 
       {/* Divider */}
-      <div className="hidden sm:block h-9 w-px bg-border shrink-0" />
+      <div className="hidden h-9 w-px shrink-0 bg-border lg:block" />
 
       {/* Status bar — fills remaining space */}
-      <div className="hidden sm:flex flex-1 flex-col gap-2.5">
+      <div className="hidden flex-1 flex-col gap-2.5 sm:flex">
         <p className="text-[11px] font-medium tracking-[0.04em] text-text-secondary uppercase">
           Issues by Status
         </p>
@@ -117,6 +133,21 @@ export function SprintStrip({
             </span>
           ))}
         </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <Button asChild size="sm" variant="secondary">
+          <Link
+            href={`/${workspaceSlug}/projects/${sprint.project_id}/sprint-planning?sprint=${sprint.id}`}
+          >
+            Sprint Planning
+          </Link>
+        </Button>
+        <Button asChild size="sm" variant="ghost">
+          <Link href={`/${workspaceSlug}/analytics?tab=sprints&sprint=${sprint.id}`}>
+            Analytics
+          </Link>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/sprints/complete-sprint-modal.tsx
+++ b/src/components/sprints/complete-sprint-modal.tsx
@@ -18,6 +18,7 @@ interface CompleteSprintModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   sprint: Tables<"sprints">;
+  workspaceSlug: string;
   totalIssues: number;
   doneIssues: number;
   incompleteIssues: number;
@@ -27,6 +28,7 @@ export function CompleteSprintModal({
   open,
   onOpenChange,
   sprint,
+  workspaceSlug,
   totalIssues,
   doneIssues,
   incompleteIssues,
@@ -49,8 +51,8 @@ export function CompleteSprintModal({
 
     setLoading(false);
     onOpenChange(false);
-    router.refresh();
-  }, [sprint.id, onOpenChange, router]);
+    router.push(`/${workspaceSlug}/analytics?tab=sprints&sprint=${sprint.id}`);
+  }, [sprint.id, workspaceSlug, onOpenChange, router]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -59,6 +61,7 @@ export function CompleteSprintModal({
           <DialogTitle>Complete {sprint.name}</DialogTitle>
           <DialogDescription>
             {doneIssues} of {totalIssues} issue{totalIssues !== 1 ? "s" : ""} completed.
+            {" "}Flow will open sprint analytics after completion.
           </DialogDescription>
         </DialogHeader>
 
@@ -84,7 +87,7 @@ export function CompleteSprintModal({
             Cancel
           </Button>
           <Button onClick={handleComplete} disabled={loading}>
-            {loading ? "Completing..." : "Complete Sprint"}
+            {loading ? "Completing..." : "Complete & Review"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/sprints/sprint-header.tsx
+++ b/src/components/sprints/sprint-header.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { formatDateFull } from "@/lib/utils/dates";
 import type { Tables } from "@/lib/types";
 
@@ -7,6 +9,8 @@ interface SprintHeaderProps {
   doneIssues: number;
   totalPoints: number;
   donePoints: number;
+  workspaceSlug: string;
+  projectId: string;
 }
 
 export function SprintHeader({
@@ -15,44 +19,67 @@ export function SprintHeader({
   doneIssues,
   totalPoints,
   donePoints,
+  workspaceSlug,
+  projectId,
 }: SprintHeaderProps) {
   const completionPercent =
     totalIssues > 0 ? Math.round((doneIssues / totalIssues) * 100) : 0;
 
   return (
-    <div className="px-6 py-3 border-b border-border bg-surface-hover/50">
-      <div className="flex items-center gap-3">
-        <span className="text-sm font-medium text-text">{sprint.name}</span>
+    <div className="border-b border-border bg-surface-hover/50 px-6 py-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-success/20 bg-success/5 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-success">
+              Active Sprint
+            </span>
+            <span className="text-sm font-semibold text-text">{sprint.name}</span>
+            <span className="text-xs text-text-muted">{completionPercent}% complete</span>
+            <span className="text-xs text-text-muted tabular-nums">
+              {donePoints} / {totalPoints} pts
+            </span>
+          </div>
 
-        {sprint.start_date && sprint.end_date && (
-          <span className="text-xs text-text-muted">
-            {formatDateFull(sprint.start_date)} –{" "}
-            {formatDateFull(sprint.end_date)}
-          </span>
-        )}
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-muted">
+            {sprint.start_date && sprint.end_date && (
+              <span>
+                {formatDateFull(sprint.start_date)} - {formatDateFull(sprint.end_date)}
+              </span>
+            )}
+            <span>
+              {doneIssues} of {totalIssues} issue{totalIssues !== 1 ? "s" : ""} done
+            </span>
+          </div>
 
-        <span className="text-xs text-text-muted">
-          {completionPercent}% complete
-        </span>
+          {sprint.goal && (
+            <p className="mt-2 max-w-3xl text-sm text-text-secondary">
+              Goal: {sprint.goal}
+            </p>
+          )}
+        </div>
 
-        <span className="text-xs text-text-muted tabular-nums">
-          {donePoints} / {totalPoints} pts
-        </span>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button asChild size="sm" variant="secondary">
+            <Link
+              href={`/${workspaceSlug}/projects/${projectId}/sprint-planning?sprint=${sprint.id}`}
+            >
+              Sprint Planning
+            </Link>
+          </Button>
+          <Button asChild size="sm" variant="ghost">
+            <Link href={`/${workspaceSlug}/analytics?tab=sprints&sprint=${sprint.id}`}>
+              Analytics
+            </Link>
+          </Button>
+        </div>
       </div>
 
-      {/* Progress bar */}
-      <div className="mt-2 h-1 w-full max-w-xs rounded-full bg-border overflow-hidden">
+      <div className="mt-3 h-1.5 w-full max-w-xl overflow-hidden rounded-full bg-border">
         <div
           className="h-full rounded-full bg-success transition-all"
           style={{ width: `${completionPercent}%` }}
         />
       </div>
-
-      {sprint.goal && (
-        <p className="mt-1.5 text-xs text-text-muted truncate">
-          Goal: {sprint.goal}
-        </p>
-      )}
     </div>
   );
 }

--- a/src/components/sprints/sprint-planning-view.tsx
+++ b/src/components/sprints/sprint-planning-view.tsx
@@ -74,6 +74,24 @@ const QUICK_FILTER_CONFIG: {
   { key: "my-issues", label: "My Issues", activeClass: "border-text-muted text-text bg-surface-hover" },
 ];
 
+const SPRINT_STATUS_CONFIG = {
+  active: {
+    label: "Active",
+    badgeClassName: "text-success border-success/40 bg-success/5",
+    dotClassName: "bg-success",
+  },
+  planning: {
+    label: "Planning",
+    badgeClassName: "text-warning border-warning/40 bg-warning/5",
+    dotClassName: "bg-warning",
+  },
+  completed: {
+    label: "Completed",
+    badgeClassName: "text-text-secondary border-border bg-background",
+    dotClassName: "bg-text-muted",
+  },
+} as const;
+
 // --- Helpers ---
 
 function findContainer(
@@ -98,9 +116,15 @@ function formatDateRange(start: string | null, end: string | null): string {
 
 // --- Draggable Issue Row ---
 
-function DraggableIssueRow({ issue }: { issue: IssueWithDetails }) {
+function DraggableIssueRow({
+  issue,
+  disabled = false,
+}: {
+  issue: IssueWithDetails;
+  disabled?: boolean;
+}) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
-    useDraggable({ id: issue.id });
+    useDraggable({ id: issue.id, disabled });
 
   const style = transform
     ? { transform: `translate(${transform.x}px, ${transform.y}px)` }
@@ -112,10 +136,13 @@ function DraggableIssueRow({ issue }: { issue: IssueWithDetails }) {
       style={style}
       className={cn(
         "flex cursor-grab items-center gap-2.5 border-b border-border px-5 py-2.5 transition-colors hover:bg-surface-hover/60 active:cursor-grabbing",
+        disabled
+          ? "cursor-default"
+          : "cursor-grab hover:bg-surface-hover/60 active:cursor-grabbing",
         isDragging && "opacity-30",
       )}
-      {...attributes}
-      {...listeners}
+      {...(disabled ? {} : attributes)}
+      {...(disabled ? {} : listeners)}
     >
       <IssueRowContent issue={issue} />
     </div>
@@ -241,8 +268,12 @@ export function SprintPlanningView({
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const selectableSprints = useMemo(
-    () => sprints.filter((s) => s.status !== "completed"),
+  const sprintGroups = useMemo(
+    () => ({
+      active: sprints.filter((s) => s.status === "active"),
+      planning: sprints.filter((s) => s.status === "planning"),
+      completed: sprints.filter((s) => s.status === "completed"),
+    }),
     [sprints],
   );
 
@@ -343,6 +374,8 @@ export function SprintPlanningView({
   );
 
   const incompleteIssues = sprintIssues.length - doneIssues.length;
+  const dragDisabled = sprint?.status === "completed";
+  const sprintStatusConfig = sprint ? SPRINT_STATUS_CONFIG[sprint.status] : null;
 
   const teamLoad = useMemo((): TeamLoadEntry[] => {
     const map = new Map<string, number>();
@@ -584,12 +617,10 @@ export function SprintPlanningView({
                             <span
                               className={cn(
                                 "text-[10px] font-semibold px-1.5 py-0.5 rounded border",
-                                sprint.status === "active"
-                                  ? "text-success border-success/40 bg-success/5"
-                                  : "text-warning border-warning/40 bg-warning/5",
+                                sprintStatusConfig?.badgeClassName,
                               )}
                             >
-                              {sprint.status === "active" ? "Active" : "Planning"}
+                              {sprintStatusConfig?.label}
                             </span>
                             <span className="text-sm font-semibold text-text">
                               {sprint.name}
@@ -598,12 +629,10 @@ export function SprintPlanningView({
                           </button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="start" className="w-[260px]">
-                          {selectableSprints.some((s) => s.status === "active") && (
+                          {sprintGroups.active.length > 0 && (
                             <>
                               <DropdownMenuLabel>Active</DropdownMenuLabel>
-                              {selectableSprints
-                                .filter((s) => s.status === "active")
-                                .map((s) => (
+                              {sprintGroups.active.map((s) => (
                                   <DropdownMenuItem
                                     key={s.id}
                                     className={cn(
@@ -612,7 +641,12 @@ export function SprintPlanningView({
                                     )}
                                     onSelect={() => handleSprintChange(s.id)}
                                   >
-                                    <span className="w-2 h-2 rounded-full bg-success shrink-0" />
+                                    <span
+                                      className={cn(
+                                        "w-2 h-2 rounded-full shrink-0",
+                                        SPRINT_STATUS_CONFIG.active.dotClassName,
+                                      )}
+                                    />
                                     <span className="text-sm text-text flex-1">{s.name}</span>
                                     <span className="text-xs text-text-muted">
                                       {formatDateRange(s.start_date, s.end_date)}
@@ -624,12 +658,10 @@ export function SprintPlanningView({
                                 ))}
                             </>
                           )}
-                          {selectableSprints.some((s) => s.status === "planning") && (
+                          {sprintGroups.planning.length > 0 && (
                             <>
                               <DropdownMenuLabel>Planning</DropdownMenuLabel>
-                              {selectableSprints
-                                .filter((s) => s.status === "planning")
-                                .map((s) => (
+                              {sprintGroups.planning.map((s) => (
                                   <DropdownMenuItem
                                     key={s.id}
                                     className={cn(
@@ -638,7 +670,12 @@ export function SprintPlanningView({
                                     )}
                                     onSelect={() => handleSprintChange(s.id)}
                                   >
-                                    <span className="w-2 h-2 rounded-full bg-warning shrink-0" />
+                                    <span
+                                      className={cn(
+                                        "w-2 h-2 rounded-full shrink-0",
+                                        SPRINT_STATUS_CONFIG.planning.dotClassName,
+                                      )}
+                                    />
                                     <span className="text-sm text-text flex-1">{s.name}</span>
                                     <span className="text-xs text-text-muted">
                                       {formatDateRange(s.start_date, s.end_date)}
@@ -648,6 +685,35 @@ export function SprintPlanningView({
                                     )}
                                   </DropdownMenuItem>
                                 ))}
+                            </>
+                          )}
+                          {sprintGroups.completed.length > 0 && (
+                            <>
+                              <DropdownMenuLabel>Completed</DropdownMenuLabel>
+                              {sprintGroups.completed.map((s) => (
+                                <DropdownMenuItem
+                                  key={s.id}
+                                  className={cn(
+                                    "flex items-center gap-2 cursor-pointer",
+                                    s.id === sprint.id && "bg-surface-hover",
+                                  )}
+                                  onSelect={() => handleSprintChange(s.id)}
+                                >
+                                  <span
+                                    className={cn(
+                                      "w-2 h-2 rounded-full shrink-0",
+                                      SPRINT_STATUS_CONFIG.completed.dotClassName,
+                                    )}
+                                  />
+                                  <span className="text-sm text-text flex-1">{s.name}</span>
+                                  <span className="text-xs text-text-muted">
+                                    {formatDateRange(s.start_date, s.end_date)}
+                                  </span>
+                                  {s.id === sprint.id && (
+                                    <X className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                                  )}
+                                </DropdownMenuItem>
+                              ))}
                             </>
                           )}
                           <DropdownMenuSeparator />
@@ -713,7 +779,7 @@ export function SprintPlanningView({
 
                   {/* Sprint actions */}
                   <div className="flex items-center gap-2 mt-3">
-                    {sprint.status === "active" && (
+                    {sprint.status !== "planning" && (
                       <Button asChild size="sm" variant="ghost">
                         <Link href={`/${workspaceSlug}/analytics?tab=sprints&sprint=${sprint.id}`}>
                           Analytics
@@ -740,6 +806,12 @@ export function SprintPlanningView({
                     )}
                   </div>
 
+                  {dragDisabled && (
+                    <p className="mt-2 text-xs text-text-secondary">
+                      Completed sprint scope is read-only.
+                    </p>
+                  )}
+
                   {startingError && (
                     <p className="mt-2 text-xs text-danger">{startingError}</p>
                   )}
@@ -747,12 +819,18 @@ export function SprintPlanningView({
 
                 <div className="flex-1 overflow-y-auto">
                   {sprintIssues.map((issue) => (
-                    <DraggableIssueRow key={issue.id} issue={issue} />
+                    <DraggableIssueRow
+                      key={issue.id}
+                      issue={issue}
+                      disabled={dragDisabled}
+                    />
                   ))}
 
                   {/* Drop zone placeholder */}
                   <div className="mx-5 my-3 flex min-h-20 flex-1 items-center justify-center rounded-lg border-2 border-dashed border-border text-xs text-text-muted">
-                    Drag issues here from backlog
+                    {dragDisabled
+                      ? "Completed sprint. Scope is read-only."
+                      : "Drag issues here from backlog"}
                   </div>
                 </div>
 

--- a/src/components/sprints/sprint-planning-view.tsx
+++ b/src/components/sprints/sprint-planning-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef, useCallback, useEffect } from "react";
+import Link from "next/link";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import {
   DndContext,
@@ -19,7 +20,6 @@ import { Plus, Search, ChevronDown, X } from "lucide-react";
 import { format } from "date-fns";
 import { updateIssue } from "@/lib/actions/issues";
 import { startSprint } from "@/lib/actions/sprints";
-import { formatDateFull } from "@/lib/utils/dates";
 import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { cn } from "@/lib/utils/cn";
 import { getInitials } from "@/lib/utils/format";
@@ -44,6 +44,7 @@ import type { WorkspaceMember } from "@/lib/queries/members";
 // --- Types ---
 
 interface SprintPlanningViewProps {
+  workspaceSlug: string;
   projectId: string;
   workspaceId: string;
   sprint: Tables<"sprints"> | null;
@@ -203,6 +204,7 @@ function DroppablePane({
 // --- Main Component ---
 
 export function SprintPlanningView({
+  workspaceSlug,
   projectId,
   workspaceId,
   sprint,
@@ -278,7 +280,6 @@ export function SprintPlanningView({
 
     return () => window.cancelAnimationFrame(syncFrame);
   }, [initialBacklogIssues, initialSprintIssues]);
-
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 8 },
@@ -339,11 +340,6 @@ export function SprintPlanningView({
   const doneIssues = useMemo(
     () => sprintIssues.filter((i) => i.status === "done"),
     [sprintIssues],
-  );
-
-  const donePoints = useMemo(
-    () => doneIssues.reduce((sum, i) => sum + (i.story_points ?? 0), 0),
-    [doneIssues],
   );
 
   const incompleteIssues = sprintIssues.length - doneIssues.length;
@@ -482,8 +478,10 @@ export function SprintPlanningView({
     const result = await startSprint(sprint.id);
     if (result.error) {
       setStartingError(result.error);
+      return;
     }
-  }, [sprint]);
+    router.refresh();
+  }, [router, sprint]);
 
   // --- Render ---
 
@@ -715,6 +713,13 @@ export function SprintPlanningView({
 
                   {/* Sprint actions */}
                   <div className="flex items-center gap-2 mt-3">
+                    {sprint.status === "active" && (
+                      <Button asChild size="sm" variant="ghost">
+                        <Link href={`/${workspaceSlug}/analytics?tab=sprints&sprint=${sprint.id}`}>
+                          Analytics
+                        </Link>
+                      </Button>
+                    )}
                     {sprint.status === "planning" && (
                       <Button
                         size="sm"
@@ -822,6 +827,7 @@ export function SprintPlanningView({
           open={showCompleteModal}
           onOpenChange={setShowCompleteModal}
           sprint={sprint}
+          workspaceSlug={workspaceSlug}
           totalIssues={sprintIssues.length}
           doneIssues={doneIssues.length}
           incompleteIssues={incompleteIssues}

--- a/src/lib/actions/sprints.ts
+++ b/src/lib/actions/sprints.ts
@@ -198,14 +198,19 @@ export async function completeSprint(
     return { error: "Only active sprints can be completed" };
   }
 
-  // Count and move incomplete issues to backlog
-  const { data: incompleteIssues } = await supabase
+  // Capture the sprint scope before moving issues so completed sprint analytics can
+  // reconstruct the original sprint composition later.
+  const { data: sprintIssues, error: sprintIssuesError } = await supabase
     .from("issues")
-    .select("id")
-    .eq("sprint_id", sprintId)
-    .neq("status", "done");
+    .select("id, status")
+    .eq("sprint_id", sprintId);
 
-  const movedCount = incompleteIssues?.length ?? 0;
+  if (sprintIssuesError) {
+    return { error: sprintIssuesError.message };
+  }
+
+  const scopeIssueIds = (sprintIssues ?? []).map((issue) => issue.id);
+  const movedCount = (sprintIssues ?? []).filter((issue) => issue.status !== "done").length;
 
   if (movedCount > 0) {
     const { error: moveError } = await supabase
@@ -248,6 +253,7 @@ export async function completeSprint(
           name: data.name,
           project_id: data.project_id,
           moved_count: movedCount,
+          scope_issue_ids: scopeIssueIds,
         },
       });
 
@@ -314,4 +320,3 @@ export async function deleteSprint(
   revalidatePath("/", "layout");
   return { data: undefined };
 }
-

--- a/src/lib/queries/analytics.ts
+++ b/src/lib/queries/analytics.ts
@@ -13,6 +13,7 @@ import { differenceInDays, startOfWeek, format, addWeeks } from "date-fns";
 type SprintCompletionInfo = {
   movedCount: number;
   completedAt: string | null;
+  scopeIssueIds: string[] | null;
 };
 
 async function getSprintCompletionInfo(
@@ -33,10 +34,16 @@ async function getSprintCompletionInfo(
     (completionActivity?.metadata as Record<string, unknown> | null) ?? null;
   const movedCount =
     typeof metadata?.moved_count === "number" ? metadata.moved_count : 0;
+  const scopeIssueIds = Array.isArray(metadata?.scope_issue_ids)
+    ? metadata.scope_issue_ids.filter(
+        (value): value is string => typeof value === "string"
+      )
+    : null;
 
   return {
     movedCount,
     completedAt: completionActivity?.created_at ?? null,
+    scopeIssueIds,
   };
 }
 
@@ -65,13 +72,19 @@ export async function getSprintAnalytics(
 ): Promise<SprintKPIs> {
   const supabase = await createClient();
 
-  const [{ data: issues }, completionInfo] = await Promise.all([
-    supabase
-      .from("issues")
-      .select("id, status, story_points, created_at, completed_at")
-      .eq("sprint_id", sprintId),
-    getSprintCompletionInfo(supabase, sprintId),
-  ]);
+  const completionInfo = await getSprintCompletionInfo(supabase, sprintId);
+  const hasScopeIssueIds =
+    !!completionInfo.scopeIssueIds && completionInfo.scopeIssueIds.length > 0;
+  const issuesQuery = hasScopeIssueIds
+    ? supabase
+        .from("issues")
+        .select("id, status, story_points, created_at, completed_at")
+        .in("id", completionInfo.scopeIssueIds!)
+    : supabase
+        .from("issues")
+        .select("id, status, story_points, created_at, completed_at")
+        .eq("sprint_id", sprintId);
+  const { data: issues } = await issuesQuery;
 
   if ((!issues || issues.length === 0) && completionInfo.movedCount === 0) {
     return {
@@ -86,7 +99,9 @@ export async function getSprintAnalytics(
   const sprintIssues = issues ?? [];
   const doneIssues = sprintIssues.filter((i) => i.status === "done");
   const issuesCompleted = doneIssues.length;
-  const totalIssues = sprintIssues.length + completionInfo.movedCount;
+  const totalIssues = hasScopeIssueIds
+    ? completionInfo.scopeIssueIds!.length
+    : sprintIssues.length + completionInfo.movedCount;
   const avgCycleTime = computeCycleTime(sprintIssues);
   const velocity = doneIssues.reduce(
     (sum, i) => sum + (i.story_points ?? 0),
@@ -130,19 +145,24 @@ export async function getSprintBurndown(
 ): Promise<BurndownPoint[]> {
   const supabase = await createClient();
 
-  const [{ data: sprintIssues }, completionInfo] = await Promise.all([
-    supabase
+  const completionInfo = await getSprintCompletionInfo(supabase, sprintId);
+  const scopeIssueIds = completionInfo.scopeIssueIds ?? [];
+
+  let issueIds = scopeIssueIds;
+  let totalIssues = scopeIssueIds.length;
+
+  if (scopeIssueIds.length === 0) {
+    const { data: sprintIssues } = await supabase
       .from("issues")
       .select("id")
-      .eq("sprint_id", sprintId),
-    getSprintCompletionInfo(supabase, sprintId),
-  ]);
+      .eq("sprint_id", sprintId);
 
-  const issueRows = sprintIssues ?? [];
-  const totalIssues = issueRows.length + completionInfo.movedCount;
+    const issueRows = sprintIssues ?? [];
+    issueIds = issueRows.map((i) => i.id);
+    totalIssues = issueRows.length + completionInfo.movedCount;
+  }
+
   if (totalIssues === 0) return [];
-
-  const issueIds = issueRows.map((i) => i.id);
 
   if (issueIds.length === 0) {
     return computeBurndownSeries([], sprint, totalIssues);
@@ -180,17 +200,25 @@ export async function getSprintSnapshot(
 ): Promise<SprintSnapshot> {
   const supabase = await createClient();
 
-  const [{ data: issues }, { data: project }, completionInfo] = await Promise.all([
-    supabase
-      .from("issues")
-      .select("status")
-      .eq("sprint_id", sprint.id),
+  const completionInfo = await getSprintCompletionInfo(supabase, sprint.id);
+  const hasScopeIssueIds =
+    !!completionInfo.scopeIssueIds && completionInfo.scopeIssueIds.length > 0;
+
+  const [{ data: issues }, { data: project }] = await Promise.all([
+    hasScopeIssueIds
+      ? supabase
+          .from("issues")
+          .select("status")
+          .in("id", completionInfo.scopeIssueIds!)
+      : supabase
+          .from("issues")
+          .select("status")
+          .eq("sprint_id", sprint.id),
     supabase
       .from("projects")
       .select("id, name")
       .eq("id", sprint.project_id)
       .single(),
-    getSprintCompletionInfo(supabase, sprint.id),
   ]);
 
   const sprintIssues = issues ?? [];
@@ -208,7 +236,9 @@ export async function getSprintSnapshot(
     startDate: sprint.start_date,
     endDate: sprint.end_date,
     completedAt: completionInfo.completedAt,
-    scopeIssues: sprintIssues.length + completionInfo.movedCount,
+    scopeIssues: hasScopeIssueIds
+      ? completionInfo.scopeIssueIds!.length
+      : sprintIssues.length + completionInfo.movedCount,
     issuesCompleted,
     rolledOverIssues: completionInfo.movedCount,
   };
@@ -226,20 +256,30 @@ export async function getIssuesByLabel(
 ): Promise<LabelCount[]> {
   const supabase = await createClient();
 
-  // Get issues (optionally filtered by sprint)
-  let issueQuery = supabase
-    .from("issues")
-    .select("id")
-    .eq("workspace_id", workspaceId);
+  let issueIds: string[] = [];
 
   if (sprintId) {
-    issueQuery = issueQuery.eq("sprint_id", sprintId);
+    const completionInfo = await getSprintCompletionInfo(supabase, sprintId);
+
+    if (completionInfo.scopeIssueIds && completionInfo.scopeIssueIds.length > 0) {
+      issueIds = completionInfo.scopeIssueIds;
+    } else {
+      const { data: issues } = await supabase
+        .from("issues")
+        .select("id")
+        .eq("workspace_id", workspaceId)
+        .eq("sprint_id", sprintId);
+      issueIds = (issues ?? []).map((issue) => issue.id);
+    }
+  } else {
+    const { data: issues } = await supabase
+      .from("issues")
+      .select("id")
+      .eq("workspace_id", workspaceId);
+    issueIds = (issues ?? []).map((issue) => issue.id);
   }
 
-  const { data: issues } = await issueQuery;
-  if (!issues || issues.length === 0) return [];
-
-  const issueIds = issues.map((i) => i.id);
+  if (issueIds.length === 0) return [];
 
   // Get issue_labels joins
   const { data: issueLabels } = await supabase

--- a/src/lib/queries/analytics.ts
+++ b/src/lib/queries/analytics.ts
@@ -10,6 +10,36 @@ import {
 } from "@/lib/utils/analytics";
 import { differenceInDays, startOfWeek, format, addWeeks } from "date-fns";
 
+type SprintCompletionInfo = {
+  movedCount: number;
+  completedAt: string | null;
+};
+
+async function getSprintCompletionInfo(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  sprintId: string
+): Promise<SprintCompletionInfo> {
+  const { data: completionActivity } = await supabase
+    .from("activities")
+    .select("created_at, metadata")
+    .eq("entity_type", "sprint")
+    .eq("action", "completed")
+    .eq("entity_id", sprintId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const metadata =
+    (completionActivity?.metadata as Record<string, unknown> | null) ?? null;
+  const movedCount =
+    typeof metadata?.moved_count === "number" ? metadata.moved_count : 0;
+
+  return {
+    movedCount,
+    completedAt: completionActivity?.created_at ?? null,
+  };
+}
+
 export async function getWorkspaceSprints(
   workspaceId: string
 ): Promise<Tables<"sprints">[]> {
@@ -35,12 +65,15 @@ export async function getSprintAnalytics(
 ): Promise<SprintKPIs> {
   const supabase = await createClient();
 
-  const { data: issues } = await supabase
-    .from("issues")
-    .select("id, status, story_points, created_at, completed_at")
-    .eq("sprint_id", sprintId);
+  const [{ data: issues }, completionInfo] = await Promise.all([
+    supabase
+      .from("issues")
+      .select("id, status, story_points, created_at, completed_at")
+      .eq("sprint_id", sprintId),
+    getSprintCompletionInfo(supabase, sprintId),
+  ]);
 
-  if (!issues || issues.length === 0) {
+  if ((!issues || issues.length === 0) && completionInfo.movedCount === 0) {
     return {
       issuesCompleted: 0,
       totalIssues: 0,
@@ -50,10 +83,11 @@ export async function getSprintAnalytics(
     };
   }
 
-  const doneIssues = issues.filter((i) => i.status === "done");
+  const sprintIssues = issues ?? [];
+  const doneIssues = sprintIssues.filter((i) => i.status === "done");
   const issuesCompleted = doneIssues.length;
-  const totalIssues = issues.length;
-  const avgCycleTime = computeCycleTime(issues);
+  const totalIssues = sprintIssues.length + completionInfo.movedCount;
+  const avgCycleTime = computeCycleTime(sprintIssues);
   const velocity = doneIssues.reduce(
     (sum, i) => sum + (i.story_points ?? 0),
     0
@@ -96,23 +130,23 @@ export async function getSprintBurndown(
 ): Promise<BurndownPoint[]> {
   const supabase = await createClient();
 
-  // Get total issues in sprint
-  const { count: totalIssues } = await supabase
-    .from("issues")
-    .select("id", { count: "exact", head: true })
-    .eq("sprint_id", sprintId);
+  const [{ data: sprintIssues }, completionInfo] = await Promise.all([
+    supabase
+      .from("issues")
+      .select("id")
+      .eq("sprint_id", sprintId),
+    getSprintCompletionInfo(supabase, sprintId),
+  ]);
 
-  if (!totalIssues || totalIssues === 0) return [];
+  const issueRows = sprintIssues ?? [];
+  const totalIssues = issueRows.length + completionInfo.movedCount;
+  if (totalIssues === 0) return [];
 
-  // Get all status-change activities for issues in this sprint
-  const { data: sprintIssues } = await supabase
-    .from("issues")
-    .select("id")
-    .eq("sprint_id", sprintId);
+  const issueIds = issueRows.map((i) => i.id);
 
-  if (!sprintIssues || sprintIssues.length === 0) return [];
-
-  const issueIds = sprintIssues.map((i) => i.id);
+  if (issueIds.length === 0) {
+    return computeBurndownSeries([], sprint, totalIssues);
+  }
 
   const { data: activities } = await supabase
     .from("activities")
@@ -124,6 +158,60 @@ export async function getSprintBurndown(
     .order("created_at", { ascending: true });
 
   return computeBurndownSeries(activities ?? [], sprint, totalIssues);
+}
+
+export type SprintSnapshot = {
+  sprintId: string;
+  sprintName: string;
+  projectId: string;
+  projectName: string;
+  status: Tables<"sprints">["status"];
+  goal: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  completedAt: string | null;
+  scopeIssues: number;
+  issuesCompleted: number;
+  rolledOverIssues: number;
+};
+
+export async function getSprintSnapshot(
+  sprint: Tables<"sprints">
+): Promise<SprintSnapshot> {
+  const supabase = await createClient();
+
+  const [{ data: issues }, { data: project }, completionInfo] = await Promise.all([
+    supabase
+      .from("issues")
+      .select("status")
+      .eq("sprint_id", sprint.id),
+    supabase
+      .from("projects")
+      .select("id, name")
+      .eq("id", sprint.project_id)
+      .single(),
+    getSprintCompletionInfo(supabase, sprint.id),
+  ]);
+
+  const sprintIssues = issues ?? [];
+  const issuesCompleted = sprintIssues.filter(
+    (issue) => issue.status === "done"
+  ).length;
+
+  return {
+    sprintId: sprint.id,
+    sprintName: sprint.name,
+    projectId: sprint.project_id,
+    projectName: project?.name ?? "Project",
+    status: sprint.status,
+    goal: sprint.goal,
+    startDate: sprint.start_date,
+    endDate: sprint.end_date,
+    completedAt: completionInfo.completedAt,
+    scopeIssues: sprintIssues.length + completionInfo.movedCount,
+    issuesCompleted,
+    rolledOverIssues: completionInfo.movedCount,
+  };
 }
 
 export type LabelCount = {

--- a/src/lib/queries/sprints.ts
+++ b/src/lib/queries/sprints.ts
@@ -1,5 +1,14 @@
 import { createClient } from "@/lib/supabase/server";
+import type { Tables } from "@/lib/types";
 import { enrichIssues, type IssueWithDetails } from "./issues";
+
+export type ActiveSprintSummary = {
+  sprint: Tables<"sprints">;
+  totalIssues: number;
+  doneIssues: number;
+  totalPoints: number;
+  donePoints: number;
+};
 
 export async function getBacklogIssues(
   projectId: string,
@@ -40,4 +49,41 @@ export async function getSprintIssues(
   if (!issues || issues.length === 0) return [];
 
   return enrichIssues(issues, supabase);
+}
+
+export async function getProjectActiveSprintSummary(
+  projectId: string
+): Promise<ActiveSprintSummary | null> {
+  const supabase = await createClient();
+
+  const { data: sprint } = await supabase
+    .from("sprints")
+    .select("*")
+    .eq("project_id", projectId)
+    .eq("status", "active")
+    .single();
+
+  if (!sprint) return null;
+
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("status, story_points")
+    .eq("sprint_id", sprint.id);
+
+  const sprintIssues = issues ?? [];
+  const doneIssues = sprintIssues.filter((issue) => issue.status === "done");
+
+  return {
+    sprint,
+    totalIssues: sprintIssues.length,
+    doneIssues: doneIssues.length,
+    totalPoints: sprintIssues.reduce(
+      (sum, issue) => sum + (issue.story_points ?? 0),
+      0
+    ),
+    donePoints: doneIssues.reduce(
+      (sum, issue) => sum + (issue.story_points ?? 0),
+      0
+    ),
+  };
 }

--- a/src/lib/queries/sprints.ts
+++ b/src/lib/queries/sprints.ts
@@ -10,6 +10,29 @@ export type ActiveSprintSummary = {
   donePoints: number;
 };
 
+async function getCompletedSprintScopeIssueIds(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  sprintId: string
+): Promise<string[] | null> {
+  const { data: completionActivity } = await supabase
+    .from("activities")
+    .select("metadata")
+    .eq("entity_type", "sprint")
+    .eq("action", "completed")
+    .eq("entity_id", sprintId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const metadata =
+    (completionActivity?.metadata as Record<string, unknown> | null) ?? null;
+  const scopeIssueIds = metadata?.scope_issue_ids;
+
+  if (!Array.isArray(scopeIssueIds)) return null;
+
+  return scopeIssueIds.filter((value): value is string => typeof value === "string");
+}
+
 export async function getBacklogIssues(
   projectId: string,
   excludeSprintId?: string
@@ -40,11 +63,27 @@ export async function getSprintIssues(
 ): Promise<IssueWithDetails[]> {
   const supabase = await createClient();
 
-  const { data: issues } = await supabase
-    .from("issues")
-    .select("*")
-    .eq("sprint_id", sprintId)
-    .order("sort_order", { ascending: true });
+  const completedSprintScopeIssueIds = await getCompletedSprintScopeIssueIds(
+    supabase,
+    sprintId,
+  );
+
+  let issues: Tables<"issues">[] | null = null;
+
+  if (completedSprintScopeIssueIds && completedSprintScopeIssueIds.length > 0) {
+    const { data } = await supabase
+      .from("issues")
+      .select("*")
+      .in("id", completedSprintScopeIssueIds);
+    issues = (data ?? []).sort((a, b) => a.sort_order - b.sort_order);
+  } else {
+    const { data } = await supabase
+      .from("issues")
+      .select("*")
+      .eq("sprint_id", sprintId)
+      .order("sort_order", { ascending: true });
+    issues = data ?? [];
+  }
 
   if (!issues || issues.length === 0) return [];
 

--- a/tests/phase1-auth-flow.spec.ts
+++ b/tests/phase1-auth-flow.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../src/lib/types";
 
 /**
  * Phase 1 Verification #1 (from issue #3):
@@ -17,7 +18,7 @@ const TEST_FULL_NAME = "E2E Tester";
 const TEST_WORKSPACE_NAME = `Test Workspace ${Date.now()}`;
 const TEST_WORKSPACE_SLUG = `test-ws-${Date.now()}`;
 
-let adminClient: ReturnType<typeof createClient>;
+let adminClient: SupabaseClient<Database>;
 let testUserId: string | null = null;
 
 test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {

--- a/tests/sprint-integration.spec.ts
+++ b/tests/sprint-integration.spec.ts
@@ -1,7 +1,16 @@
 import { test, expect } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../src/lib/types";
 
 const WS = "/pw-workspace";
 const SPRINT_GOAL = "Ship dashboard redesign and fix critical auth issues";
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+let admin: SupabaseClient<Database>;
+let completedSprintId: string | null = null;
+let completedSprintName = "";
+let completedSprintProjectId: string | null = null;
 
 test("sprint planning is connected to dashboard, analytics, and project views", async ({
   page,
@@ -35,4 +44,127 @@ test("sprint planning is connected to dashboard, analytics, and project views", 
   await expect(page).toHaveURL(/\/projects\/.+\/board$/, { timeout: 10000 });
   await expect(page.getByText(`Goal: ${SPRINT_GOAL}`)).toBeVisible();
   await expect(page.locator("main").getByRole("link", { name: "Analytics" })).toBeVisible();
+});
+
+test.describe.serial("completed sprint review links", () => {
+  test.beforeAll(async () => {
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+      throw new Error("Missing Supabase env for sprint integration test");
+    }
+
+    admin = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+    const { data: workspace, error: workspaceError } = await admin
+      .from("workspaces")
+      .select("id")
+      .eq("slug", WS.slice(1))
+      .single();
+
+    if (workspaceError || !workspace) {
+      throw new Error(
+        `Failed to load sprint integration workspace: ${workspaceError?.message ?? "missing"}`
+      );
+    }
+
+    const { data: activeSprint, error: activeSprintError } = await admin
+      .from("sprints")
+      .select("project_id")
+      .eq("workspace_id", workspace.id)
+      .eq("status", "active")
+      .single();
+
+    if (activeSprintError || !activeSprint) {
+      throw new Error(
+        `Failed to load active sprint project: ${activeSprintError?.message ?? "missing"}`
+      );
+    }
+
+    completedSprintName = `Review Completed Sprint ${Date.now()}`;
+
+    const { data: sprint, error: sprintError } = await admin
+      .from("sprints")
+      .insert({
+        workspace_id: workspace.id,
+        project_id: activeSprint.project_id,
+        name: completedSprintName,
+        goal: "Validate completed sprint review links",
+        start_date: "2026-03-01",
+        end_date: "2026-03-14",
+        status: "completed",
+        capacity: 0,
+      })
+      .select("id, project_id")
+      .single();
+
+    if (sprintError || !sprint) {
+      throw new Error(
+        `Failed to create completed sprint: ${sprintError?.message ?? "missing"}`
+      );
+    }
+
+    const { data: users, error: usersError } = await admin.auth.admin.listUsers();
+    if (usersError) {
+      throw new Error(`Failed to load test user: ${usersError.message}`);
+    }
+
+    const actorId =
+      users.users.find((user) => user.email === "playwright@test.flow.dev")?.id ?? null;
+
+    if (!actorId) {
+      throw new Error("Missing playwright@test.flow.dev for sprint integration test");
+    }
+
+    const { error: activityError } = await admin.from("activities").insert({
+      workspace_id: workspace.id,
+      actor_id: actorId,
+      action: "completed",
+      entity_type: "sprint",
+      entity_id: sprint.id,
+      metadata: {
+        name: completedSprintName,
+        project_id: sprint.project_id,
+        moved_count: 0,
+        scope_issue_ids: [],
+      },
+    });
+
+    if (activityError) {
+      throw new Error(
+        `Failed to create sprint completion activity: ${activityError.message}`
+      );
+    }
+
+    completedSprintId = sprint.id;
+    completedSprintProjectId = sprint.project_id;
+  });
+
+  test.afterAll(async () => {
+    if (!completedSprintId) return;
+
+    await admin
+      .from("activities")
+      .delete()
+      .eq("entity_type", "sprint")
+      .eq("action", "completed")
+      .eq("entity_id", completedSprintId);
+
+    await admin.from("sprints").delete().eq("id", completedSprintId);
+  });
+
+  test("analytics review links back to the same completed sprint in read-only mode", async ({
+    page,
+  }) => {
+    test.skip(!completedSprintId || !completedSprintProjectId, "Completed sprint setup failed");
+
+    await page.goto(`${WS}/analytics?tab=sprints&sprint=${completedSprintId}`);
+
+    await expect(page.getByRole("heading", { name: completedSprintName })).toBeVisible();
+    await page.getByRole("link", { name: "Sprint Planning" }).click();
+
+    await expect(page).toHaveURL(
+      `${WS}/projects/${completedSprintProjectId}/sprint-planning?sprint=${completedSprintId}`
+    );
+    await expect(page.getByText(completedSprintName)).toBeVisible();
+    await expect(page.getByText("Completed sprint scope is read-only.")).toBeVisible();
+  });
 });

--- a/tests/sprint-integration.spec.ts
+++ b/tests/sprint-integration.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+const WS = "/pw-workspace";
+const SPRINT_GOAL = "Ship dashboard redesign and fix critical auth issues";
+
+test("sprint planning is connected to dashboard, analytics, and project views", async ({
+  page,
+}) => {
+  await page.goto(`${WS}/dashboard`);
+
+  await expect(page.getByText("Sprint 24")).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText(SPRINT_GOAL)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Sprint Planning" })).toBeVisible();
+
+  await page.getByRole("link", { name: "Sprint Planning" }).click();
+  await expect(page).toHaveURL(/\/projects\/.+\/sprint-planning\?sprint=/, {
+    timeout: 10000,
+  });
+
+  await expect(page.getByRole("button", { name: "Complete Sprint" })).toBeVisible();
+  await expect(page.locator("main").getByRole("link", { name: "Analytics" })).toBeVisible();
+
+  await page.locator("main").getByRole("link", { name: "Analytics" }).click();
+  await expect(page).toHaveURL(/\/pw-workspace\/analytics\?tab=sprints&sprint=/, {
+    timeout: 10000,
+  });
+
+  await expect(page.getByText("Sprint Context")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sprint 24" })).toBeVisible();
+  await expect(page.getByText(SPRINT_GOAL)).toBeVisible();
+  await expect(page.getByText(/in scope, .* completed/)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Project Board" })).toBeVisible();
+
+  await page.locator("main").getByRole("link", { name: "Project Board" }).click();
+  await expect(page).toHaveURL(/\/projects\/.+\/board$/, { timeout: 10000 });
+  await expect(page.getByText(`Goal: ${SPRINT_GOAL}`)).toBeVisible();
+  await expect(page.locator("main").getByRole("link", { name: "Analytics" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- connect active sprint context across dashboard, board, list, timeline, and sprint planning
- route sprint completion into analytics review and add a sprint snapshot card with links back to planning and board
- preserve completed sprint scope in analytics using sprint completion activity metadata and cover the flow with Playwright

## Testing
- npx eslint src/app/'(app)'/[workspaceSlug]/analytics/page.tsx src/app/'(app)'/[workspaceSlug]/dashboard/page.tsx src/app/'(app)'/[workspaceSlug]/projects/[projectId]/board/page.tsx src/app/'(app)'/[workspaceSlug]/projects/[projectId]/list/page.tsx src/app/'(app)'/[workspaceSlug]/projects/[projectId]/timeline/page.tsx src/app/'(app)'/[workspaceSlug]/projects/[projectId]/sprint-planning/page.tsx src/components/analytics/sprint-snapshot-card.tsx src/components/dashboard/sprint-strip.tsx src/components/sprints/complete-sprint-modal.tsx src/components/sprints/sprint-header.tsx src/components/sprints/sprint-planning-view.tsx src/lib/queries/analytics.ts src/lib/queries/sprints.ts
- npx eslint tests/sprint-integration.spec.ts
- npx playwright test tests/sprint-integration.spec.ts --project=authenticated