### PR TITLE
Polish mobile workflows across the app

### DIFF
--- a/src/app/(app)/[workspaceSlug]/analytics/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/analytics/page.tsx
@@ -73,12 +73,12 @@ export default async function AnalyticsPage({
       ]);
 
     return (
-      <div className="flex flex-col py-6 px-10 gap-6">
+      <div className="flex flex-col gap-6 px-4 py-6 md:px-10">
         <Breadcrumb
           workspaceName={result.workspace.name}
           pageName="Analytics"
         />
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-[26px] font-bold text-text">Analytics</h1>
           <TimeRangeSelector activeRange={range} />
         </div>
@@ -92,7 +92,7 @@ export default async function AnalyticsPage({
 
         <ThroughputChart data={throughputData} />
 
-        <div className="flex gap-4">
+        <div className="grid gap-4 xl:grid-cols-2">
           <CycleTimeChart data={cycleTimeData} />
           <AssigneeChart data={assigneeData} />
         </div>
@@ -116,7 +116,7 @@ export default async function AnalyticsPage({
   if (!selectedSprint) {
     // Shouldn't happen since hasSprints is true, but handle gracefully
     return (
-      <div className="flex flex-col py-6 px-10 gap-6">
+      <div className="flex flex-col gap-6 px-4 py-6 md:px-10">
         <Breadcrumb
           workspaceName={result.workspace.name}
           pageName="Analytics"
@@ -138,9 +138,9 @@ export default async function AnalyticsPage({
     ]);
 
   return (
-    <div className="flex flex-col py-6 px-10 gap-6">
+    <div className="flex flex-col gap-6 px-4 py-6 md:px-10">
       <Breadcrumb workspaceName={result.workspace.name} pageName="Analytics" />
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-[26px] font-bold text-text">Analytics</h1>
         <SprintSelector
           sprints={sprints}
@@ -159,7 +159,7 @@ export default async function AnalyticsPage({
 
       <BurndownChart data={burndownData} />
 
-      <div className="flex gap-4">
+      <div className="grid gap-4 xl:grid-cols-2">
         <LabelChart data={labelData} />
         <VelocityChart data={velocityData} />
       </div>

--- a/src/app/(app)/[workspaceSlug]/my-issues/my-issues-client.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/my-issues-client.tsx
@@ -24,7 +24,11 @@ export function MyIssuesClient({
 
   return (
     <>
-      <Button size="sm" onClick={() => setShowCreateModal(true)}>
+      <Button
+        size="sm"
+        onClick={() => setShowCreateModal(true)}
+        className="w-full sm:w-auto"
+      >
         <Plus className="w-4 h-4 mr-1" />
         New Issue
       </Button>

--- a/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, Suspense } from "react";
+import { useState, useMemo, useCallback, Suspense, useSyncExternalStore } from "react";
 import { ChevronDown } from "lucide-react";
 import { IssueList } from "@/components/issues/issue-list";
 import { BoardView } from "@/components/board/board-view";
@@ -34,6 +34,7 @@ const SORT_OPTIONS: { key: SortKey; label: string }[] = [
 
 const VIEW_STORAGE_KEY = "flow-my-issues-view";
 const SORT_STORAGE_KEY = "flow-my-issues-sort";
+const STORAGE_EVENT = "flow-my-issues-preferences";
 
 interface MyIssuesContentProps {
   issues: IssueWithDetails[];
@@ -42,32 +43,44 @@ interface MyIssuesContentProps {
   projects?: { id: string; name: string; color: string }[];
 }
 
+function subscribePreferences(onStoreChange: () => void) {
+  window.addEventListener("storage", onStoreChange);
+  window.addEventListener(STORAGE_EVENT, onStoreChange);
+
+  return () => {
+    window.removeEventListener("storage", onStoreChange);
+    window.removeEventListener(STORAGE_EVENT, onStoreChange);
+  };
+}
+
+function getStoredViewMode(): ViewMode {
+  const storedView = window.localStorage.getItem(VIEW_STORAGE_KEY);
+  return storedView === "list" || storedView === "board" ? storedView : "list";
+}
+
+function getStoredSortKey(): SortKey {
+  const storedSort = window.localStorage.getItem(SORT_STORAGE_KEY);
+  return storedSort && SORT_OPTIONS.some((option) => option.key === storedSort)
+    ? (storedSort as SortKey)
+    : "priority";
+}
+
 function MyIssuesContentInner({
   issues,
   members = [],
   labels = [],
   projects = [],
 }: MyIssuesContentProps) {
-  const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    if (typeof window === "undefined") {
-      return "list";
-    }
-
-    const storedView = window.localStorage.getItem(VIEW_STORAGE_KEY);
-    return storedView === "board" ? "board" : "list";
-  });
-  const [sortKey, setSortKey] = useState<SortKey>(() => {
-    if (typeof window === "undefined") {
-      return "priority";
-    }
-
-    const storedSort = window.localStorage.getItem(SORT_STORAGE_KEY);
-    if (storedSort && SORT_OPTIONS.some((option) => option.key === storedSort)) {
-      return storedSort as SortKey;
-    }
-
-    return "priority";
-  });
+  const viewMode = useSyncExternalStore(
+    subscribePreferences,
+    getStoredViewMode,
+    () => "list",
+  );
+  const sortKey = useSyncExternalStore(
+    subscribePreferences,
+    getStoredSortKey,
+    () => "priority",
+  );
   const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
@@ -98,13 +111,13 @@ function MyIssuesContentInner({
   });
 
   function handleViewChange(mode: ViewMode) {
-    setViewMode(mode);
-    localStorage.setItem(VIEW_STORAGE_KEY, mode);
+    window.localStorage.setItem(VIEW_STORAGE_KEY, mode);
+    window.dispatchEvent(new Event(STORAGE_EVENT));
   }
 
   function handleSortChange(key: string) {
-    setSortKey(key as SortKey);
-    localStorage.setItem(SORT_STORAGE_KEY, key);
+    window.localStorage.setItem(SORT_STORAGE_KEY, key);
+    window.dispatchEvent(new Event(STORAGE_EVENT));
   }
 
   const handleIssueClick = useCallback(
@@ -171,13 +184,13 @@ function MyIssuesContentInner({
       />
 
       {/* Controls row */}
-      <div className="flex items-center gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         {/* View toggle */}
-        <div className="flex items-center gap-0.5 overflow-hidden rounded-lg bg-surface-inset p-0.5">
+        <div className="flex w-full items-center gap-0.5 overflow-hidden rounded-lg bg-surface-inset p-0.5 sm:w-auto">
           <button
             onClick={() => handleViewChange("list")}
             className={cn(
-              "px-3.5 py-1.5 text-sm font-medium rounded-md transition-colors",
+              "flex-1 px-3.5 py-1.5 text-sm font-medium rounded-md transition-colors sm:flex-none",
               viewMode === "list"
                 ? "bg-surface text-text"
                 : "text-text-secondary hover:text-text"
@@ -188,7 +201,7 @@ function MyIssuesContentInner({
           <button
             onClick={() => handleViewChange("board")}
             className={cn(
-              "px-3.5 py-1.5 text-sm font-medium rounded-md transition-colors",
+              "flex-1 px-3.5 py-1.5 text-sm font-medium rounded-md transition-colors sm:flex-none",
               viewMode === "board"
                 ? "bg-surface text-text"
                 : "text-text-secondary hover:text-text"
@@ -201,7 +214,7 @@ function MyIssuesContentInner({
         {/* Sort dropdown */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <button className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary border border-border rounded-lg hover:bg-surface-hover transition-colors">
+            <button className="flex w-full items-center justify-between gap-1.5 rounded-lg border border-border px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-hover sm:w-auto sm:justify-start sm:py-1.5">
               <span>Sort: {activeSortLabel}</span>
               <ChevronDown className="w-3.5 h-3.5" />
             </button>

--- a/src/app/(app)/[workspaceSlug]/my-issues/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/page.tsx
@@ -6,7 +6,6 @@ import { getWorkspaceMembers } from "@/lib/queries/members";
 import { getWorkspaceProjects } from "@/lib/queries/workspaces";
 import { getWorkspaceSprints } from "@/lib/queries/analytics";
 import { getWorkspaceLabels } from "@/lib/queries/projects";
-import { IssueList } from "@/components/issues/issue-list";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { MyIssuesClient } from "./my-issues-client";
 import { MyIssuesContent } from "./my-issues-content";
@@ -56,9 +55,9 @@ export default async function MyIssuesPage({
       <Breadcrumb workspaceName={result.workspace.name} pageName="My Issues" />
 
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl font-bold text-text">My Issues</h1>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 sm:justify-end">
           <MyIssuesClient
             projects={projects}
             members={members}

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/layout.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/layout.tsx
@@ -15,7 +15,7 @@ export default async function ProjectLayout({
 
   return (
     <div className="flex flex-col h-[calc(100vh-64px)]">
-      <div className="border-b border-border px-6 shrink-0">
+      <div className="shrink-0 border-b border-border px-4 md:px-6">
         <div className="flex items-center gap-2 pt-3 pb-1">
           <span
             className="size-2.5 rounded-sm"

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/project-tab-nav.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/project-tab-nav.tsx
@@ -38,7 +38,10 @@ export function ProjectTabNav({ workspaceSlug, projectId }: ProjectTabNavProps) 
   useHotkeys(hotkeys);
 
   return (
-    <nav className="flex items-center gap-4" aria-label="Project views">
+    <nav
+      className="-mx-4 flex items-center gap-4 overflow-x-auto px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:mx-0 sm:px-0"
+      aria-label="Project views"
+    >
       {projectTabs.map((tab) => {
         const href = `${base}/${tab.href}`;
         const active = pathname.startsWith(href);
@@ -47,7 +50,7 @@ export function ProjectTabNav({ workspaceSlug, projectId }: ProjectTabNavProps) 
             key={tab.href}
             href={href}
             className={cn(
-              "group pb-2.5 pt-3 text-sm font-medium border-b-2 -mb-px transition-colors",
+              "group -mb-px shrink-0 whitespace-nowrap border-b-2 pb-2.5 pt-3 text-sm font-medium transition-colors",
               active
                 ? "text-text border-primary"
                 : "text-text-secondary border-transparent hover:text-text",
@@ -55,7 +58,7 @@ export function ProjectTabNav({ workspaceSlug, projectId }: ProjectTabNavProps) 
           >
             {tab.label}
             {tab.key && (
-              <span aria-hidden="true" className="ml-1.5 text-[10px] text-text-muted opacity-0 group-hover:opacity-50">
+              <span aria-hidden="true" className="ml-1.5 hidden text-[10px] text-text-muted opacity-0 transition-opacity group-hover:opacity-50 md:inline">
                 {tab.key}
               </span>
             )}

--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -28,7 +28,7 @@ export function SprintSelector({
     <select
       value={selectedSprintId ?? ""}
       onChange={handleChange}
-      className="cursor-pointer rounded-lg border border-border-input bg-surface px-4 py-2 text-[13px] font-medium text-text transition-colors hover:border-border"
+      className="w-full max-w-full cursor-pointer rounded-lg border border-border-input bg-surface px-4 py-2 text-[13px] font-medium text-text transition-colors hover:border-border sm:w-auto"
     >
       {sprints.map((sprint) => (
         <option key={sprint.id} value={sprint.id}>

--- a/src/components/analytics/kpi-card.tsx
+++ b/src/components/analytics/kpi-card.tsx
@@ -6,10 +6,10 @@ export type KPICardProps = {
 
 export function KPICard({ label, value, delta }: KPICardProps) {
   return (
-    <div className="flex flex-col grow shrink basis-0 gap-1.5 rounded-xl border border-border-input bg-surface p-5">
+    <div className="flex min-w-0 grow shrink basis-0 flex-col gap-1.5 rounded-xl border border-border-input bg-surface p-4 sm:p-5">
       <span className="text-xs font-medium text-text-muted">{label}</span>
-      <div className="flex items-baseline gap-2">
-        <span className="text-[32px] font-bold leading-10 text-text">
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="text-[28px] font-bold leading-9 text-text sm:text-[32px] sm:leading-10">
           {value}
         </span>
         {delta && (

--- a/src/components/analytics/kpi-cards.tsx
+++ b/src/components/analytics/kpi-cards.tsx
@@ -10,7 +10,7 @@ export function KPICards({
   previous: SprintKPIs | null;
 }) {
   return (
-    <div className="flex gap-4">
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <KPICard
         label="Issues Completed"
         value={String(current.issuesCompleted)}

--- a/src/components/analytics/overview-kpi-cards.tsx
+++ b/src/components/analytics/overview-kpi-cards.tsx
@@ -10,7 +10,7 @@ export function OverviewKPICards({
   previous: OverviewKPIs | null;
 }) {
   return (
-    <div className="flex gap-4">
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <KPICard
         label="Issues Completed"
         value={String(current.issuesCompleted)}

--- a/src/components/analytics/time-range-selector.tsx
+++ b/src/components/analytics/time-range-selector.tsx
@@ -18,14 +18,14 @@ export function TimeRangeSelector({ activeRange }: { activeRange: TimeRange }) {
   }
 
   return (
-    <div className="inline-flex items-center gap-0.5 rounded-lg bg-surface-inset p-1">
+    <div className="inline-flex w-full items-center justify-between gap-0.5 rounded-lg bg-surface-inset p-1 sm:w-auto sm:justify-start">
       {ranges.map((range) => {
         const isActive = activeRange === range;
         return (
           <button
             key={range}
             onClick={() => handleChange(range)}
-            className={`rounded-md px-3 py-1 text-[13px] font-medium transition-colors ${
+            className={`flex-1 rounded-md px-3 py-1 text-[13px] font-medium transition-colors sm:flex-none ${
               isActive
                 ? "bg-surface text-text shadow-sm"
                 : "text-text-muted hover:text-text"

--- a/src/components/board/board-column.tsx
+++ b/src/components/board/board-column.tsx
@@ -45,7 +45,7 @@ export function BoardColumn({
 
   return (
     <div
-      className="flex flex-col min-w-[280px] w-[280px] shrink-0"
+      className="flex w-full min-w-0 shrink-0 flex-col rounded-xl border border-border bg-surface p-2 md:min-w-[280px] md:w-[280px] md:rounded-none md:border-none md:bg-transparent md:p-0"
       role="region"
       aria-label={`${config.label} column, ${issues.length} ${issues.length === 1 ? "issue" : "issues"}`}
     >
@@ -81,7 +81,7 @@ export function BoardColumn({
       >
         <div
           ref={setNodeRef}
-          className="flex flex-col gap-2 px-1 pb-4 flex-1 min-h-[120px] overflow-y-auto"
+          className="flex flex-1 flex-col gap-2 overflow-visible px-1 pb-2 md:min-h-[120px] md:overflow-y-auto md:pb-4"
         >
           {issues.map((issue) => (
             <BoardCard

--- a/src/components/board/board-view.tsx
+++ b/src/components/board/board-view.tsx
@@ -264,7 +264,7 @@ export function BoardView({
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div className="flex gap-4 p-6 h-full overflow-x-auto">
+      <div className="flex h-full flex-col gap-4 overflow-y-auto p-4 md:flex-row md:overflow-x-auto md:overflow-y-hidden md:p-6">
         {STATUS_ORDER.map((status) => (
           <BoardColumn
             key={status}

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -4,7 +4,11 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { Command } from "cmdk";
 import { PlusCircle, Search, Settings2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { searchIssuesClient, getRecentIssuesClient, type SearchResult } from "@/lib/queries/search";
+import {
+  searchIssuesClient,
+  getRecentIssuesClient,
+  type SearchResult,
+} from "@/lib/queries/search";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -18,8 +22,8 @@ interface CommandPaletteProps {
 
 function KBD({ children }: { children: React.ReactNode }) {
   return (
-    <span className="flex items-center justify-center rounded-sm border border-border-input bg-surface-inset py-0.5 px-1.5">
-      <span className="font-mono text-[10px] leading-[14px] font-medium text-text-muted">
+    <span className="flex items-center justify-center rounded-sm border border-border-input bg-surface-inset px-1.5 py-0.5">
+      <span className="font-mono text-[10px] font-medium leading-[14px] text-text-muted">
         {children}
       </span>
     </span>
@@ -41,7 +45,6 @@ export function CommandPalette({
   const [recentItems, setRecentItems] = useState<SearchResult[]>([]);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // Load recent items on open
   useEffect(() => {
     if (!open) return;
 
@@ -64,7 +67,6 @@ export function CommandPalette({
     };
   }, [open, workspaceId, userId]);
 
-  // Debounced search
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
@@ -102,24 +104,32 @@ export function CommandPalette({
   const displayItems = query.trim() ? results : recentItems;
   const sectionLabel = query.trim() ? "RESULTS" : "RECENT";
 
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        setQuery("");
+        setResults([]);
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange],
+  );
+
   return (
     <Command.Dialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       label="Command palette"
       className="fixed inset-0 z-50"
       shouldFilter={false}
     >
-      {/* Overlay */}
       <div
         className="fixed inset-0 bg-overlay backdrop-blur-sm"
-        onClick={() => onOpenChange(false)}
+        onClick={() => handleOpenChange(false)}
       />
 
-      {/* Palette card */}
-      <div className="fixed left-1/2 top-[180px] flex w-[640px] -translate-x-1/2 flex-col overflow-hidden rounded-[14px] border border-border-input bg-surface shadow-2xl">
-        {/* Search input */}
-        <div className="flex items-center gap-3.5 border-b border-border-subtle py-4 px-5">
+      <div className="fixed left-1/2 top-4 flex max-h-[calc(100vh-2rem)] w-[min(640px,calc(100vw-1rem))] -translate-x-1/2 flex-col overflow-hidden rounded-[18px] border border-border-input bg-surface shadow-2xl sm:top-[180px] sm:max-h-[unset] sm:rounded-[14px]">
+        <div className="flex items-center gap-3 border-b border-border-subtle px-4 py-3.5 sm:gap-3.5 sm:px-5 sm:py-4">
           <Search className="h-[18px] w-[18px] shrink-0 text-text-muted opacity-60" />
           <Command.Input
             value={query}
@@ -129,13 +139,11 @@ export function CommandPalette({
           />
         </div>
 
-        {/* Results */}
-        <Command.List className="flex max-h-[360px] flex-col overflow-y-auto p-2">
-          {/* Issues section */}
+        <Command.List className="flex max-h-[min(360px,calc(100vh-10.5rem))] flex-col overflow-y-auto p-2 sm:max-h-[360px]">
           {displayItems.length > 0 && (
             <Command.Group
               heading={
-                <span className="block px-3 pt-2 pb-1.5 font-mono text-[10px] leading-3 tracking-[0.08em] text-text-muted opacity-60">
+                <span className="block px-3 pb-1.5 pt-2 font-mono text-[10px] leading-3 tracking-[0.08em] text-text-muted opacity-60">
                   {sectionLabel}
                 </span>
               }
@@ -145,41 +153,41 @@ export function CommandPalette({
                   key={item.id}
                   value={`issue-${item.id}`}
                   onSelect={() => navigateToIssue(item)}
-                  className="flex cursor-pointer items-center justify-between rounded-lg py-2.5 px-3 data-[selected=true]:bg-surface-hover"
+                  className="cursor-pointer rounded-lg px-3 py-2.5 data-[selected=true]:bg-surface-hover"
                 >
-                  <div className="flex items-center gap-3">
-                    <span className="font-mono text-[11px] leading-[14px] text-text-muted opacity-60">
-                      {item.issue_key}
-                    </span>
-                    <span className="text-[13px] leading-4 font-medium text-text">
-                      {item.title}
-                    </span>
-                  </div>
-                  {item.project && (
-                    <div className="flex items-center gap-1.5">
-                      <span
-                        className="rounded-full size-1.5 shrink-0"
-                        style={{ backgroundColor: item.project.color }}
-                      />
-                      <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">
-                        {item.project.name}
+                  <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <span className="shrink-0 font-mono text-[11px] leading-[14px] text-text-muted opacity-60">
+                        {item.issue_key}
+                      </span>
+                      <span className="truncate text-[13px] font-medium leading-4 text-text">
+                        {item.title}
                       </span>
                     </div>
-                  )}
+                    {item.project && (
+                      <div className="flex items-center gap-1.5 pl-6 sm:pl-0">
+                        <span
+                          className="size-1.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: item.project.color }}
+                        />
+                        <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">
+                          {item.project.name}
+                        </span>
+                      </div>
+                    )}
+                  </div>
                 </Command.Item>
               ))}
             </Command.Group>
           )}
 
-          {/* Divider */}
           {!query.trim() && (
             <>
               <div className="my-0.5 h-px w-full bg-border-subtle" />
 
-              {/* Actions section */}
               <Command.Group
                 heading={
-                  <span className="block px-3 pt-2.5 pb-1.5 font-mono text-[10px] leading-3 tracking-[0.08em] text-text-muted opacity-60">
+                  <span className="block px-3 pb-1.5 pt-2.5 font-mono text-[10px] leading-3 tracking-[0.08em] text-text-muted opacity-60">
                     ACTIONS
                   </span>
                 }
@@ -190,17 +198,19 @@ export function CommandPalette({
                     onOpenChange(false);
                     onCreateIssue?.();
                   }}
-                  className="flex cursor-pointer items-center justify-between rounded-lg py-2.5 px-3 data-[selected=true]:bg-surface-hover"
+                  className="cursor-pointer rounded-lg px-3 py-2.5 data-[selected=true]:bg-surface-hover"
                 >
-                  <div className="flex items-center gap-2.5">
-                    <PlusCircle className="h-4 w-4 text-text-muted opacity-60" />
-                    <span className="text-[13px] leading-4 font-medium text-text">
-                      Create new issue
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <KBD>⌘</KBD>
-                    <KBD>N</KBD>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-center gap-2.5">
+                      <PlusCircle className="h-4 w-4 text-text-muted opacity-60" />
+                      <span className="text-[13px] font-medium leading-4 text-text">
+                        Create new issue
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 pl-6 sm:pl-0">
+                      <KBD>⌘</KBD>
+                      <KBD>N</KBD>
+                    </div>
                   </div>
                 </Command.Item>
 
@@ -210,34 +220,35 @@ export function CommandPalette({
                     router.push(`/${workspaceSlug}/settings/general`);
                     onOpenChange(false);
                   }}
-                  className="flex cursor-pointer items-center justify-between rounded-lg py-2.5 px-3 data-[selected=true]:bg-surface-hover"
+                  className="cursor-pointer rounded-lg px-3 py-2.5 data-[selected=true]:bg-surface-hover"
                 >
-                  <div className="flex items-center gap-2.5">
-                    <Settings2 className="h-4 w-4 text-text-muted opacity-60" />
-                    <span className="text-[13px] leading-4 font-medium text-text">
-                      Go to settings
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <KBD>⌘</KBD>
-                    <KBD>,</KBD>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-center gap-2.5">
+                      <Settings2 className="h-4 w-4 text-text-muted opacity-60" />
+                      <span className="text-[13px] font-medium leading-4 text-text">
+                        Go to settings
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 pl-6 sm:pl-0">
+                      <KBD>⌘</KBD>
+                      <KBD>,</KBD>
+                    </div>
                   </div>
                 </Command.Item>
 
-                {/* Project switching */}
                 {projects.map((project) => (
                   <Command.Item
                     key={project.id}
                     value={`project-${project.name}`}
                     onSelect={() => navigateToProject(project.id)}
-                    className="flex cursor-pointer items-center justify-between rounded-lg py-2.5 px-3 data-[selected=true]:bg-surface-hover"
+                    className="cursor-pointer rounded-lg px-3 py-2.5 data-[selected=true]:bg-surface-hover"
                   >
                     <div className="flex items-center gap-2.5">
                       <span
-                        className="rounded-full size-2 shrink-0"
+                        className="size-2 shrink-0 rounded-full"
                         style={{ backgroundColor: project.color }}
                       />
-                      <span className="text-[13px] leading-4 font-medium text-text">
+                      <span className="text-[13px] font-medium leading-4 text-text">
                         {project.name}
                       </span>
                     </div>
@@ -247,7 +258,6 @@ export function CommandPalette({
             </>
           )}
 
-          {/* Empty state */}
           {query.trim() && results.length === 0 && (
             <Command.Empty className="py-6 text-center text-[13px] text-text-muted">
               No results found.
@@ -255,23 +265,22 @@ export function CommandPalette({
           )}
         </Command.List>
 
-        {/* Footer */}
-        <div className="flex items-center gap-3 border-t border-border-subtle py-2.5 px-5">
+        <div className="flex flex-wrap items-center gap-3 border-t border-border-subtle px-4 py-2.5 sm:px-5">
           <div className="flex items-center gap-1">
-            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset py-px px-1">
-              <span className="font-mono text-[9px] leading-[14px] font-medium text-text-muted">↑↓</span>
+            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset px-1 py-px">
+              <span className="font-mono text-[9px] font-medium leading-[14px] text-text-muted">↑↓</span>
             </span>
             <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">Navigate</span>
           </div>
           <div className="flex items-center gap-1">
-            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset py-px px-1">
-              <span className="font-mono text-[9px] leading-[14px] font-medium text-text-muted">↵</span>
+            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset px-1 py-px">
+              <span className="font-mono text-[9px] font-medium leading-[14px] text-text-muted">↵</span>
             </span>
             <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">Open</span>
           </div>
           <div className="flex items-center gap-1">
-            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset py-px px-1">
-              <span className="font-mono text-[9px] leading-[14px] font-medium text-text-muted">esc</span>
+            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset px-1 py-px">
+              <span className="font-mono text-[9px] font-medium leading-[14px] text-text-muted">esc</span>
             </span>
             <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">Close</span>
           </div>

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -48,15 +48,15 @@ export function DashboardContent({
 
   return (
     <>
-      <div className="flex flex-1 gap-6 px-4 md:px-10 pt-6 pb-8">
-        <div className="flex flex-col" style={{ flexGrow: 1.6, flexBasis: 0 }}>
+      <div className="flex flex-1 flex-col gap-6 px-4 pt-6 pb-8 md:px-10 lg:flex-row">
+        <div className="flex flex-col lg:min-w-0" style={{ flexGrow: 1.6, flexBasis: 0 }}>
           <MyFocusCard
             issues={issues}
             workspaceSlug={workspaceSlug}
             onIssueClick={handleIssueClick}
           />
         </div>
-        <div className="flex flex-col flex-1" style={{ flexBasis: 0 }}>
+        <div className="flex flex-col lg:min-w-0 lg:flex-1" style={{ flexBasis: 0 }}>
           <RecentActivityCard
             activities={activities}
             workspaceSlug={workspaceSlug}

--- a/src/components/dashboard/my-focus-card.tsx
+++ b/src/components/dashboard/my-focus-card.tsx
@@ -45,39 +45,39 @@ export function MyFocusCard({ issues, workspaceSlug, onIssueClick }: MyFocusCard
                     onIssueClick(issue.id);
                   }
                 }}
-                className={`flex items-center gap-3 py-3.5 px-4 bg-surface${onIssueClick ? " cursor-pointer hover:bg-surface-hover transition-colors" : ""}`}
+                className={`flex flex-col items-start gap-2.5 bg-surface px-4 py-3.5 sm:flex-row sm:items-center sm:gap-3${onIssueClick ? " cursor-pointer hover:bg-surface-hover transition-colors" : ""}`}
               >
-                {/* Priority dot */}
-                <span
-                  className="shrink-0 size-2 rounded-sm"
-                  style={{ backgroundColor: priority.color }}
-                  title={priority.label}
-                />
-
-                {/* Issue key */}
-                <span className="shrink-0 w-14 text-[11px] font-mono text-text-muted">
-                  {issue.issue_key}
-                </span>
-
-                {/* Title */}
-                <span className="flex-1 truncate text-sm font-medium text-text">
-                  {issue.title}
-                </span>
-
-                {/* Priority label */}
-                <span
-                  className="shrink-0 text-[11px] font-medium"
-                  style={{ color: priority.color }}
-                >
-                  {priority.label}
-                </span>
-
-                {/* Due date */}
-                {issue.due_date && (
-                  <span className="shrink-0 text-[11px] text-text-muted">
-                    {formatDate(issue.due_date)}
+                <div className="flex w-full items-center gap-3">
+                  <span
+                    className="shrink-0 size-2 rounded-sm"
+                    style={{ backgroundColor: priority.color }}
+                    title={priority.label}
+                  />
+                  <span className="shrink-0 text-[11px] font-mono text-text-muted sm:w-14">
+                    {issue.issue_key}
                   </span>
-                )}
+                  <span className="flex-1 truncate text-sm font-medium text-text">
+                    {issue.title}
+                  </span>
+                </div>
+
+                <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:shrink-0 sm:justify-end">
+                  <span
+                    className="inline-flex items-center rounded-full px-2 py-1 text-[10px] font-semibold sm:bg-transparent sm:px-0 sm:py-0 sm:text-[11px]"
+                    style={{
+                      color: priority.color,
+                      backgroundColor: `${priority.color}14`,
+                    }}
+                  >
+                    {priority.label}
+                  </span>
+
+                  {issue.due_date && (
+                    <span className="inline-flex items-center rounded-full bg-background px-2 py-1 text-[10px] text-text-muted sm:bg-transparent sm:px-0 sm:py-0 sm:text-[11px]">
+                      {formatDate(issue.due_date)}
+                    </span>
+                  )}
+                </div>
               </div>
             );
           })}

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -76,29 +76,29 @@ export function InboxClient({
   return (
     <div>
       {/* Title row: Inbox + tabs inline, mark all read on the right */}
-      <div className="flex items-center justify-between pb-4">
+      <div className="pb-4">
         <Tabs defaultValue="all" className="flex-1">
-          <div className="flex items-center gap-5">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-5">
             <h1 className="text-[26px] font-bold text-text leading-8">
               Inbox
             </h1>
-            <TabsList className="gap-1 rounded-lg border-b-0 bg-surface-inset p-0.5">
+            <TabsList className="w-full gap-1 rounded-lg border-b-0 bg-surface-inset p-0.5 sm:w-auto">
               {TABS.map((tab) => (
                 <TabsTrigger
                   key={tab.value}
                   value={tab.value}
-                  className="rounded-md border-b-0 px-3.5 py-1.5 text-base data-[state=active]:bg-surface data-[state=active]:shadow-none data-[state=active]:border-b-0"
+                  className="flex-1 rounded-md border-b-0 px-3.5 py-1.5 text-base data-[state=active]:bg-surface data-[state=active]:shadow-none data-[state=active]:border-b-0 sm:flex-none"
                 >
                   {tab.label}
                 </TabsTrigger>
               ))}
             </TabsList>
-            <div className="flex-1" />
+            <div className="hidden flex-1 sm:block" />
             {unreadCount > 0 && (
               <button
                 onClick={handleMarkAllRead}
                 disabled={isPending}
-                className="text-sm text-text-secondary hover:text-text transition-colors disabled:opacity-50"
+                className="text-left text-sm text-text-secondary transition-colors hover:text-text disabled:opacity-50 sm:text-right"
               >
                 Mark all as read
               </button>

--- a/src/components/inbox/notification-row.tsx
+++ b/src/components/inbox/notification-row.tsx
@@ -49,26 +49,36 @@ export function NotificationRow({
     }
   }
 
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleClick();
+    }
+  }
+
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={isPending || isLoading ? -1 : 0}
+      aria-disabled={isPending || isLoading}
       onClick={handleClick}
-      disabled={isPending || isLoading}
+      onKeyDown={handleKeyDown}
       className={cn(
-        "group w-full flex items-start gap-3 py-3.5 px-4 text-left transition-colors",
+        "group flex w-full cursor-pointer flex-col gap-3 rounded-xl px-4 py-3.5 text-left transition-colors sm:flex-row sm:items-start",
         isUnread
-          ? "bg-[#2E2E2C0A] border-l-[3px] border-l-primary rounded-r-lg"
-          : "rounded-lg hover:bg-background/50"
+          ? "border border-primary/15 bg-primary/5 shadow-sm"
+          : "border border-transparent hover:bg-background/50"
       )}
     >
       {/* Avatar + unread dot */}
       <div className="relative shrink-0">
         <Avatar size="sm" className="size-8">
-          <AvatarFallback>
+        <AvatarFallback>
             {getInitials(activity?.actor?.full_name, activity?.actor?.email)}
           </AvatarFallback>
         </Avatar>
         {isUnread && (
-          <span className="absolute -top-0.5 -right-0.5 size-2.5 rounded-full bg-[#8B4049] ring-2 ring-white" />
+          <span className="absolute -right-0.5 -top-0.5 size-2.5 rounded-full bg-danger ring-2 ring-[var(--color-surface)]" />
         )}
       </div>
 
@@ -79,7 +89,7 @@ export function NotificationRow({
             "text-sm leading-[18px]",
             isUnread
               ? "font-semibold text-text"
-              : "text-[#7A756C]"
+              : "text-text-secondary"
           )}
         >
           {actionText}
@@ -92,14 +102,21 @@ export function NotificationRow({
       </div>
 
       {/* Timestamp + mark-as-read / loading spinner */}
-      <div className="shrink-0 flex items-center gap-2">
+      <div className="flex w-full shrink-0 items-center justify-between gap-2 sm:w-auto sm:justify-end">
         {isLoading ? (
           <LoaderCircle className="size-4 animate-spin text-text-muted" />
         ) : (
           <>
-            <span className="text-xs text-text-muted whitespace-nowrap">
-              {formatRelative(notification.created_at)}
-            </span>
+            <div className="flex items-center gap-2">
+              {isUnread && (
+                <span className="inline-flex items-center rounded-full bg-surface px-2 py-0.5 text-[10px] font-mono font-medium uppercase tracking-[0.08em] text-text-secondary">
+                  Unread
+                </span>
+              )}
+              <span className="text-xs text-text-muted whitespace-nowrap">
+                {formatRelative(notification.created_at)}
+              </span>
+            </div>
             {isUnread && (
               <button
                 type="button"
@@ -111,7 +128,7 @@ export function NotificationRow({
                     onMarkedRead?.(notification.id);
                   });
                 }}
-                className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-surface-hover"
+                className="rounded p-1 opacity-100 transition-opacity hover:bg-surface-hover sm:opacity-0 sm:group-hover:opacity-100"
                 title="Mark as read"
               >
                 <Check className="size-3.5 text-text-muted" />
@@ -120,6 +137,6 @@ export function NotificationRow({
           </>
         )}
       </div>
-    </button>
+    </div>
   );
 }

--- a/src/components/issues/issue-list.tsx
+++ b/src/components/issues/issue-list.tsx
@@ -32,9 +32,9 @@ export function IssueList({ issues, showProject = true, onIssueClick }: IssueLis
   );
 
   return (
-    <div>
+    <div className="space-y-4 sm:space-y-0">
       {/* Column headers */}
-      <div className="flex items-center gap-3 px-6 py-2 border-b border-border text-[10px] text-text-muted uppercase tracking-wider font-medium">
+      <div className="hidden items-center gap-3 border-b border-border px-6 py-2 text-[10px] font-medium uppercase tracking-wider text-text-muted sm:flex">
         <div className="w-4 shrink-0" />
         <span className="w-[72px] shrink-0">ID</span>
         <span className="flex-1">Title</span>
@@ -74,7 +74,7 @@ function StatusGroup({
     <div>
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 px-6 py-2.5 w-full hover:bg-surface-hover transition-colors"
+        className="flex w-full items-center gap-2 rounded-xl px-4 py-2.5 transition-colors hover:bg-surface-hover sm:rounded-none sm:px-6"
       >
         {expanded ? (
           <ChevronDown className="w-3.5 h-3.5 text-text-muted" />
@@ -90,7 +90,7 @@ function StatusGroup({
       </button>
 
       {expanded && (
-        <div>
+        <div className="flex flex-col gap-2 px-4 pb-1 sm:block sm:px-0 sm:pb-0">
           {issues.map((issue) => (
             <IssueRow
               key={issue.id}

--- a/src/components/issues/issue-row.tsx
+++ b/src/components/issues/issue-row.tsx
@@ -1,4 +1,5 @@
 import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils/cn";
 import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { formatDate } from "@/lib/utils/dates";
 import type { IssuePriority } from "@/lib/types";
@@ -41,50 +42,105 @@ export function IssueRow({
     new Date(dueDate) < new Date(new Date().toDateString());
 
   return (
-    <div
-      onClick={() => onClick?.(id)}
-      className="group flex cursor-pointer items-center gap-3 border-b border-border px-6 py-2.5 transition-colors last:border-b-0 hover:bg-surface-hover/50"
-    >
-      {/* Checkbox */}
-      <Checkbox className="shrink-0" onClick={(e) => e.stopPropagation()} />
+    <>
+      <div
+        onClick={() => onClick?.(id)}
+        className="cursor-pointer rounded-xl border border-border bg-surface px-4 py-3.5 shadow-sm transition-colors hover:bg-surface-hover/70 sm:hidden"
+      >
+        <div className="flex items-start gap-3">
+          <Checkbox className="mt-0.5 shrink-0" onClick={(e) => e.stopPropagation()} />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[11px] font-mono text-text-muted">
+                {issueKey}
+              </span>
+              {showProject && project && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-surface-hover px-2 py-1 text-[10px] font-medium text-text-secondary">
+                  <span
+                    className="size-1.5 rounded-full shrink-0"
+                    style={{ backgroundColor: project.color }}
+                  />
+                  <span className="max-w-[140px] truncate">{project.name}</span>
+                </span>
+              )}
+            </div>
 
-      {/* Issue key */}
-      <span className="text-xs font-mono text-text-muted w-[72px] shrink-0">
-        {issueKey}
-      </span>
+            <p className="mt-2 text-sm font-medium leading-5 text-text">
+              {title}
+            </p>
 
-      {/* Title */}
-      <span className="text-sm text-text flex-1 truncate">{title}</span>
-
-      {/* Project */}
-      {showProject && project && (
-        <div className="flex items-center gap-1.5 shrink-0 w-[140px]">
-          <span
-            className="w-2 h-2 rounded-full shrink-0"
-            style={{ backgroundColor: project.color }}
-          />
-          <span className="text-xs text-text-secondary truncate">
-            {project.name}
-          </span>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <span
+                className="inline-flex items-center rounded-full px-2 py-1 text-[10px] font-semibold"
+                style={{
+                  color: priorityConfig.color,
+                  backgroundColor: priorityConfig.bgColor,
+                }}
+              >
+                {priorityConfig.label}
+              </span>
+              {dueDateDisplay && (
+                <span
+                  className={cn(
+                    "inline-flex items-center rounded-full px-2 py-1 text-[10px] font-medium",
+                    isOverdue
+                      ? "bg-danger-light text-danger"
+                      : "bg-background text-text-secondary",
+                  )}
+                >
+                  {isDone ? dueDateDisplay : `Due ${dueDateDisplay}`}
+                </span>
+              )}
+            </div>
+          </div>
         </div>
-      )}
+      </div>
 
-      {/* Priority */}
-      <span
-        className="text-sm font-semibold w-[72px] text-center shrink-0"
-        style={{ color: priorityConfig.color }}
+      <div
+        onClick={() => onClick?.(id)}
+        className="group hidden cursor-pointer items-center gap-3 border-b border-border px-6 py-2.5 transition-colors last:border-b-0 hover:bg-surface-hover/50 sm:flex"
       >
-        {priorityConfig.label}
-      </span>
+        {/* Checkbox */}
+        <Checkbox className="shrink-0" onClick={(e) => e.stopPropagation()} />
 
-      {/* Due date */}
-      <span
-        className={`text-xs w-[72px] text-right shrink-0 ${
-          isOverdue ? "text-danger font-medium" : "text-text-muted"
-        }`}
-      >
-        {dueDateDisplay}
-      </span>
-    </div>
+        {/* Issue key */}
+        <span className="text-xs font-mono text-text-muted w-[72px] shrink-0">
+          {issueKey}
+        </span>
+
+        {/* Title */}
+        <span className="text-sm text-text flex-1 truncate">{title}</span>
+
+        {/* Project */}
+        {showProject && project && (
+          <div className="flex items-center gap-1.5 shrink-0 w-[140px]">
+            <span
+              className="w-2 h-2 rounded-full shrink-0"
+              style={{ backgroundColor: project.color }}
+            />
+            <span className="text-xs text-text-secondary truncate">
+              {project.name}
+            </span>
+          </div>
+        )}
+
+        {/* Priority */}
+        <span
+          className="text-sm font-semibold w-[72px] text-center shrink-0"
+          style={{ color: priorityConfig.color }}
+        >
+          {priorityConfig.label}
+        </span>
+
+        {/* Due date */}
+        <span
+          className={`text-xs w-[72px] text-right shrink-0 ${
+            isOverdue ? "text-danger font-medium" : "text-text-muted"
+          }`}
+        >
+          {dueDateDisplay}
+        </span>
+      </div>
+    </>
   );
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -65,12 +65,13 @@ export function Header({
       {/* Search trigger */}
       <button
         type="button"
+        aria-label="Search..."
         onClick={() => shell?.openPalette()}
-        className="hidden min-w-[210px] items-center gap-2 rounded-lg border border-border bg-surface-subtle px-4 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-hover sm:flex"
+        className="inline-flex items-center gap-2 rounded-lg border border-border bg-surface-subtle px-2.5 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-hover sm:min-w-[210px] sm:px-4"
       >
         <Search className="w-3.5 h-3.5" />
-        <span className="flex-1 text-left text-[13px]">Search...</span>
-        <kbd className="inline-flex items-center rounded-sm border border-border-strong bg-surface-kbd px-1.5 py-0.5 text-[11px] text-text-muted font-mono">
+        <span className="hidden flex-1 text-left text-[13px] sm:inline">Search...</span>
+        <kbd className="hidden items-center rounded-sm border border-border-strong bg-surface-kbd px-1.5 py-0.5 text-[11px] text-text-muted font-mono sm:inline-flex">
           <span className="text-[11px]">&#8984;</span>K
         </kbd>
       </button>

--- a/src/components/sprints/sprint-planning-view.tsx
+++ b/src/components/sprints/sprint-planning-view.tsx
@@ -135,7 +135,7 @@ function DraggableIssueRow({
       ref={setNodeRef}
       style={style}
       className={cn(
-        "flex cursor-grab items-center gap-2.5 border-b border-border px-5 py-2.5 transition-colors hover:bg-surface-hover/60 active:cursor-grabbing",
+        "border-b border-border px-4 py-3 transition-colors sm:px-5 sm:py-2.5",
         disabled
           ? "cursor-default"
           : "cursor-grab hover:bg-surface-hover/60 active:cursor-grabbing",
@@ -154,39 +154,86 @@ function IssueRowContent({ issue }: { issue: IssueWithDetails }) {
 
   return (
     <>
-      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" className="shrink-0">
-        <circle cx="2" cy="2" r="1.2" fill="var(--color-text-muted)" />
-        <circle cx="5" cy="2" r="1.2" fill="var(--color-text-muted)" />
-        <circle cx="8" cy="2" r="1.2" fill="var(--color-text-muted)" />
-        <circle cx="2" cy="5" r="1.2" fill="var(--color-text-muted)" />
-        <circle cx="5" cy="5" r="1.2" fill="var(--color-text-muted)" />
-        <circle cx="8" cy="5" r="1.2" fill="var(--color-text-muted)" />
-        <circle cx="2" cy="8" r="1.2" fill="var(--color-text-muted)" />
-        <circle cx="5" cy="8" r="1.2" fill="var(--color-text-muted)" />
-        <circle cx="8" cy="8" r="1.2" fill="var(--color-text-muted)" />
-      </svg>
-      <span className="text-[11px] font-mono text-text-secondary shrink-0 w-13">
-        {issue.issue_key}
-      </span>
-      <span className="text-[13px] text-text truncate flex-1">{issue.title}</span>
-      <span
-        className="text-[10px] font-semibold shrink-0 rounded-sm px-1.5 py-0.5"
-        style={{ color: priorityConfig.color, backgroundColor: priorityConfig.bgColor }}
-      >
-        {priorityConfig.label}
-      </span>
-      {issue.assignee ? (
-        <div className="flex h-[22px] w-[22px] items-center justify-center shrink-0 rounded-full bg-avatar">
-          <span className="text-[9px] font-semibold text-text-secondary">
-            {getInitials(issue.assignee.full_name)}
+      <div className="flex w-full flex-col gap-2 sm:hidden">
+        <div className="flex items-center gap-2">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" className="shrink-0">
+            <circle cx="2" cy="2" r="1.2" fill="var(--color-text-muted)" />
+            <circle cx="5" cy="2" r="1.2" fill="var(--color-text-muted)" />
+            <circle cx="8" cy="2" r="1.2" fill="var(--color-text-muted)" />
+            <circle cx="2" cy="5" r="1.2" fill="var(--color-text-muted)" />
+            <circle cx="5" cy="5" r="1.2" fill="var(--color-text-muted)" />
+            <circle cx="8" cy="5" r="1.2" fill="var(--color-text-muted)" />
+            <circle cx="2" cy="8" r="1.2" fill="var(--color-text-muted)" />
+            <circle cx="5" cy="8" r="1.2" fill="var(--color-text-muted)" />
+            <circle cx="8" cy="8" r="1.2" fill="var(--color-text-muted)" />
+          </svg>
+          <span className="text-[11px] font-mono text-text-secondary">
+            {issue.issue_key}
+          </span>
+          <span
+            className="rounded-full px-2 py-1 text-[10px] font-semibold"
+            style={{ color: priorityConfig.color, backgroundColor: priorityConfig.bgColor }}
+          >
+            {priorityConfig.label}
+          </span>
+          <span className="ml-auto rounded-full bg-background px-2 py-1 text-[10px] font-mono font-medium text-text-secondary">
+            {issue.story_points ?? "–"} pts
           </span>
         </div>
-      ) : (
-        <div className="w-[22px] shrink-0" />
-      )}
-      <span className="text-[11px] font-mono font-medium text-text-secondary shrink-0 rounded-sm px-1.5 py-0.5 bg-background">
-        {issue.story_points ?? "–"}
-      </span>
+        <span className="text-[13px] leading-5 text-text">{issue.title}</span>
+        <div className="flex items-center gap-2">
+          {issue.assignee ? (
+            <div className="flex items-center gap-2">
+              <div className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-avatar">
+                <span className="text-[9px] font-semibold text-text-secondary">
+                  {getInitials(issue.assignee.full_name)}
+                </span>
+              </div>
+              <span className="text-[11px] text-text-secondary">
+                {issue.assignee.full_name ?? "Assigned"}
+              </span>
+            </div>
+          ) : (
+            <span className="text-[11px] text-text-muted">Unassigned</span>
+          )}
+        </div>
+      </div>
+
+      <div className="hidden w-full items-center gap-2.5 sm:flex">
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" className="shrink-0">
+          <circle cx="2" cy="2" r="1.2" fill="var(--color-text-muted)" />
+          <circle cx="5" cy="2" r="1.2" fill="var(--color-text-muted)" />
+          <circle cx="8" cy="2" r="1.2" fill="var(--color-text-muted)" />
+          <circle cx="2" cy="5" r="1.2" fill="var(--color-text-muted)" />
+          <circle cx="5" cy="5" r="1.2" fill="var(--color-text-muted)" />
+          <circle cx="8" cy="5" r="1.2" fill="var(--color-text-muted)" />
+          <circle cx="2" cy="8" r="1.2" fill="var(--color-text-muted)" />
+          <circle cx="5" cy="8" r="1.2" fill="var(--color-text-muted)" />
+          <circle cx="8" cy="8" r="1.2" fill="var(--color-text-muted)" />
+        </svg>
+        <span className="text-[11px] font-mono text-text-secondary shrink-0 w-13">
+          {issue.issue_key}
+        </span>
+        <span className="text-[13px] text-text truncate flex-1">{issue.title}</span>
+        <span
+          className="text-[10px] font-semibold shrink-0 rounded-sm px-1.5 py-0.5"
+          style={{ color: priorityConfig.color, backgroundColor: priorityConfig.bgColor }}
+        >
+          {priorityConfig.label}
+        </span>
+        {issue.assignee ? (
+          <div className="flex h-[22px] w-[22px] items-center justify-center shrink-0 rounded-full bg-avatar">
+            <span className="text-[9px] font-semibold text-text-secondary">
+              {getInitials(issue.assignee.full_name)}
+            </span>
+          </div>
+        ) : (
+          <div className="w-[22px] shrink-0" />
+        )}
+        <span className="text-[11px] font-mono font-medium text-text-secondary shrink-0 rounded-sm px-1.5 py-0.5 bg-background">
+          {issue.story_points ?? "–"}
+        </span>
+      </div>
     </>
   );
 }
@@ -527,11 +574,11 @@ export function SprintPlanningView({
         onDragEnd={handleDragEnd}
         onDragCancel={handleDragCancel}
       >
-        <div className="flex flex-1 min-h-0 overflow-hidden pb-6 gap-4 px-10">
+        <div className="flex flex-1 min-h-0 flex-col gap-4 overflow-y-auto px-4 pb-4 md:px-6 xl:flex-row xl:overflow-hidden xl:px-10 xl:pb-6">
           {/* LEFT PANE — Backlog */}
-          <DroppablePane id="backlog" className="flex-1 overflow-hidden rounded-xl border border-border bg-surface">
-            <div className="border-b border-border px-5 pt-4 pb-3">
-              <div className="flex items-center justify-between">
+          <DroppablePane id="backlog" className="flex-1 min-h-[22rem] overflow-hidden rounded-xl border border-border bg-surface">
+            <div className="border-b border-border px-4 pb-3 pt-4 sm:px-5">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-baseline gap-2">
                   <h2 className="text-[15px] font-semibold text-text">Backlog</h2>
                   <span className="text-xs text-text-secondary">
@@ -543,7 +590,7 @@ export function SprintPlanningView({
                 </span>
               </div>
 
-              <div className="flex items-center gap-2 mt-3">
+              <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
                 <div className="relative flex-1">
                   <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted" />
                   <Input
@@ -556,7 +603,7 @@ export function SprintPlanningView({
                 <select
                   value={priorityFilter}
                   onChange={(e) => setPriorityFilter(e.target.value)}
-                  className="h-8 rounded-lg border border-border bg-surface px-2 text-xs text-text focus:outline-none focus:ring-2 focus:ring-primary/10 focus:border-border-strong transition-colors"
+                  className="h-8 w-full rounded-lg border border-border bg-surface px-2 text-xs text-text transition-colors focus:border-border-strong focus:outline-none focus:ring-2 focus:ring-primary/10 sm:w-auto"
                 >
                   <option value="">Priority</option>
                   <option value="0">P0</option>
@@ -567,7 +614,7 @@ export function SprintPlanningView({
               </div>
 
               {/* Quick filter chips */}
-              <div className="flex items-center gap-1.5 mt-2.5">
+              <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
                 {QUICK_FILTER_CONFIG.map((chip) => (
                   <button
                     key={chip.key}
@@ -602,17 +649,17 @@ export function SprintPlanningView({
           </DroppablePane>
 
           {/* RIGHT PANE — Sprint (warm tint) */}
-          <DroppablePane id="sprint" className="flex-1 overflow-hidden rounded-r-xl border border-border border-l-2 border-l-accent bg-surface">
+          <DroppablePane id="sprint" className="flex-1 min-h-[22rem] overflow-hidden rounded-xl border border-border border-l-2 border-l-accent bg-surface xl:rounded-r-xl">
             {sprint ? (
               <>
-                <div className="border-b border-border px-5 pt-4 pb-3.5">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-1.5">
+                <div className="border-b border-border px-4 pb-3.5 pt-4 sm:px-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 flex-col gap-2">
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <button
                             type="button"
-                            className="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 hover:bg-surface-hover transition-colors"
+                            className="inline-flex max-w-full items-center gap-2 rounded-full border border-border px-3 py-1 transition-colors hover:bg-surface-hover"
                           >
                             <span
                               className={cn(
@@ -622,7 +669,7 @@ export function SprintPlanningView({
                             >
                               {sprintStatusConfig?.label}
                             </span>
-                            <span className="text-sm font-semibold text-text">
+                            <span className="truncate text-sm font-semibold text-text">
                               {sprint.name}
                             </span>
                             <ChevronDown className="w-3.5 h-3.5 text-text-muted" />
@@ -742,7 +789,7 @@ export function SprintPlanningView({
                   </div>
 
                   {/* Date range and goal */}
-                  <div className="mt-1.5 flex items-center gap-2 text-[11px] text-text-secondary">
+                  <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] text-text-secondary">
                     {sprint.start_date && sprint.end_date && (
                       <span>
                         {formatDateRange(sprint.start_date, sprint.end_date)}
@@ -778,9 +825,9 @@ export function SprintPlanningView({
                   )}
 
                   {/* Sprint actions */}
-                  <div className="flex items-center gap-2 mt-3">
+                  <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
                     {sprint.status !== "planning" && (
-                      <Button asChild size="sm" variant="ghost">
+                      <Button asChild size="sm" variant="ghost" className="w-full sm:w-auto">
                         <Link href={`/${workspaceSlug}/analytics?tab=sprints&sprint=${sprint.id}`}>
                           Analytics
                         </Link>
@@ -791,6 +838,7 @@ export function SprintPlanningView({
                         size="sm"
                         onClick={handleStartSprint}
                         disabled={sprintIssues.length === 0}
+                        className="w-full sm:w-auto"
                       >
                         Start Sprint
                       </Button>
@@ -800,6 +848,7 @@ export function SprintPlanningView({
                         size="sm"
                         variant="secondary"
                         onClick={() => setShowCompleteModal(true)}
+                        className="w-full sm:w-auto"
                       >
                         Complete Sprint
                       </Button>
@@ -827,7 +876,7 @@ export function SprintPlanningView({
                   ))}
 
                   {/* Drop zone placeholder */}
-                  <div className="mx-5 my-3 flex min-h-20 flex-1 items-center justify-center rounded-lg border-2 border-dashed border-border text-xs text-text-muted">
+                  <div className="mx-4 my-3 flex min-h-20 flex-1 items-center justify-center rounded-lg border-2 border-dashed border-border px-4 text-center text-xs text-text-muted sm:mx-5">
                     {dragDisabled
                       ? "Completed sprint. Scope is read-only."
                       : "Drag issues here from backlog"}

--- a/tests/mobile-polish.spec.ts
+++ b/tests/mobile-polish.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "@playwright/test";
+
+const BASE_URL = "http://localhost:3001";
+const WS = "/pw-workspace";
+
+test.use({ viewport: { width: 375, height: 812 } });
+
+async function openFrontendProject(page: import("@playwright/test").Page) {
+  await page.goto(`${BASE_URL}${WS}/projects`);
+  await page.getByRole("link", { name: /Frontend v2\.4/i }).click();
+}
+
+test("dashboard stacks recent activity below the primary content on mobile", async ({
+  page,
+}) => {
+  await page.goto(`${BASE_URL}${WS}/dashboard`);
+
+  const primary = page.getByRole("heading", { name: "My Top Issues" });
+  const secondary = page.getByRole("heading", { name: "Recent Activity" });
+
+  await expect(primary).toBeVisible();
+  await expect(secondary).toBeVisible();
+
+  const primaryBox = await primary.boundingBox();
+  const secondaryBox = await secondary.boundingBox();
+
+  expect(primaryBox).not.toBeNull();
+  expect(secondaryBox).not.toBeNull();
+  expect((secondaryBox?.y ?? 0) - (primaryBox?.y ?? 0)).toBeGreaterThan(120);
+});
+
+test("command palette stays inside the mobile viewport", async ({ page }) => {
+  await page.goto(`${BASE_URL}${WS}/dashboard`);
+  await page.getByRole("button", { name: "Search..." }).click();
+
+  const input = page.getByPlaceholder("Search issues, projects, actions...");
+  await expect(input).toBeVisible();
+
+  const dialog = page.locator('[cmdk-dialog][data-state="open"]').filter({ has: input });
+
+  const box = await dialog.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box?.x ?? 0).toBeGreaterThanOrEqual(0);
+  expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(375);
+});
+
+test("project tabs remain visible without wrapping on mobile", async ({ page }) => {
+  await openFrontendProject(page);
+
+  await expect(page.getByRole("link", { name: "Sprint Planning" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
+});
+
+test("my issues shows assigned issue titles as readable mobile cards", async ({
+  page,
+}) => {
+  await page.goto(`${BASE_URL}${WS}/my-issues`);
+
+  const issueTitle = page.getByText("Redesign onboarding flow").first();
+  await expect(issueTitle).toBeVisible();
+
+  const issueBox = await issueTitle.boundingBox();
+  expect(issueBox).not.toBeNull();
+  expect(issueBox?.width ?? 0).toBeGreaterThan(180);
+});
+
+test("board columns stack vertically on mobile instead of forcing a horizontal-only kanban", async ({
+  page,
+}) => {
+  await openFrontendProject(page);
+
+  const todo = page.getByRole("region", { name: /Todo column/i });
+  const inProgress = page.getByRole("region", { name: /In Progress column/i });
+
+  await expect(todo).toBeVisible();
+  await expect(inProgress).toBeVisible();
+
+  const todoBox = await todo.boundingBox();
+  const inProgressBox = await inProgress.boundingBox();
+
+  expect(todoBox).not.toBeNull();
+  expect(inProgressBox).not.toBeNull();
+  expect(todoBox?.width ?? 0).toBeGreaterThan(300);
+  expect(inProgressBox?.width ?? 0).toBeGreaterThan(300);
+  expect(inProgressBox?.y ?? 0).toBeGreaterThan((todoBox?.y ?? 0) + 300);
+});
+
+test("sprint planning stacks backlog and sprint panes on mobile", async ({
+  page,
+}) => {
+  await openFrontendProject(page);
+  await page.getByRole("link", { name: "Sprint Planning" }).click();
+
+  const backlogHeading = page.getByRole("heading", { name: "Backlog" });
+  const sprintHeading = page.getByText("Sprint 24").first();
+
+  await expect(backlogHeading).toBeVisible();
+  await expect(sprintHeading).toBeVisible();
+
+  const backlogBox = await backlogHeading.boundingBox();
+  const sprintBox = await sprintHeading.boundingBox();
+
+  expect(backlogBox).not.toBeNull();
+  expect(sprintBox).not.toBeNull();
+  expect((sprintBox?.y ?? 0) - (backlogBox?.y ?? 0)).toBeGreaterThan(250);
+});
+
+test("analytics KPI cards fit the mobile viewport", async ({ page }) => {
+  await page.goto(`${BASE_URL}${WS}/analytics`);
+
+  await expect(page.getByText("Issues Completed")).toBeVisible();
+  await expect(page.getByText("Avg Cycle Time")).toBeVisible();
+  await expect(page.getByText("Throughput", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Points Delivered")).toBeVisible();
+});
+
+test("older unread inbox notifications stay visually distinct on mobile", async ({
+  page,
+}) => {
+  await page.goto(`${BASE_URL}${WS}/inbox`);
+
+  const olderUnreadRow = page
+    .locator('[role="button"]')
+    .filter({ hasText: "Alex commented on FLO-279" });
+  await expect(olderUnreadRow).toBeVisible();
+  await expect(olderUnreadRow.getByText("UNREAD")).toBeVisible();
+
+  const readRow = page
+    .locator('[role="button"]')
+    .filter({ hasText: "James moved FLO-288 to Done" });
+  await expect(readRow).toBeVisible();
+  await expect(readRow.getByText("UNREAD")).toHaveCount(0);
+});

--- a/tests/mobile-polish.spec.ts
+++ b/tests/mobile-polish.spec.ts
@@ -1,19 +1,18 @@
 import { expect, test } from "@playwright/test";
 
-const BASE_URL = "http://localhost:3001";
 const WS = "/pw-workspace";
 
 test.use({ viewport: { width: 375, height: 812 } });
 
 async function openFrontendProject(page: import("@playwright/test").Page) {
-  await page.goto(`${BASE_URL}${WS}/projects`);
+  await page.goto(`${WS}/projects`);
   await page.getByRole("link", { name: /Frontend v2\.4/i }).click();
 }
 
 test("dashboard stacks recent activity below the primary content on mobile", async ({
   page,
 }) => {
-  await page.goto(`${BASE_URL}${WS}/dashboard`);
+  await page.goto(`${WS}/dashboard`);
 
   const primary = page.getByRole("heading", { name: "My Top Issues" });
   const secondary = page.getByRole("heading", { name: "Recent Activity" });
@@ -30,7 +29,7 @@ test("dashboard stacks recent activity below the primary content on mobile", asy
 });
 
 test("command palette stays inside the mobile viewport", async ({ page }) => {
-  await page.goto(`${BASE_URL}${WS}/dashboard`);
+  await page.goto(`${WS}/dashboard`);
   await page.getByRole("button", { name: "Search..." }).click();
 
   const input = page.getByPlaceholder("Search issues, projects, actions...");
@@ -54,7 +53,7 @@ test("project tabs remain visible without wrapping on mobile", async ({ page }) 
 test("my issues shows assigned issue titles as readable mobile cards", async ({
   page,
 }) => {
-  await page.goto(`${BASE_URL}${WS}/my-issues`);
+  await page.goto(`${WS}/my-issues`);
 
   const issueTitle = page.getByText("Redesign onboarding flow").first();
   await expect(issueTitle).toBeVisible();
@@ -106,7 +105,7 @@ test("sprint planning stacks backlog and sprint panes on mobile", async ({
 });
 
 test("analytics KPI cards fit the mobile viewport", async ({ page }) => {
-  await page.goto(`${BASE_URL}${WS}/analytics`);
+  await page.goto(`${WS}/analytics`);
 
   await expect(page.getByText("Issues Completed")).toBeVisible();
   await expect(page.getByText("Avg Cycle Time")).toBeVisible();
@@ -117,7 +116,7 @@ test("analytics KPI cards fit the mobile viewport", async ({ page }) => {
 test("older unread inbox notifications stay visually distinct on mobile", async ({
   page,
 }) => {
-  await page.goto(`${BASE_URL}${WS}/inbox`);
+  await page.goto(`${WS}/inbox`);
 
   const olderUnreadRow = page
     .locator('[role="button"]')


### PR DESCRIPTION
## Summary
- polish mobile layouts for my issues, dashboard, board, sprint planning, analytics, command palette, project tabs, and inbox rows
- convert cramped mobile issue rows into readable cards and stack previously split panes/columns for small screens
- add focused Playwright mobile regression coverage for the critique-11 cases

## Verification
- npx eslint src/app/'(app)'/[workspaceSlug]/analytics/page.tsx src/app/'(app)'/[workspaceSlug]/my-issues/my-issues-client.tsx src/app/'(app)'/[workspaceSlug]/my-issues/my-issues-content.tsx src/app/'(app)'/[workspaceSlug]/my-issues/page.tsx src/app/'(app)'/[workspaceSlug]/projects/[projectId]/layout.tsx src/app/'(app)'/[workspaceSlug]/projects/[projectId]/project-tab-nav.tsx src/app/'(app)'/[workspaceSlug]/projects/[projectId]/sprint-planning/page.tsx src/components/analytics/analytics-client.tsx src/components/analytics/kpi-card.tsx src/components/analytics/kpi-cards.tsx src/components/analytics/overview-kpi-cards.tsx src/components/analytics/time-range-selector.tsx src/components/board/board-column.tsx src/components/board/board-view.tsx src/components/command-palette/command-palette.tsx src/components/dashboard/dashboard-content.tsx src/components/dashboard/my-focus-card.tsx src/components/inbox/inbox-client.tsx src/components/inbox/notification-row.tsx src/components/issues/issue-list.tsx src/components/issues/issue-row.tsx src/components/sprints/sprint-planning-view.tsx tests/mobile-polish.spec.ts
- npx playwright test tests/auth.setup.ts --project=setup
- npx playwright test tests/mobile-polish.spec.ts --project=authenticated --no-deps
- playwright-cli mobile QA pass at 375x812 on dashboard, my issues, board, sprint planning, analytics, and inbox

## Notes
- repo-wide dev warnings still exist for Radix dialog accessibility and DnD hydration attributes; those were not changed in this PR