### PR TITLE
Implement polished warm dark mode

### DIFF
--- a/src/app/(app)/[workspaceSlug]/error.tsx
+++ b/src/app/(app)/[workspaceSlug]/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { AlertCircle } from "lucide-react";
 
 export default function WorkspaceError({
@@ -11,8 +12,8 @@ export default function WorkspaceError({
 }) {
   return (
     <div className="flex flex-col items-center justify-center py-24 px-6">
-      <div className="size-12 rounded-full bg-[#8B404918] flex items-center justify-center mb-4">
-        <AlertCircle className="size-6 text-[#C45A3C]" />
+      <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-danger-muted/10">
+        <AlertCircle className="size-6 text-danger" />
       </div>
       <h2 className="text-[17px] font-semibold text-text mb-1">
         Something went wrong
@@ -23,16 +24,16 @@ export default function WorkspaceError({
       <div className="flex items-center gap-3">
         <button
           onClick={reset}
-          className="rounded-lg py-2.5 px-6 bg-[#2E2E2C] text-white text-[13px] font-medium hover:bg-[#1E1E1C] transition-colors"
+          className="rounded-lg bg-primary px-6 py-2.5 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover"
         >
           Try again
         </button>
-        <a
+        <Link
           href="/"
-          className="rounded-lg py-2.5 px-6 border border-[#2E2E2C14] text-[13px] font-medium text-text hover:bg-[#F6F5F1] transition-colors"
+          className="rounded-lg border border-border-input px-6 py-2.5 text-[13px] font-medium text-text transition-colors hover:bg-surface-hover"
         >
           Go to dashboard
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback, Suspense } from "react";
+import { useState, useMemo, useCallback, Suspense } from "react";
 import { ChevronDown } from "lucide-react";
 import { IssueList } from "@/components/issues/issue-list";
 import { BoardView } from "@/components/board/board-view";
@@ -48,8 +48,26 @@ function MyIssuesContentInner({
   labels = [],
   projects = [],
 }: MyIssuesContentProps) {
-  const [viewMode, setViewMode] = useState<ViewMode>("list");
-  const [sortKey, setSortKey] = useState<SortKey>("priority");
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    if (typeof window === "undefined") {
+      return "list";
+    }
+
+    const storedView = window.localStorage.getItem(VIEW_STORAGE_KEY);
+    return storedView === "board" ? "board" : "list";
+  });
+  const [sortKey, setSortKey] = useState<SortKey>(() => {
+    if (typeof window === "undefined") {
+      return "priority";
+    }
+
+    const storedSort = window.localStorage.getItem(SORT_STORAGE_KEY);
+    if (storedSort && SORT_OPTIONS.some((option) => option.key === storedSort)) {
+      return storedSort as SortKey;
+    }
+
+    return "priority";
+  });
   const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
@@ -78,16 +96,6 @@ function MyIssuesContentInner({
     issues,
     enabledFilters: ["status", "priority", "assignee", "label", "project"],
   });
-
-  // Load persisted state from localStorage
-  useEffect(() => {
-    const storedView = localStorage.getItem(VIEW_STORAGE_KEY);
-    if (storedView === "list" || storedView === "board") setViewMode(storedView);
-    const storedSort = localStorage.getItem(SORT_STORAGE_KEY);
-    if (storedSort && SORT_OPTIONS.some((o) => o.key === storedSort)) {
-      setSortKey(storedSort as SortKey);
-    }
-  }, []);
 
   function handleViewChange(mode: ViewMode) {
     setViewMode(mode);
@@ -165,13 +173,13 @@ function MyIssuesContentInner({
       {/* Controls row */}
       <div className="flex items-center gap-3">
         {/* View toggle */}
-        <div className="flex items-center rounded-lg overflow-hidden bg-[#EDEAE4] p-0.5 gap-0.5">
+        <div className="flex items-center gap-0.5 overflow-hidden rounded-lg bg-surface-inset p-0.5">
           <button
             onClick={() => handleViewChange("list")}
             className={cn(
               "px-3.5 py-1.5 text-sm font-medium rounded-md transition-colors",
               viewMode === "list"
-                ? "bg-white text-text"
+                ? "bg-surface text-text"
                 : "text-text-secondary hover:text-text"
             )}
           >
@@ -182,7 +190,7 @@ function MyIssuesContentInner({
             className={cn(
               "px-3.5 py-1.5 text-sm font-medium rounded-md transition-colors",
               viewMode === "board"
-                ? "bg-white text-text"
+                ? "bg-surface text-text"
                 : "text-text-secondary hover:text-text"
             )}
           >

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/error.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/error.tsx
@@ -11,8 +11,8 @@ export default function ProjectError({
 }) {
   return (
     <div className="flex flex-col items-center justify-center py-24 px-6">
-      <div className="size-12 rounded-full bg-[#8B404918] flex items-center justify-center mb-4">
-        <AlertCircle className="size-6 text-[#C45A3C]" />
+      <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-danger-muted/10">
+        <AlertCircle className="size-6 text-danger" />
       </div>
       <h2 className="text-[17px] font-semibold text-text mb-1">
         Failed to load project
@@ -22,7 +22,7 @@ export default function ProjectError({
       </p>
       <button
         onClick={reset}
-        className="rounded-lg py-2.5 px-6 bg-[#2E2E2C] text-white text-[13px] font-medium hover:bg-[#1E1E1C] transition-colors"
+        className="rounded-lg bg-primary px-6 py-2.5 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover"
       >
         Try again
       </button>

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -19,7 +19,7 @@ export default function ForgotPasswordPage() {
     <div className="w-full max-w-md">
       {/* Logo */}
       <div className="flex items-center gap-3 mb-8">
-        <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-white font-bold">
+        <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-background font-bold">
           F
         </div>
         <span className="font-medium text-text text-lg">Flow</span>
@@ -71,7 +71,7 @@ export default function ForgotPasswordPage() {
           <button
             type="submit"
             disabled={pending}
-            className="bg-primary text-white w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
+            className="bg-primary text-background w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
           >
             {pending ? "Sending..." : "Send Reset Link"}
           </button>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
     <div className="w-full max-w-md">
       {/* Logo */}
       <div className="flex items-center gap-3 mb-8">
-        <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-white font-bold">
+        <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-background font-bold">
           F
         </div>
         <span className="font-medium text-text text-lg">Flow</span>
@@ -82,7 +82,7 @@ export default function LoginPage() {
         <button
           type="submit"
           disabled={pending}
-          className="bg-primary text-white w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
+          className="bg-primary text-background w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {pending ? "Signing In..." : "Sign In"}
         </button>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -27,7 +27,7 @@ export default function ResetPasswordPage() {
     <div className="w-full max-w-md">
       {/* Logo */}
       <div className="flex items-center gap-3 mb-8">
-        <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-white font-bold">
+        <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-background font-bold">
           F
         </div>
         <span className="font-medium text-text text-lg">Flow</span>
@@ -93,7 +93,7 @@ export default function ResetPasswordPage() {
         <button
           type="submit"
           disabled={pending}
-          className="bg-primary text-white w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
+          className="bg-primary text-background w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {pending ? "Updating..." : "Update Password"}
         </button>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -18,7 +18,7 @@ export default function SignUpPage() {
     <div className="w-full max-w-md">
       {/* Logo */}
       <div className="flex items-center gap-3 mb-8">
-        <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-white font-bold">
+        <div className="bg-primary rounded-lg w-10 h-10 flex items-center justify-center text-background font-bold">
           F
         </div>
         <span className="font-medium text-text text-lg">Flow</span>
@@ -96,7 +96,7 @@ export default function SignUpPage() {
         <button
           type="submit"
           disabled={pending}
-          className="bg-primary text-white w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
+          className="bg-primary text-background w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {pending ? "Creating Account..." : "Create Account"}
         </button>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -16,7 +16,7 @@ export default function Error({
         </p>
         <button
           onClick={reset}
-          className="mt-6 inline-block cursor-pointer rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+          className="mt-6 inline-block cursor-pointer rounded-lg bg-primary px-6 py-3 text-sm font-medium text-background transition-colors hover:bg-primary-hover"
         >
           Try again
         </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,11 +1,17 @@
 @import "tailwindcss";
 
-@theme inline {
+@theme {
   --color-background: #F6F5F1;
+  --color-sidebar: #F6F5F1;
   --color-surface: #FFFFFF;
   --color-surface-hover: #FAF8F5;
+  --color-surface-subtle: #EDEAE4;
+  --color-surface-kbd: #DFDBCF;
+  --color-surface-inset: #F0EDE7;
   --color-border: #E8E4DE;
   --color-border-strong: #D6CFC7;
+  --color-border-subtle: #2E2E2C0F;
+  --color-border-input: #2E2E2C14;
   --color-text: #2D2A26;
   --color-text-secondary: #9C9689;
   --color-text-muted: #B8B3AB;
@@ -19,12 +25,67 @@
   --color-warning-light: #FFFBEB;
   --color-danger: #DC2626;
   --color-danger-light: #FEF2F2;
+  --color-danger-muted: #8B4049;
+  --color-danger-muted-hover: #7A3640;
   --color-purple: #7C3AED;
   --color-purple-light: #F5F3FF;
+  --color-avatar: #E8E4DE;
+  --color-overlay: #2E2E2C73;
+  --color-chart-grid: #F0EDE7;
+  --color-chart-line: #D5D0C8;
+  --color-chart-muted: #DFD9D2;
+  --color-chart-strong: #2E2E2C;
+  --color-chart-highlight: #E8E4DE;
 
   --font-sans: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
   --font-serif: "Instrument Serif", ui-serif, Georgia, serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
+}
+
+.dark {
+  --color-background: #1A1918;
+  --color-sidebar: #161514;
+  --color-surface: #222120;
+  --color-surface-hover: #2A2927;
+  --color-surface-subtle: #2A2927;
+  --color-surface-kbd: #3D3B38;
+  --color-surface-inset: #1E1D1B;
+  --color-border: #2E2D2A;
+  --color-border-strong: #3D3B38;
+  --color-border-subtle: #E8E5E00F;
+  --color-border-input: #E8E5E014;
+  --color-text: #E8E5E0;
+  --color-text-secondary: #8A857D;
+  --color-text-muted: #5C5852;
+  --color-primary: #E8E5E0;
+  --color-primary-hover: #D9D5CE;
+  --color-accent: #E8622C;
+  --color-accent-light: #382218;
+  --color-success: #5A8A6C;
+  --color-success-light: #203026;
+  --color-warning: #E0914A;
+  --color-warning-light: #362619;
+  --color-danger: #D4554B;
+  --color-danger-light: #341C19;
+  --color-danger-muted: #A04D58;
+  --color-danger-muted-hover: #8B4049;
+  --color-purple: #8B7BA6;
+  --color-purple-light: #2B2533;
+  --color-avatar: #2A2927;
+  --color-overlay: #00000080;
+  --color-chart-grid: #2E2D2A;
+  --color-chart-line: #3D3B38;
+  --color-chart-muted: #5C5852;
+  --color-chart-strong: #E8E5E0;
+  --color-chart-highlight: #3D3B38;
+}
+
+html {
+  color-scheme: light;
+}
+
+html.dark {
+  color-scheme: dark;
 }
 
 body {
@@ -34,8 +95,8 @@ body {
 }
 
 ::selection {
-  background-color: #2D2A26;
-  color: #F6F5F1;
+  background-color: var(--color-primary);
+  color: var(--color-background);
 }
 
 input::placeholder,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { Space_Grotesk, JetBrains_Mono, Instrument_Serif } from "next/font/google";
-import { Toaster } from "sonner";
+import Script from "next/script";
+import { ThemeToaster } from "@/components/ui/theme-toaster";
+import { getThemeScript } from "@/lib/theme";
+import { ThemeProvider } from "@/providers/theme-provider";
 import "./globals.css";
 
 const spaceGrotesk = Space_Grotesk({
@@ -37,10 +40,16 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${spaceGrotesk.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
-      <body className="h-full font-sans">
-        {children}
-        <Toaster position="bottom-right" />
+      <body className="h-full bg-background font-sans text-text">
+        <Script id="flow-theme-init" strategy="beforeInteractive">
+          {getThemeScript()}
+        </Script>
+        <ThemeProvider>
+          {children}
+          <ThemeToaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -10,7 +10,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="mt-6 inline-block rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+          className="mt-6 inline-block rounded-lg bg-primary px-6 py-3 text-sm font-medium text-background transition-colors hover:bg-primary-hover"
         >
           Go home
         </Link>

--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -28,7 +28,7 @@ export function SprintSelector({
     <select
       value={selectedSprintId ?? ""}
       onChange={handleChange}
-      className="rounded-lg py-2 px-4 text-[13px] font-medium text-text bg-white border border-border/50 cursor-pointer hover:border-border transition-colors"
+      className="cursor-pointer rounded-lg border border-border-input bg-surface px-4 py-2 text-[13px] font-medium text-text transition-colors hover:border-border"
     >
       {sprints.map((sprint) => (
         <option key={sprint.id} value={sprint.id}>

--- a/src/components/analytics/assignee-chart.tsx
+++ b/src/components/analytics/assignee-chart.tsx
@@ -5,7 +5,7 @@ import type { AssigneeCount } from "@/lib/queries/analytics";
 export function AssigneeChart({ data }: { data: AssigneeCount[] }) {
   if (data.length === 0) {
     return (
-      <div className="flex flex-col grow shrink basis-0 rounded-xl gap-5 bg-white border border-border/50 p-5">
+      <div className="flex flex-col grow shrink basis-0 gap-5 rounded-xl border border-border-input bg-surface p-5">
         <span className="text-sm font-semibold text-text">
           Issues by Assignee
         </span>
@@ -19,7 +19,7 @@ export function AssigneeChart({ data }: { data: AssigneeCount[] }) {
   const maxCount = Math.max(...data.map((d) => d.count));
 
   return (
-    <div className="flex flex-col grow shrink basis-0 rounded-xl gap-5 bg-white border border-border/50 p-5">
+    <div className="flex flex-col grow shrink basis-0 gap-5 rounded-xl border border-border-input bg-surface p-5">
       <span className="text-sm font-semibold text-text">
         Issues by Assignee
       </span>
@@ -34,7 +34,7 @@ export function AssigneeChart({ data }: { data: AssigneeCount[] }) {
                   className="w-5 h-5 rounded-full object-cover"
                 />
               ) : (
-                <div className="w-5 h-5 rounded-full bg-[#E8E4DE] flex items-center justify-center">
+                <div className="flex h-5 w-5 items-center justify-center rounded-full bg-avatar">
                   <span className="text-[9px] font-medium text-text-muted">
                     {item.name.charAt(0).toUpperCase()}
                   </span>
@@ -42,12 +42,12 @@ export function AssigneeChart({ data }: { data: AssigneeCount[] }) {
               )}
               <span className="text-xs text-text truncate">{item.name}</span>
             </div>
-            <div className="grow shrink basis-0 h-5 rounded-sm overflow-clip bg-[#F0EDE7]">
+            <div className="grow shrink basis-0 h-5 rounded-sm overflow-clip bg-surface-inset">
               <div
                 className="h-full rounded-sm transition-all"
                 style={{
                   width: `${(item.count / maxCount) * 100}%`,
-                  backgroundColor: "#2E2E2C",
+                  backgroundColor: "var(--color-chart-strong)",
                 }}
               />
             </div>

--- a/src/components/analytics/burndown-chart.tsx
+++ b/src/components/analytics/burndown-chart.tsx
@@ -14,7 +14,7 @@ import type { BurndownPoint } from "@/lib/utils/analytics";
 export function BurndownChart({ data }: { data: BurndownPoint[] }) {
   if (data.length === 0) {
     return (
-      <div className="flex flex-col rounded-xl gap-4 bg-white border border-border/50 p-5">
+      <div className="flex flex-col gap-4 rounded-xl border border-border-input bg-surface p-5">
         <span className="text-sm font-semibold text-text">
           Sprint Burndown
         </span>
@@ -26,18 +26,18 @@ export function BurndownChart({ data }: { data: BurndownPoint[] }) {
   }
 
   return (
-    <div className="flex flex-col rounded-xl gap-4 bg-white border border-border/50 p-5">
+    <div className="flex flex-col gap-4 rounded-xl border border-border-input bg-surface p-5">
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold text-text">
           Sprint Burndown
         </span>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-1.5">
-            <div className="w-4 h-0.5 rounded-sm bg-[#2E2E2C]" />
+            <div className="h-0.5 w-4 rounded-sm bg-[var(--color-chart-strong)]" />
             <span className="text-[11px] text-text-muted">Actual</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <div className="w-4 h-0.5 rounded-sm bg-[#D5D0C8] border-t border-dashed border-[#D5D0C8]" />
+            <div className="h-0.5 w-4 rounded-sm border-t border-dashed border-[var(--color-chart-line)] bg-[var(--color-chart-line)]" />
             <span className="text-[11px] text-text-muted">Ideal</span>
           </div>
         </div>
@@ -46,34 +46,34 @@ export function BurndownChart({ data }: { data: BurndownPoint[] }) {
         <LineChart data={data}>
           <CartesianGrid
             strokeDasharray="0"
-            stroke="#F0EDE7"
+            stroke="var(--color-chart-grid)"
             vertical={false}
           />
           <XAxis
             dataKey="date"
-            tick={{ fontSize: 10, fontFamily: "JetBrains Mono", fill: "#B8B3AB" }}
+            tick={{ fontSize: 10, fontFamily: "JetBrains Mono", fill: "var(--color-text-muted)" }}
             axisLine={false}
             tickLine={false}
           />
           <YAxis
-            tick={{ fontSize: 10, fontFamily: "JetBrains Mono", fill: "#B8B3AB" }}
+            tick={{ fontSize: 10, fontFamily: "JetBrains Mono", fill: "var(--color-text-muted)" }}
             axisLine={false}
             tickLine={false}
             width={30}
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: "#2E2E2C",
-              border: "none",
+              backgroundColor: "var(--color-primary)",
+              border: "1px solid var(--color-border-strong)",
               borderRadius: "8px",
               fontSize: "12px",
-              color: "#F6F5F1",
+              color: "var(--color-background)",
             }}
           />
           <Line
             type="monotone"
             dataKey="ideal"
-            stroke="#D5D0C8"
+            stroke="var(--color-chart-line)"
             strokeWidth={1.5}
             strokeDasharray="6 4"
             dot={false}
@@ -81,10 +81,10 @@ export function BurndownChart({ data }: { data: BurndownPoint[] }) {
           <Line
             type="monotone"
             dataKey="actual"
-            stroke="#2E2E2C"
+            stroke="var(--color-chart-strong)"
             strokeWidth={2.5}
             dot={false}
-            activeDot={{ r: 4, fill: "#2E2E2C" }}
+            activeDot={{ r: 4, fill: "var(--color-chart-strong)" }}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/src/components/analytics/cycle-time-chart.tsx
+++ b/src/components/analytics/cycle-time-chart.tsx
@@ -17,7 +17,7 @@ const BAR_COLORS = ["#4A7A5C", "#5C8A6E", "#7AA08A", "#9CB8A8", "#BED0C6"];
 export function CycleTimeChart({ data }: { data: CycleTimeBucket[] }) {
   if (data.length === 0 || data.every((d) => d.count === 0)) {
     return (
-      <div className="flex flex-col grow shrink basis-0 rounded-xl gap-4 bg-white border border-border/50 p-5">
+      <div className="flex flex-col grow shrink basis-0 gap-4 rounded-xl border border-border-input bg-surface p-5">
         <span className="text-sm font-semibold text-text">
           Cycle Time Distribution
         </span>
@@ -29,7 +29,7 @@ export function CycleTimeChart({ data }: { data: CycleTimeBucket[] }) {
   }
 
   return (
-    <div className="flex flex-col grow shrink basis-0 rounded-xl gap-4 bg-white border border-border/50 p-5">
+    <div className="flex flex-col grow shrink basis-0 gap-4 rounded-xl border border-border-input bg-surface p-5">
       <span className="text-sm font-semibold text-text">
         Cycle Time Distribution
       </span>
@@ -37,7 +37,7 @@ export function CycleTimeChart({ data }: { data: CycleTimeBucket[] }) {
         <BarChart data={data} layout="vertical">
           <CartesianGrid
             strokeDasharray="0"
-            stroke="#F0EDE7"
+            stroke="var(--color-chart-grid)"
             horizontal={false}
           />
           <XAxis
@@ -45,7 +45,7 @@ export function CycleTimeChart({ data }: { data: CycleTimeBucket[] }) {
             tick={{
               fontSize: 10,
               fontFamily: "JetBrains Mono",
-              fill: "#B8B3AB",
+              fill: "var(--color-text-muted)",
             }}
             axisLine={false}
             tickLine={false}
@@ -57,7 +57,7 @@ export function CycleTimeChart({ data }: { data: CycleTimeBucket[] }) {
             tick={{
               fontSize: 11,
               fontFamily: "JetBrains Mono",
-              fill: "#9C9689",
+              fill: "var(--color-text-secondary)",
             }}
             axisLine={false}
             tickLine={false}
@@ -65,11 +65,11 @@ export function CycleTimeChart({ data }: { data: CycleTimeBucket[] }) {
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: "#2E2E2C",
-              border: "none",
+              backgroundColor: "var(--color-primary)",
+              border: "1px solid var(--color-border-strong)",
               borderRadius: "8px",
               fontSize: "12px",
-              color: "#F6F5F1",
+              color: "var(--color-background)",
             }}
             formatter={(value) => [`${value} issues`, "Count"]}
           />

--- a/src/components/analytics/kpi-card.tsx
+++ b/src/components/analytics/kpi-card.tsx
@@ -6,7 +6,7 @@ export type KPICardProps = {
 
 export function KPICard({ label, value, delta }: KPICardProps) {
   return (
-    <div className="flex flex-col grow shrink basis-0 rounded-xl gap-1.5 bg-white border border-border/50 p-5">
+    <div className="flex flex-col grow shrink basis-0 gap-1.5 rounded-xl border border-border-input bg-surface p-5">
       <span className="text-xs font-medium text-text-muted">{label}</span>
       <div className="flex items-baseline gap-2">
         <span className="text-[32px] font-bold leading-10 text-text">
@@ -15,7 +15,7 @@ export function KPICard({ label, value, delta }: KPICardProps) {
         {delta && (
           <span
             className="text-[13px] font-medium"
-            style={{ color: delta.isPositive ? "#4A7A5C" : "#8B4049" }}
+            style={{ color: delta.isPositive ? "var(--color-success)" : "var(--color-danger-muted)" }}
           >
             {delta.text}
           </span>

--- a/src/components/analytics/label-chart.tsx
+++ b/src/components/analytics/label-chart.tsx
@@ -5,7 +5,7 @@ import type { LabelCount } from "@/lib/queries/analytics";
 export function LabelChart({ data }: { data: LabelCount[] }) {
   if (data.length === 0) {
     return (
-      <div className="flex flex-col grow shrink basis-0 rounded-xl gap-5 bg-white border border-border/50 p-5">
+      <div className="flex flex-col grow shrink basis-0 gap-5 rounded-xl border border-border-input bg-surface p-5">
         <span className="text-sm font-semibold text-text">
           Issues by Label
         </span>
@@ -19,7 +19,7 @@ export function LabelChart({ data }: { data: LabelCount[] }) {
   const maxCount = Math.max(...data.map((d) => d.count));
 
   return (
-    <div className="flex flex-col grow shrink basis-0 rounded-xl gap-5 bg-white border border-border/50 p-5">
+    <div className="flex flex-col grow shrink basis-0 gap-5 rounded-xl border border-border-input bg-surface p-5">
       <span className="text-sm font-semibold text-text">
         Issues by Label
       </span>
@@ -29,7 +29,7 @@ export function LabelChart({ data }: { data: LabelCount[] }) {
             <span className="w-15 shrink-0 text-xs text-text">
               {item.name}
             </span>
-            <div className="grow shrink basis-0 h-5 rounded-sm overflow-clip bg-[#F0EDE7]">
+            <div className="grow shrink basis-0 h-5 rounded-sm overflow-clip bg-surface-inset">
               <div
                 className="h-full rounded-sm transition-all"
                 style={{

--- a/src/components/analytics/throughput-chart.tsx
+++ b/src/components/analytics/throughput-chart.tsx
@@ -14,7 +14,7 @@ import type { ThroughputPoint } from "@/lib/queries/analytics";
 export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
   if (data.length === 0 || data.every((d) => d.count === 0)) {
     return (
-      <div className="flex flex-col rounded-xl gap-4 bg-white border border-border/50 p-5">
+      <div className="flex flex-col gap-4 rounded-xl border border-border-input bg-surface p-5">
         <span className="text-sm font-semibold text-text">Throughput</span>
         <div className="flex items-center justify-center h-40 text-sm text-text-muted">
           No completed issues in this period.
@@ -24,7 +24,7 @@ export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
   }
 
   return (
-    <div className="flex flex-col rounded-xl gap-4 bg-white border border-border/50 p-5">
+    <div className="flex flex-col gap-4 rounded-xl border border-border-input bg-surface p-5">
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold text-text">Throughput</span>
         <span className="text-[11px] text-text-muted">issues / week</span>
@@ -33,7 +33,7 @@ export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
         <BarChart data={data}>
           <CartesianGrid
             strokeDasharray="0"
-            stroke="#F0EDE7"
+            stroke="var(--color-chart-grid)"
             vertical={false}
           />
           <XAxis
@@ -41,7 +41,7 @@ export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
             tick={{
               fontSize: 10,
               fontFamily: "JetBrains Mono",
-              fill: "#B8B3AB",
+              fill: "var(--color-text-muted)",
             }}
             axisLine={false}
             tickLine={false}
@@ -50,7 +50,7 @@ export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
             tick={{
               fontSize: 10,
               fontFamily: "JetBrains Mono",
-              fill: "#B8B3AB",
+              fill: "var(--color-text-muted)",
             }}
             axisLine={false}
             tickLine={false}
@@ -59,16 +59,16 @@ export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: "#2E2E2C",
-              border: "none",
+              backgroundColor: "var(--color-primary)",
+              border: "1px solid var(--color-border-strong)",
               borderRadius: "8px",
               fontSize: "12px",
-              color: "#F6F5F1",
+              color: "var(--color-background)",
             }}
           />
           <Bar
             dataKey="count"
-            fill="#2E2E2C"
+            fill="var(--color-chart-strong)"
             radius={[4, 4, 0, 0]}
             maxBarSize={40}
           />

--- a/src/components/analytics/time-range-selector.tsx
+++ b/src/components/analytics/time-range-selector.tsx
@@ -18,7 +18,7 @@ export function TimeRangeSelector({ activeRange }: { activeRange: TimeRange }) {
   }
 
   return (
-    <div className="inline-flex items-center gap-0.5 rounded-lg bg-[#F0EDE7] p-1">
+    <div className="inline-flex items-center gap-0.5 rounded-lg bg-surface-inset p-1">
       {ranges.map((range) => {
         const isActive = activeRange === range;
         return (
@@ -27,7 +27,7 @@ export function TimeRangeSelector({ activeRange }: { activeRange: TimeRange }) {
             onClick={() => handleChange(range)}
             className={`rounded-md px-3 py-1 text-[13px] font-medium transition-colors ${
               isActive
-                ? "bg-white text-text shadow-sm"
+                ? "bg-surface text-text shadow-sm"
                 : "text-text-muted hover:text-text"
             }`}
           >

--- a/src/components/analytics/velocity-chart.tsx
+++ b/src/components/analytics/velocity-chart.tsx
@@ -5,7 +5,7 @@ import type { VelocityPoint } from "@/lib/queries/analytics";
 export function VelocityChart({ data }: { data: VelocityPoint[] }) {
   if (data.length === 0) {
     return (
-      <div className="flex flex-col grow shrink basis-0 rounded-xl gap-5 bg-white border border-border/50 p-5">
+      <div className="flex flex-col grow shrink basis-0 gap-5 rounded-xl border border-border-input bg-surface p-5">
         <span className="text-sm font-semibold text-text">
           Team Velocity
         </span>
@@ -20,7 +20,7 @@ export function VelocityChart({ data }: { data: VelocityPoint[] }) {
   const maxHeight = 120; // px
 
   return (
-    <div className="flex flex-col grow shrink basis-0 rounded-xl gap-5 bg-white border border-border/50 p-5">
+    <div className="flex flex-col grow shrink basis-0 gap-5 rounded-xl border border-border-input bg-surface p-5">
       <span className="text-sm font-semibold text-text">
         Team Velocity
       </span>
@@ -30,13 +30,17 @@ export function VelocityChart({ data }: { data: VelocityPoint[] }) {
           const height =
             maxPoints > 0 ? (item.points / maxPoints) * maxHeight : 0;
 
-          // Color gradient from light to dark
-          const colors = ["#E8E4DE", "#DFD9D2", "#D6CFC6", "#2E2E2C"];
+          const colors = [
+            "var(--color-chart-highlight)",
+            "var(--color-chart-muted)",
+            "var(--color-chart-line)",
+            "var(--color-chart-strong)",
+          ];
           const colorIndex = Math.min(
             i + (4 - data.length),
             colors.length - 1
           );
-          const barColor = isLast ? "#2E2E2C" : colors[Math.max(0, colorIndex)];
+          const barColor = isLast ? "var(--color-chart-strong)" : colors[Math.max(0, colorIndex)];
 
           return (
             <div
@@ -53,7 +57,7 @@ export function VelocityChart({ data }: { data: VelocityPoint[] }) {
               <span
                 className="text-[10px] font-mono"
                 style={{
-                  color: isLast ? "#2E2E2C" : "#B8B3AB",
+                  color: isLast ? "var(--color-text)" : "var(--color-text-muted)",
                   fontWeight: isLast ? 600 : 400,
                 }}
               >
@@ -62,7 +66,7 @@ export function VelocityChart({ data }: { data: VelocityPoint[] }) {
               <span
                 className="text-xs"
                 style={{
-                  color: isLast ? "#2D2A26" : "#9C9689",
+                  color: isLast ? "var(--color-text)" : "var(--color-text-secondary)",
                   fontWeight: isLast ? 600 : 400,
                 }}
               >

--- a/src/components/board/board-quick-add.tsx
+++ b/src/components/board/board-quick-add.tsx
@@ -99,7 +99,7 @@ export function BoardQuickAdd({
                 className={cn(
                   "px-1.5 py-0.5 rounded text-[10px] font-medium transition-colors",
                   priority === p
-                    ? "text-white"
+                    ? "text-background"
                     : "text-text-muted bg-surface-hover hover:bg-border",
                 )}
                 style={

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Command } from "cmdk";
+import { PlusCircle, Search, Settings2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { searchIssuesClient, getRecentIssuesClient, type SearchResult } from "@/lib/queries/search";
 
@@ -17,8 +18,8 @@ interface CommandPaletteProps {
 
 function KBD({ children }: { children: React.ReactNode }) {
   return (
-    <span className="flex items-center justify-center rounded-sm py-0.5 px-1.5 bg-[#F6F5F1] border border-[#2E2E2C0F]">
-      <span className="text-[#A3A39E] font-mono font-medium text-[10px] leading-[14px]">
+    <span className="flex items-center justify-center rounded-sm border border-border-input bg-surface-inset py-0.5 px-1.5">
+      <span className="font-mono text-[10px] leading-[14px] font-medium text-text-muted">
         {children}
       </span>
     </span>
@@ -42,11 +43,25 @@ export function CommandPalette({
 
   // Load recent items on open
   useEffect(() => {
-    if (open) {
+    if (!open) return;
+
+    const resetTimer = window.setTimeout(() => {
       setQuery("");
       setResults([]);
-      getRecentIssuesClient(workspaceId, userId, 3).then(setRecentItems);
-    }
+    }, 0);
+
+    let cancelled = false;
+
+    getRecentIssuesClient(workspaceId, userId, 3).then((items) => {
+      if (!cancelled) {
+        setRecentItems(items);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(resetTimer);
+    };
   }, [open, workspaceId, userId]);
 
   // Debounced search
@@ -54,7 +69,6 @@ export function CommandPalette({
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     if (!query.trim()) {
-      setResults([]);
       return;
     }
 
@@ -98,49 +112,46 @@ export function CommandPalette({
     >
       {/* Overlay */}
       <div
-        className="fixed inset-0 bg-[#2E2E2C73]"
+        className="fixed inset-0 bg-overlay backdrop-blur-sm"
         onClick={() => onOpenChange(false)}
       />
 
       {/* Palette card */}
-      <div className="fixed left-1/2 top-[180px] -translate-x-1/2 w-[640px] flex flex-col rounded-[14px] overflow-hidden bg-white border border-[#2E2E2C14] shadow-[0px_24px_64px_#2E2E2C33,0px_2px_8px_#2E2E2C0F]">
+      <div className="fixed left-1/2 top-[180px] flex w-[640px] -translate-x-1/2 flex-col overflow-hidden rounded-[14px] border border-border-input bg-surface shadow-2xl">
         {/* Search input */}
-        <div className="flex items-center py-4 px-5 gap-3.5 border-b border-[#2E2E2C0F]">
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" className="shrink-0 opacity-30">
-            <circle cx="8" cy="8" r="5.5" stroke="#2E2E2C" strokeWidth="1.5" />
-            <path d="M12 12L16 16" stroke="#2E2E2C" strokeWidth="1.5" strokeLinecap="round" />
-          </svg>
+        <div className="flex items-center gap-3.5 border-b border-border-subtle py-4 px-5">
+          <Search className="h-[18px] w-[18px] shrink-0 text-text-muted opacity-60" />
           <Command.Input
             value={query}
             onValueChange={setQuery}
             placeholder="Search issues, projects, actions..."
-            className="flex-1 bg-transparent text-[15px] leading-5 text-[#2E2E2C] placeholder:text-[#2E2E2C] placeholder:opacity-30 focus:outline-none"
+            className="flex-1 bg-transparent text-[15px] leading-5 text-text placeholder:text-text-muted focus:outline-none"
           />
         </div>
 
         {/* Results */}
-        <Command.List className="flex flex-col p-2 max-h-[360px] overflow-y-auto">
+        <Command.List className="flex max-h-[360px] flex-col overflow-y-auto p-2">
           {/* Issues section */}
           {displayItems.length > 0 && (
             <Command.Group
               heading={
-                <span className="tracking-[0.08em] opacity-50 text-[#A3A39E] font-mono font-medium text-[10px] leading-3 px-3 pt-2 pb-1.5 block">
+                <span className="block px-3 pt-2 pb-1.5 font-mono text-[10px] leading-3 tracking-[0.08em] text-text-muted opacity-60">
                   {sectionLabel}
                 </span>
               }
             >
-              {displayItems.map((item, i) => (
+              {displayItems.map((item) => (
                 <Command.Item
                   key={item.id}
                   value={`issue-${item.id}`}
                   onSelect={() => navigateToIssue(item)}
-                  className="flex items-center justify-between rounded-lg py-2.5 px-3 cursor-pointer data-[selected=true]:bg-[#F6F5F1]"
+                  className="flex cursor-pointer items-center justify-between rounded-lg py-2.5 px-3 data-[selected=true]:bg-surface-hover"
                 >
                   <div className="flex items-center gap-3">
-                    <span className="opacity-50 text-[#A3A39E] font-mono text-[11px] leading-[14px]">
+                    <span className="font-mono text-[11px] leading-[14px] text-text-muted opacity-60">
                       {item.issue_key}
                     </span>
-                    <span className="text-[#2E2E2C] font-medium text-[13px] leading-4">
+                    <span className="text-[13px] leading-4 font-medium text-text">
                       {item.title}
                     </span>
                   </div>
@@ -150,7 +161,7 @@ export function CommandPalette({
                         className="rounded-full size-1.5 shrink-0"
                         style={{ backgroundColor: item.project.color }}
                       />
-                      <span className="opacity-50 text-[#A3A39E] font-mono text-[10px] leading-3">
+                      <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">
                         {item.project.name}
                       </span>
                     </div>
@@ -163,12 +174,12 @@ export function CommandPalette({
           {/* Divider */}
           {!query.trim() && (
             <>
-              <div className="w-full h-px bg-[#2E2E2C0F] my-0.5" />
+              <div className="my-0.5 h-px w-full bg-border-subtle" />
 
               {/* Actions section */}
               <Command.Group
                 heading={
-                  <span className="tracking-[0.08em] opacity-50 text-[#A3A39E] font-mono font-medium text-[10px] leading-3 px-3 pt-2.5 pb-1.5 block">
+                  <span className="block px-3 pt-2.5 pb-1.5 font-mono text-[10px] leading-3 tracking-[0.08em] text-text-muted opacity-60">
                     ACTIONS
                   </span>
                 }
@@ -179,14 +190,11 @@ export function CommandPalette({
                     onOpenChange(false);
                     onCreateIssue?.();
                   }}
-                  className="flex items-center justify-between rounded-lg py-2.5 px-3 cursor-pointer data-[selected=true]:bg-[#F6F5F1]"
+                  className="flex cursor-pointer items-center justify-between rounded-lg py-2.5 px-3 data-[selected=true]:bg-surface-hover"
                 >
                   <div className="flex items-center gap-2.5">
-                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="opacity-35">
-                      <circle cx="7" cy="7" r="6" stroke="#2E2E2C" strokeWidth="1.2" />
-                      <path d="M7 4.5V9.5M4.5 7H9.5" stroke="#2E2E2C" strokeWidth="1.2" strokeLinecap="round" />
-                    </svg>
-                    <span className="text-[#2E2E2C] font-medium text-[13px] leading-4">
+                    <PlusCircle className="h-4 w-4 text-text-muted opacity-60" />
+                    <span className="text-[13px] leading-4 font-medium text-text">
                       Create new issue
                     </span>
                   </div>
@@ -202,14 +210,11 @@ export function CommandPalette({
                     router.push(`/${workspaceSlug}/settings/general`);
                     onOpenChange(false);
                   }}
-                  className="flex items-center justify-between rounded-lg py-2.5 px-3 cursor-pointer data-[selected=true]:bg-[#F6F5F1]"
+                  className="flex cursor-pointer items-center justify-between rounded-lg py-2.5 px-3 data-[selected=true]:bg-surface-hover"
                 >
                   <div className="flex items-center gap-2.5">
-                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="opacity-35">
-                      <circle cx="7" cy="7" r="2" stroke="#2E2E2C" strokeWidth="1.2" />
-                      <path d="M7 1V3M7 11V13M1 7H3M11 7H13M2.75 2.75L4.17 4.17M9.83 9.83L11.25 11.25M11.25 2.75L9.83 4.17M4.17 9.83L2.75 11.25" stroke="#2E2E2C" strokeWidth="1.2" strokeLinecap="round" />
-                    </svg>
-                    <span className="text-[#2E2E2C] font-medium text-[13px] leading-4">
+                    <Settings2 className="h-4 w-4 text-text-muted opacity-60" />
+                    <span className="text-[13px] leading-4 font-medium text-text">
                       Go to settings
                     </span>
                   </div>
@@ -225,14 +230,14 @@ export function CommandPalette({
                     key={project.id}
                     value={`project-${project.name}`}
                     onSelect={() => navigateToProject(project.id)}
-                    className="flex items-center justify-between rounded-lg py-2.5 px-3 cursor-pointer data-[selected=true]:bg-[#F6F5F1]"
+                    className="flex cursor-pointer items-center justify-between rounded-lg py-2.5 px-3 data-[selected=true]:bg-surface-hover"
                   >
                     <div className="flex items-center gap-2.5">
                       <span
                         className="rounded-full size-2 shrink-0"
                         style={{ backgroundColor: project.color }}
                       />
-                      <span className="text-[#2E2E2C] font-medium text-[13px] leading-4">
+                      <span className="text-[13px] leading-4 font-medium text-text">
                         {project.name}
                       </span>
                     </div>
@@ -244,31 +249,31 @@ export function CommandPalette({
 
           {/* Empty state */}
           {query.trim() && results.length === 0 && (
-            <Command.Empty className="py-6 text-center text-[13px] text-[#A3A39E]">
+            <Command.Empty className="py-6 text-center text-[13px] text-text-muted">
               No results found.
             </Command.Empty>
           )}
         </Command.List>
 
         {/* Footer */}
-        <div className="flex items-center gap-3 py-2.5 px-5 border-t border-[#2E2E2C0F]">
+        <div className="flex items-center gap-3 border-t border-border-subtle py-2.5 px-5">
           <div className="flex items-center gap-1">
-            <span className="flex items-center justify-center rounded-[3px] py-px px-1 bg-[#F6F5F1] border border-[#2E2E2C0F]">
-              <span className="text-[#A3A39E] font-mono font-medium text-[9px] leading-[14px]">↑↓</span>
+            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset py-px px-1">
+              <span className="font-mono text-[9px] leading-[14px] font-medium text-text-muted">↑↓</span>
             </span>
-            <span className="opacity-50 text-[#A3A39E] font-mono text-[10px] leading-3">Navigate</span>
+            <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">Navigate</span>
           </div>
           <div className="flex items-center gap-1">
-            <span className="flex items-center justify-center rounded-[3px] py-px px-1 bg-[#F6F5F1] border border-[#2E2E2C0F]">
-              <span className="text-[#A3A39E] font-mono font-medium text-[9px] leading-[14px]">↵</span>
+            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset py-px px-1">
+              <span className="font-mono text-[9px] leading-[14px] font-medium text-text-muted">↵</span>
             </span>
-            <span className="opacity-50 text-[#A3A39E] font-mono text-[10px] leading-3">Open</span>
+            <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">Open</span>
           </div>
           <div className="flex items-center gap-1">
-            <span className="flex items-center justify-center rounded-[3px] py-px px-1 bg-[#F6F5F1] border border-[#2E2E2C0F]">
-              <span className="text-[#A3A39E] font-mono font-medium text-[9px] leading-[14px]">esc</span>
+            <span className="flex items-center justify-center rounded-[3px] border border-border-input bg-surface-inset py-px px-1">
+              <span className="font-mono text-[9px] leading-[14px] font-medium text-text-muted">esc</span>
             </span>
-            <span className="opacity-50 text-[#A3A39E] font-mono text-[10px] leading-3">Close</span>
+            <span className="font-mono text-[10px] leading-3 text-text-muted opacity-60">Close</span>
           </div>
         </div>
       </div>

--- a/src/components/dashboard/recent-activity-card.tsx
+++ b/src/components/dashboard/recent-activity-card.tsx
@@ -81,7 +81,7 @@ export function RecentActivityCard({
               className={`flex items-start gap-2.5 py-3.5 px-4 bg-surface${isClickable ? " cursor-pointer hover:bg-surface-hover transition-colors" : ""}`}
             >
               {/* Avatar */}
-              <div className="shrink-0 size-7 rounded-[14px] bg-[#E8E4DE] flex items-center justify-center text-[10px] font-medium text-text-secondary">
+              <div className="shrink-0 size-7 rounded-[14px] bg-avatar flex items-center justify-center text-[10px] font-medium text-text-secondary">
                 {getActorInitials(activity.actor)}
               </div>
 

--- a/src/components/dashboard/sprint-strip.tsx
+++ b/src/components/dashboard/sprint-strip.tsx
@@ -18,10 +18,10 @@ const STATUS_BAR_ORDER: IssueStatus[] = [
 ];
 
 const NEUTRAL_STATUS_COLORS: Record<IssueStatus, string> = {
-  done: "#2D2A26",
-  in_review: "#9C9689",
-  in_progress: "#C8C3BB",
-  todo: "#E8E4DE",
+  done: "var(--color-primary)",
+  in_review: "var(--color-text-secondary)",
+  in_progress: "var(--color-text-muted)",
+  todo: "var(--color-border)",
 };
 
 const STATUS_LABELS: Record<IssueStatus, string> = {

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -82,12 +82,12 @@ export function InboxClient({
             <h1 className="text-[26px] font-bold text-text leading-8">
               Inbox
             </h1>
-            <TabsList className="border-b-0 bg-[#EDEAE4] rounded-lg p-0.5 gap-1">
+            <TabsList className="gap-1 rounded-lg border-b-0 bg-surface-inset p-0.5">
               {TABS.map((tab) => (
                 <TabsTrigger
                   key={tab.value}
                   value={tab.value}
-                  className="rounded-md px-3.5 py-1.5 text-base data-[state=active]:bg-white data-[state=active]:shadow-none border-b-0 data-[state=active]:border-b-0"
+                  className="rounded-md border-b-0 px-3.5 py-1.5 text-base data-[state=active]:bg-surface data-[state=active]:shadow-none data-[state=active]:border-b-0"
                 >
                   {tab.label}
                 </TabsTrigger>

--- a/src/components/issues/create-issue-modal.tsx
+++ b/src/components/issues/create-issue-modal.tsx
@@ -209,7 +209,7 @@ export function CreateIssueModal({
                         className={cn(
                           "px-2.5 py-1 rounded-md text-xs font-medium transition-colors",
                           priority === p
-                            ? "text-white"
+                            ? "text-background"
                             : "text-text-secondary bg-surface-hover hover:bg-border",
                         )}
                         style={
@@ -240,7 +240,7 @@ export function CreateIssueModal({
                       className={cn(
                         "flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-colors",
                         status === s
-                          ? "text-white"
+                          ? "text-background"
                           : "text-text-secondary bg-surface-hover hover:bg-border",
                       )}
                       style={

--- a/src/components/issues/issue-detail-panel.tsx
+++ b/src/components/issues/issue-detail-panel.tsx
@@ -304,7 +304,7 @@ export function IssueDetailPanel({
                         className={cn(
                           "flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium transition-colors",
                           status === s
-                            ? "text-white"
+                            ? "text-background"
                             : "text-text-secondary bg-surface-hover hover:bg-border"
                         )}
                         style={
@@ -336,7 +336,7 @@ export function IssueDetailPanel({
                         className={cn(
                           "px-2 py-1 rounded-md text-xs font-medium transition-colors",
                           priority === p
-                            ? "text-white"
+                            ? "text-background"
                             : "text-text-secondary bg-surface-hover hover:bg-border"
                         )}
                         style={

--- a/src/components/issues/issue-list.tsx
+++ b/src/components/issues/issue-list.tsx
@@ -34,7 +34,7 @@ export function IssueList({ issues, showProject = true, onIssueClick }: IssueLis
   return (
     <div>
       {/* Column headers */}
-      <div className="flex items-center gap-3 px-6 py-2 border-b border-[#E8E4DE] text-[10px] text-text-muted uppercase tracking-wider font-medium">
+      <div className="flex items-center gap-3 px-6 py-2 border-b border-border text-[10px] text-text-muted uppercase tracking-wider font-medium">
         <div className="w-4 shrink-0" />
         <span className="w-[72px] shrink-0">ID</span>
         <span className="flex-1">Title</span>

--- a/src/components/issues/issue-row.tsx
+++ b/src/components/issues/issue-row.tsx
@@ -43,7 +43,7 @@ export function IssueRow({
   return (
     <div
       onClick={() => onClick?.(id)}
-      className="flex items-center gap-3 px-6 py-2.5 hover:bg-surface-hover/50 transition-colors group border-b border-[#F0EDE7] last:border-b-0 cursor-pointer"
+      className="group flex cursor-pointer items-center gap-3 border-b border-border px-6 py-2.5 transition-colors last:border-b-0 hover:bg-surface-hover/50"
     >
       {/* Checkbox */}
       <Checkbox className="shrink-0" onClick={(e) => e.stopPropagation()} />

--- a/src/components/landing/feature-sprint.tsx
+++ b/src/components/landing/feature-sprint.tsx
@@ -25,7 +25,7 @@ export function FeatureSprint() {
             key={`${day}-${i}`}
             className={`flex h-9 w-9 items-center justify-center rounded-full text-xs font-medium transition-all duration-300 ${
               i === activeDay
-                ? "bg-primary text-white scale-110"
+                ? "bg-primary text-background scale-110"
                 : "text-text-secondary hover:bg-surface-hover"
             }`}
           >
@@ -42,7 +42,7 @@ export function FeatureSprint() {
       </div>
 
       {/* Button */}
-      <button className="mt-4 w-full rounded-full bg-primary px-6 py-3 text-sm font-medium text-white transition-transform duration-200 hover:scale-[1.02]">
+      <button className="mt-4 w-full rounded-full bg-primary px-6 py-3 text-sm font-medium text-background transition-transform duration-200 hover:scale-[1.02]">
         Commit Plan
       </button>
     </div>

--- a/src/components/landing/magnetic-button.tsx
+++ b/src/components/landing/magnetic-button.tsx
@@ -48,7 +48,7 @@ export function MagneticButton({
   };
 
   const variantStyles = {
-    primary: "bg-primary text-white",
+    primary: "bg-primary text-background",
     outline: "border border-border-strong text-text bg-transparent",
     inverted: "bg-surface text-primary",
   };

--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -72,46 +72,46 @@ export function Pricing() {
               key={plan.name}
               className={`flex flex-col rounded-3xl p-8 text-left ${
                 plan.dark
-                  ? "bg-primary text-white"
+                  ? "bg-primary text-background"
                   : "border border-border bg-surface"
               }`}
             >
               {/* Header */}
               <div>
                 <div className="flex items-center gap-3">
-                  <span className={`text-sm font-semibold ${plan.dark ? "text-white" : "text-text"}`}>
+                  <span className={`text-sm font-semibold ${plan.dark ? "text-background" : "text-text"}`}>
                     {plan.name}
                   </span>
                   {plan.badge && (
-                    <span className="rounded-full bg-white/20 px-2.5 py-0.5 text-[11px] font-medium text-white">
+                    <span className="rounded-full bg-background/20 px-2.5 py-0.5 text-[11px] font-medium text-background">
                       {plan.badge}
                     </span>
                   )}
                 </div>
                 <div className="mt-3 flex items-baseline gap-1">
-                  <span className={`text-4xl font-bold ${plan.dark ? "text-white" : "text-text"}`}>
+                  <span className={`text-4xl font-bold ${plan.dark ? "text-background" : "text-text"}`}>
                     {plan.price}
                   </span>
                   {plan.priceSuffix && (
-                    <span className={`text-sm ${plan.dark ? "text-white/60" : "text-text-muted"}`}>
+                    <span className={`text-sm ${plan.dark ? "text-background/60" : "text-text-muted"}`}>
                       {plan.priceSuffix}
                     </span>
                   )}
                 </div>
-                <p className={`mt-2 text-sm ${plan.dark ? "text-white/50" : "text-text-muted"}`}>
+                <p className={`mt-2 text-sm ${plan.dark ? "text-background/50" : "text-text-muted"}`}>
                   {plan.sub}
                 </p>
               </div>
 
               {/* Divider */}
-              <div className={`my-6 h-px ${plan.dark ? "bg-white/10" : "bg-border"}`} />
+              <div className={`my-6 h-px ${plan.dark ? "bg-background/10" : "bg-border"}`} />
 
               {/* Features */}
               <ul className="flex-1 space-y-3">
                 {plan.features.map((feature) => (
                   <li
                     key={feature}
-                    className={`text-sm ${plan.dark ? "text-white/70" : "text-text-secondary"}`}
+                    className={`text-sm ${plan.dark ? "text-background/70" : "text-text-secondary"}`}
                   >
                     {feature}
                   </li>
@@ -123,7 +123,7 @@ export function Pricing() {
                 <MagneticButton
                   variant={plan.variant}
                   href="/signup"
-                  className={`w-full ${plan.dark ? "border-white/20" : ""}`}
+                  className={`w-full ${plan.dark ? "border-background/20" : ""}`}
                 >
                   {plan.cta}
                 </MagneticButton>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useShell } from "@/components/layout/workspace-shell";
+import { ThemeToggle } from "@/components/layout/theme-toggle";
 
 interface HeaderProps {
   workspaceSlug: string;
@@ -48,14 +49,16 @@ export function Header({
       <button
         type="button"
         onClick={() => shell?.openPalette()}
-        className="flex items-center gap-2 bg-[#EDEAE4] rounded-lg px-4 py-2 text-sm text-text-secondary hover:opacity-80 transition-opacity"
+        className="hidden min-w-[210px] items-center gap-2 rounded-lg border border-border bg-surface-subtle px-4 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-hover sm:flex"
       >
         <Search className="w-3.5 h-3.5" />
         <span className="flex-1 text-left text-[13px]">Search...</span>
-        <kbd className="hidden sm:inline-flex items-center rounded-sm bg-[#DFDBCF] px-1.5 py-0.5 text-[11px] text-text-muted font-mono">
+        <kbd className="inline-flex items-center rounded-sm border border-border-strong bg-surface-kbd px-1.5 py-0.5 text-[11px] text-text-muted font-mono">
           <span className="text-[11px]">&#8984;</span>K
         </kbd>
       </button>
+
+      <ThemeToggle />
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/src/components/layout/inbox-badge.tsx
+++ b/src/components/layout/inbox-badge.tsx
@@ -23,7 +23,7 @@ export function InboxBadge({
 
   return (
     <span
-      className="bg-[#8B4049] text-white text-[10px] font-mono font-medium rounded-full px-1.5 py-0.5 min-w-[18px] flex items-center justify-center leading-3"
+      className="bg-danger-muted text-white text-[10px] font-mono font-medium rounded-full px-1.5 py-0.5 min-w-[18px] flex items-center justify-center leading-3"
       title={`${unreadCount} unread`}
     >
       {unreadCount > 99 ? "99+" : unreadCount}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -60,13 +60,13 @@ export function Sidebar({
 }: SidebarProps) {
   const pathname = usePathname();
   const base = `/${workspaceSlug}`;
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
 
-  // Load collapsed state from localStorage
-  useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "true") setCollapsed(true);
-  }, []);
+    return window.localStorage.getItem(STORAGE_KEY) === "true";
+  });
 
   function toggleCollapsed() {
     const next = !collapsed;
@@ -148,7 +148,7 @@ export function Sidebar({
         })}
 
         {/* Divider */}
-        <div className="!my-3 h-px bg-[#2E2E2C]/6" />
+        <div className="!my-3 h-px bg-border-subtle" />
 
         {/* Projects section */}
         {!isCollapsed && (
@@ -229,7 +229,7 @@ export function Sidebar({
       {/* Desktop sidebar */}
       <aside
         className={cn(
-          "hidden md:flex bg-background border-r border-[#2E2E2C]/6 flex-col h-screen shrink-0 transition-all duration-200",
+          "hidden md:flex bg-sidebar border-r border-border-subtle flex-col h-screen shrink-0 transition-all duration-200",
           collapsed ? "w-14" : "w-56",
         )}
       >
@@ -241,11 +241,11 @@ export function Sidebar({
         <div className="fixed inset-0 z-50 md:hidden">
           {/* Backdrop */}
           <div
-            className="absolute inset-0 bg-black/40"
+            className="absolute inset-0 bg-overlay"
             onClick={onMobileClose}
           />
           {/* Sidebar panel */}
-          <aside className="relative w-56 h-full bg-background border-r border-[#2E2E2C]/6 flex flex-col">
+          <aside className="relative w-56 h-full bg-sidebar border-r border-border-subtle flex flex-col">
             {sidebarContent(false, true)}
           </aside>
         </div>

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { Laptop, Moon, Sun } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useTheme } from "@/providers/theme-provider";
+import type { ThemeMode } from "@/lib/theme";
+
+const THEME_OPTIONS: {
+  value: ThemeMode;
+  label: string;
+  icon: typeof Sun;
+}[] = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Laptop },
+];
+
+export function ThemeToggle() {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+
+  const ActiveIcon = mounted ? (resolvedTheme === "dark" ? Moon : Sun) : Laptop;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Change theme"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-surface text-text-secondary transition-colors hover:bg-surface-hover hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2"
+        >
+          <ActiveIcon className="h-4 w-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuLabel className="normal-case tracking-normal text-sm text-text">
+          Theme
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup
+          value={theme}
+          onValueChange={(value) => setTheme(value as ThemeMode)}
+        >
+          {THEME_OPTIONS.map((option) => {
+            const Icon = option.icon;
+
+            return (
+              <DropdownMenuRadioItem key={option.value} value={option.value}>
+                <Icon className="mr-2 h-4 w-4 text-text-muted" />
+                {option.label}
+              </DropdownMenuRadioItem>
+            );
+          })}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/settings/members-settings.tsx
+++ b/src/components/settings/members-settings.tsx
@@ -37,9 +37,9 @@ const ROLE_LABELS: Record<WorkspaceRole, string> = {
 };
 
 const ROLE_BADGE_STYLES: Record<WorkspaceRole, string> = {
-  owner: "bg-[#2E2E2C] text-white",
-  admin: "bg-[#2E2E2C14] text-text",
-  member: "bg-[#2E2E2C0A] text-text-muted",
+  owner: "bg-primary text-background",
+  admin: "border border-border-input bg-surface-subtle text-text",
+  member: "border border-border-subtle bg-surface-hover text-text-muted",
 };
 
 export function MembersSettings({
@@ -98,7 +98,7 @@ export function MembersSettings({
             type="button"
             onClick={handleGenerateInvite}
             disabled={inviteLoading}
-            className="rounded-lg py-2 px-4 bg-[#2E2E2C] text-white text-[13px] font-medium hover:bg-[#1E1E1C] transition-colors disabled:opacity-50"
+            className="rounded-lg bg-primary px-4 py-2 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
           >
             {inviteLoading ? "Generating..." : "Generate invite link"}
           </button>
@@ -106,7 +106,7 @@ export function MembersSettings({
       </div>
 
       {inviteLink && (
-        <div className="mt-4 flex items-center gap-3 rounded-[10px] bg-[#F6F5F1] border border-[#2E2E2C14] px-4 py-3">
+        <div className="mt-4 flex items-center gap-3 rounded-[10px] border border-border-input bg-surface-inset px-4 py-3">
           <span className="flex-1 text-[13px] font-mono text-text truncate">
             {inviteLink}
           </span>
@@ -139,7 +139,7 @@ export function MembersSettings({
           return (
             <div
               key={member.id}
-              className="flex items-center gap-3 py-3 px-3 rounded-lg hover:bg-[#F6F5F1] transition-colors"
+              className="flex items-center gap-3 rounded-lg py-3 px-3 transition-colors hover:bg-surface-hover"
             >
               <Avatar size="sm">
                 <AvatarFallback>{initials}</AvatarFallback>
@@ -169,7 +169,7 @@ export function MembersSettings({
                   onChange={(e) =>
                     handleRoleChange(member.id, e.target.value as "admin" | "member")
                   }
-                  className="px-2 py-1 rounded-md text-[11px] font-medium bg-[#2E2E2C0A] border border-[#2E2E2C14] text-text focus:outline-none"
+                  className="rounded-md border border-border-input bg-surface-subtle px-2 py-1 text-[11px] font-medium text-text focus:outline-none"
                 >
                   <option value="admin">Admin</option>
                   <option value="member">Member</option>
@@ -181,7 +181,7 @@ export function MembersSettings({
                 <button
                   type="button"
                   onClick={() => setRemovingMember(member)}
-                  className="text-[12px] text-text-muted hover:text-[#C45A3C] transition-colors"
+                  className="text-[12px] text-text-muted transition-colors hover:text-danger"
                 >
                   Remove
                 </button>

--- a/src/components/settings/profile-settings-form.tsx
+++ b/src/components/settings/profile-settings-form.tsx
@@ -90,20 +90,20 @@ export function ProfileSettingsForm({ profile }: ProfileSettingsFormProps) {
             id="profile-name"
             name="fullName"
             defaultValue={profile.full_name ?? ""}
-            className="w-full h-11 rounded-[10px] px-3.5 bg-white border border-[#2E2E2C14] text-sm font-medium text-text focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors"
+            className="h-11 w-full rounded-[10px] border border-border-input bg-surface px-3.5 text-sm font-medium text-text transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
           />
         </div>
 
         {/* Email (read-only) */}
         <div className="space-y-1.5">
           <label className="text-[13px] font-medium text-text block">Email</label>
-          <div className="flex items-center h-11 rounded-[10px] px-3.5 bg-[#F6F5F1] border border-[#2E2E2C14] text-sm text-text opacity-60">
+          <div className="flex h-11 items-center rounded-[10px] border border-border-input bg-surface-inset px-3.5 text-sm text-text opacity-60">
             {profile.email}
           </div>
         </div>
 
         {/* Notifications Section */}
-        <div className="pt-4 border-t border-[#2E2E2C0F]">
+        <div className="border-t border-border-subtle pt-4">
           <span className="tracking-[0.08em] text-text-muted text-[10px] font-mono font-medium opacity-50 uppercase">
             Notifications
           </span>
@@ -145,12 +145,12 @@ export function ProfileSettingsForm({ profile }: ProfileSettingsFormProps) {
         </div>
 
         {error && <p className="text-sm text-danger">{error}</p>}
-        {success && <p className="text-sm text-green-600">Profile updated.</p>}
+        {success && <p className="text-sm text-success">Profile updated.</p>}
 
         <button
           type="submit"
           disabled={loading}
-          className="rounded-lg py-2.5 px-6 bg-[#2E2E2C] text-white text-[13px] font-medium hover:bg-[#1E1E1C] transition-colors disabled:opacity-50"
+          className="rounded-lg bg-primary px-6 py-2.5 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
         >
           {loading ? "Saving..." : "Save changes"}
         </button>
@@ -171,7 +171,7 @@ function ToggleRow({
   onCheckedChange: (checked: boolean) => void;
 }) {
   return (
-    <div className="flex items-center justify-between py-3.5 border-b border-[#2E2E2C0F] last:border-b-0">
+    <div className="flex items-center justify-between border-b border-border-subtle py-3.5 last:border-b-0">
       <div>
         <p className="text-[13px] font-medium text-text">{label}</p>
         <p className="text-xs text-text-muted mt-0.5">{description}</p>

--- a/src/components/settings/project-general-form.tsx
+++ b/src/components/settings/project-general-form.tsx
@@ -98,7 +98,7 @@ export function ProjectGeneralForm({
             name="name"
             defaultValue={project.name}
             required
-            className="w-full h-11 rounded-[10px] px-3.5 bg-white border border-[#2E2E2C14] text-sm font-medium text-text focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors"
+            className="h-11 w-full rounded-[10px] border border-border-input bg-surface px-3.5 text-sm font-medium text-text transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
           />
         </div>
 
@@ -112,7 +112,7 @@ export function ProjectGeneralForm({
             name="description"
             defaultValue={project.description ?? ""}
             rows={3}
-            className="w-full rounded-[10px] py-3 px-3.5 bg-white border border-[#2E2E2C14] text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors resize-none"
+            className="w-full resize-none rounded-[10px] border border-border-input bg-surface py-3 px-3.5 text-sm text-text transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
           />
         </div>
 
@@ -125,7 +125,7 @@ export function ProjectGeneralForm({
             id="proj-lead"
             name="leadId"
             defaultValue={project.lead_id ?? ""}
-            className="w-full h-11 rounded-[10px] px-3.5 bg-white border border-[#2E2E2C14] text-sm font-medium text-text focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors"
+            className="h-11 w-full rounded-[10px] border border-border-input bg-surface px-3.5 text-sm font-medium text-text transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
           >
             <option value="">No lead</option>
             {members.map((m) => (
@@ -153,20 +153,20 @@ export function ProjectGeneralForm({
         </div>
 
         {error && <p className="text-sm text-danger">{error}</p>}
-        {success && <p className="text-sm text-green-600">Settings saved.</p>}
+        {success && <p className="text-sm text-success">Settings saved.</p>}
 
         <button
           type="submit"
           disabled={loading}
-          className="rounded-lg py-2.5 px-6 bg-[#2E2E2C] text-white text-[13px] font-medium hover:bg-[#1E1E1C] transition-colors disabled:opacity-50"
+          className="rounded-lg bg-primary px-6 py-2.5 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
         >
           {loading ? "Saving..." : "Save changes"}
         </button>
       </form>
 
       {/* Danger Zone */}
-      <div className="mt-12 pt-8 border-t border-[#2E2E2C0F]">
-        <span className="tracking-[0.08em] text-[#C45A3C] text-[10px] font-mono font-medium opacity-60 uppercase">
+      <div className="mt-12 border-t border-border-subtle pt-8">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-danger opacity-60">
           Danger Zone
         </span>
 
@@ -181,7 +181,7 @@ export function ProjectGeneralForm({
             <button
               type="button"
               onClick={handleArchive}
-              className="rounded-lg py-2 px-4 border border-[#2E2E2C14] text-[13px] font-medium text-text hover:bg-[#F6F5F1] transition-colors"
+              className="rounded-lg border border-border-input px-4 py-2 text-[13px] font-medium text-text transition-colors hover:bg-surface-hover"
             >
               Archive
             </button>
@@ -197,7 +197,7 @@ export function ProjectGeneralForm({
             <button
               type="button"
               onClick={() => setDeleteOpen(true)}
-              className="rounded-lg py-2 px-4 border border-[#8B404940] text-[13px] font-medium text-[#C45A3C] hover:bg-[#8B404908] transition-colors"
+              className="rounded-lg border border-danger-muted/40 px-4 py-2 text-[13px] font-medium text-danger transition-colors hover:bg-danger-muted/8"
             >
               Delete project
             </button>

--- a/src/components/settings/project-labels-editor.tsx
+++ b/src/components/settings/project-labels-editor.tsx
@@ -101,13 +101,13 @@ export function ProjectLabelsEditor({
           onChange={(e) => setNewName(e.target.value)}
           placeholder="Label name..."
           onKeyDown={(e) => e.key === "Enter" && handleAdd()}
-          className="flex-1 h-9 rounded-lg px-3 bg-white border border-[#2E2E2C14] text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors"
+          className="h-9 flex-1 rounded-lg border border-border-input bg-surface px-3 text-sm text-text transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
         />
         <button
           type="button"
           onClick={handleAdd}
           disabled={addLoading || !newName.trim()}
-          className="rounded-lg py-2 px-4 bg-[#2E2E2C] text-white text-[13px] font-medium hover:bg-[#1E1E1C] transition-colors disabled:opacity-50"
+          className="rounded-lg bg-primary px-4 py-2 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
         >
           {addLoading ? "Adding..." : "Add"}
         </button>
@@ -120,7 +120,7 @@ export function ProjectLabelsEditor({
         {labels.map((label) => (
           <div
             key={label.id}
-            className="flex items-center gap-3 py-2.5 px-3 rounded-lg hover:bg-[#F6F5F1] transition-colors group"
+            className="group flex items-center gap-3 rounded-lg py-2.5 px-3 transition-colors hover:bg-surface-hover"
           >
             {editingId === label.id ? (
               <>
@@ -140,7 +140,7 @@ export function ProjectLabelsEditor({
                   onChange={(e) => setEditName(e.target.value)}
                   onKeyDown={(e) => e.key === "Enter" && handleSaveEdit()}
                   autoFocus
-                  className="flex-1 h-8 rounded-md px-2 bg-white border border-[#2E2E2C14] text-sm text-text focus:outline-none"
+                  className="h-8 flex-1 rounded-md border border-border-input bg-surface px-2 text-sm text-text focus:outline-none"
                 />
                 <button
                   type="button"
@@ -176,7 +176,7 @@ export function ProjectLabelsEditor({
                 <button
                   type="button"
                   onClick={() => setDeletingLabel(label)}
-                  className="opacity-40 group-hover:opacity-100 transition-opacity text-text-muted hover:text-[#C45A3C]"
+                  className="text-text-muted opacity-40 transition-opacity group-hover:opacity-100 hover:text-danger"
                 >
                   <X className="size-3.5" />
                 </button>

--- a/src/components/settings/project-settings-client.tsx
+++ b/src/components/settings/project-settings-client.tsx
@@ -39,7 +39,7 @@ export function ProjectSettingsClient({
   return (
     <div className="flex h-full">
       {/* Settings sub-nav */}
-      <nav className="w-44 shrink-0 py-6 px-4 border-r border-[#2E2E2C]/6">
+      <nav className="w-44 shrink-0 border-r border-border-subtle py-6 px-4">
         <span className="text-[10px] font-mono font-medium text-text-muted opacity-40 tracking-[0.08em] uppercase">
           Project
         </span>

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -19,7 +19,7 @@ export function SettingsNav({ items, sectionLabel, basePath }: SettingsNavProps)
   const pathname = usePathname();
 
   return (
-    <nav className="w-50 shrink-0 py-6 px-5 border-r border-[#2E2E2C]/6">
+    <nav className="w-50 shrink-0 border-r border-border-subtle py-6 px-5">
       <span className="text-[10px] font-mono font-medium text-text-muted opacity-40 tracking-[0.08em] uppercase">
         {sectionLabel}
       </span>

--- a/src/components/settings/workspace-general-form.tsx
+++ b/src/components/settings/workspace-general-form.tsx
@@ -84,7 +84,7 @@ export function WorkspaceGeneralForm({ workspace }: WorkspaceGeneralFormProps) {
             id="ws-name"
             name="name"
             defaultValue={workspace.name}
-            className="w-full h-11 rounded-[10px] px-3.5 bg-white border border-[#2E2E2C14] text-sm font-medium text-text focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors"
+            className="h-11 w-full rounded-[10px] border border-border-input bg-surface px-3.5 text-sm font-medium text-text transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
           />
         </div>
 
@@ -93,7 +93,7 @@ export function WorkspaceGeneralForm({ workspace }: WorkspaceGeneralFormProps) {
           <label className="text-[13px] font-medium text-text block">
             Workspace URL
           </label>
-          <div className="flex items-center h-11 rounded-[10px] px-3.5 bg-[#F6F5F1] border border-[#2E2E2C14] text-sm text-text-muted">
+          <div className="flex h-11 items-center rounded-[10px] border border-border-input bg-surface-inset px-3.5 text-sm text-text-muted">
             flow.app/{workspace.slug}
           </div>
           <p className="text-[11px] text-text-muted opacity-60">
@@ -111,7 +111,7 @@ export function WorkspaceGeneralForm({ workspace }: WorkspaceGeneralFormProps) {
             name="issuePrefix"
             defaultValue={workspace.issue_prefix}
             maxLength={6}
-            className="w-32 h-11 rounded-[10px] px-3.5 bg-white border border-[#2E2E2C14] text-sm font-mono font-medium text-text uppercase focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors"
+            className="h-11 w-32 rounded-[10px] border border-border-input bg-surface px-3.5 font-mono text-sm font-medium text-text uppercase transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
           />
         </div>
 
@@ -124,7 +124,7 @@ export function WorkspaceGeneralForm({ workspace }: WorkspaceGeneralFormProps) {
             id="ws-tz"
             name="timezone"
             defaultValue={workspace.timezone}
-            className="w-full h-11 rounded-[10px] px-3.5 bg-white border border-[#2E2E2C14] text-sm font-medium text-text focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors"
+            className="h-11 w-full rounded-[10px] border border-border-input bg-surface px-3.5 text-sm font-medium text-text transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
           >
             {TIMEZONES.map((tz) => (
               <option key={tz} value={tz}>{tz}</option>
@@ -141,7 +141,7 @@ export function WorkspaceGeneralForm({ workspace }: WorkspaceGeneralFormProps) {
             id="ws-sprint"
             name="defaultSprintLength"
             defaultValue={workspace.default_sprint_length}
-            className="w-full h-11 rounded-[10px] px-3.5 bg-white border border-[#2E2E2C14] text-sm font-medium text-text focus:outline-none focus:ring-2 focus:ring-primary/10 transition-colors"
+            className="h-11 w-full rounded-[10px] border border-border-input bg-surface px-3.5 text-sm font-medium text-text transition-colors focus:outline-none focus:ring-2 focus:ring-primary/10"
           >
             {SPRINT_LENGTHS.map((sl) => (
               <option key={sl.value} value={sl.value}>{sl.label}</option>
@@ -150,20 +150,20 @@ export function WorkspaceGeneralForm({ workspace }: WorkspaceGeneralFormProps) {
         </div>
 
         {error && <p className="text-sm text-danger">{error}</p>}
-        {success && <p className="text-sm text-green-600">Settings saved.</p>}
+        {success && <p className="text-sm text-success">Settings saved.</p>}
 
         <button
           type="submit"
           disabled={loading}
-          className="rounded-lg py-2.5 px-6 bg-[#2E2E2C] text-white text-[13px] font-medium hover:bg-[#1E1E1C] transition-colors disabled:opacity-50"
+          className="rounded-lg bg-primary px-6 py-2.5 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
         >
           {loading ? "Saving..." : "Save changes"}
         </button>
       </form>
 
       {/* Danger Zone */}
-      <div className="mt-12 pt-8 border-t border-[#2E2E2C0F]">
-        <span className="tracking-[0.08em] text-[#C45A3C] text-[10px] font-mono font-medium opacity-60 uppercase">
+      <div className="mt-12 border-t border-border-subtle pt-8">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-danger opacity-60">
           Danger Zone
         </span>
         <div className="mt-4 flex items-center justify-between">
@@ -176,7 +176,7 @@ export function WorkspaceGeneralForm({ workspace }: WorkspaceGeneralFormProps) {
           <button
             type="button"
             onClick={() => setDeleteOpen(true)}
-            className="rounded-lg py-2 px-4 border border-[#8B404940] text-[13px] font-medium text-[#C45A3C] hover:bg-[#8B404908] transition-colors"
+            className="rounded-lg border border-danger-muted/40 px-4 py-2 text-[13px] font-medium text-danger transition-colors hover:bg-danger-muted/8"
           >
             Delete workspace
           </button>

--- a/src/components/sprints/sprint-planning-view.tsx
+++ b/src/components/sprints/sprint-planning-view.tsx
@@ -110,7 +110,7 @@ function DraggableIssueRow({ issue }: { issue: IssueWithDetails }) {
       ref={setNodeRef}
       style={style}
       className={cn(
-        "flex items-center gap-2.5 px-5 py-2.5 border-b border-[#F0EDE7] hover:bg-surface-hover/60 transition-colors cursor-grab active:cursor-grabbing",
+        "flex cursor-grab items-center gap-2.5 border-b border-border px-5 py-2.5 transition-colors hover:bg-surface-hover/60 active:cursor-grabbing",
         isDragging && "opacity-30",
       )}
       {...attributes}
@@ -127,15 +127,15 @@ function IssueRowContent({ issue }: { issue: IssueWithDetails }) {
   return (
     <>
       <svg width="10" height="10" viewBox="0 0 10 10" fill="none" className="shrink-0">
-        <circle cx="2" cy="2" r="1.2" fill="#C4C0BA" />
-        <circle cx="5" cy="2" r="1.2" fill="#C4C0BA" />
-        <circle cx="8" cy="2" r="1.2" fill="#C4C0BA" />
-        <circle cx="2" cy="5" r="1.2" fill="#C4C0BA" />
-        <circle cx="5" cy="5" r="1.2" fill="#C4C0BA" />
-        <circle cx="8" cy="5" r="1.2" fill="#C4C0BA" />
-        <circle cx="2" cy="8" r="1.2" fill="#C4C0BA" />
-        <circle cx="5" cy="8" r="1.2" fill="#C4C0BA" />
-        <circle cx="8" cy="8" r="1.2" fill="#C4C0BA" />
+        <circle cx="2" cy="2" r="1.2" fill="var(--color-text-muted)" />
+        <circle cx="5" cy="2" r="1.2" fill="var(--color-text-muted)" />
+        <circle cx="8" cy="2" r="1.2" fill="var(--color-text-muted)" />
+        <circle cx="2" cy="5" r="1.2" fill="var(--color-text-muted)" />
+        <circle cx="5" cy="5" r="1.2" fill="var(--color-text-muted)" />
+        <circle cx="8" cy="5" r="1.2" fill="var(--color-text-muted)" />
+        <circle cx="2" cy="8" r="1.2" fill="var(--color-text-muted)" />
+        <circle cx="5" cy="8" r="1.2" fill="var(--color-text-muted)" />
+        <circle cx="8" cy="8" r="1.2" fill="var(--color-text-muted)" />
       </svg>
       <span className="text-[11px] font-mono text-text-secondary shrink-0 w-13">
         {issue.issue_key}
@@ -148,7 +148,7 @@ function IssueRowContent({ issue }: { issue: IssueWithDetails }) {
         {priorityConfig.label}
       </span>
       {issue.assignee ? (
-        <div className="w-[22px] h-[22px] flex items-center justify-center shrink-0 rounded-full bg-[#E8E4DE]">
+        <div className="flex h-[22px] w-[22px] items-center justify-center shrink-0 rounded-full bg-avatar">
           <span className="text-[9px] font-semibold text-text-secondary">
             {getInitials(issue.assignee.full_name)}
           </span>
@@ -271,8 +271,12 @@ export function SprintPlanningView({
 
   // Sync local state when server re-renders with new sprint data
   useEffect(() => {
-    setBacklogIssues(initialBacklogIssues);
-    setSprintIssues(initialSprintIssues);
+    const syncFrame = window.requestAnimationFrame(() => {
+      setBacklogIssues(initialBacklogIssues);
+      setSprintIssues(initialSprintIssues);
+    });
+
+    return () => window.cancelAnimationFrame(syncFrame);
   }, [initialBacklogIssues, initialSprintIssues]);
 
   const sensors = useSensors(
@@ -494,8 +498,8 @@ export function SprintPlanningView({
       >
         <div className="flex flex-1 min-h-0 overflow-hidden pb-6 gap-4 px-10">
           {/* LEFT PANE — Backlog */}
-          <DroppablePane id="backlog" className="flex-1 rounded-xl border border-[#E8E4DE] bg-white overflow-hidden">
-            <div className="px-5 pt-4 pb-3 border-b border-[#E8E4DE]">
+          <DroppablePane id="backlog" className="flex-1 overflow-hidden rounded-xl border border-border bg-surface">
+            <div className="border-b border-border px-5 pt-4 pb-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-baseline gap-2">
                   <h2 className="text-[15px] font-semibold text-text">Backlog</h2>
@@ -567,10 +571,10 @@ export function SprintPlanningView({
           </DroppablePane>
 
           {/* RIGHT PANE — Sprint (warm tint) */}
-          <DroppablePane id="sprint" className="flex-1 rounded-r-xl border border-[#E8E4DE] border-l-2 border-l-[#C17B5A] bg-[#FDFBF8] overflow-hidden">
+          <DroppablePane id="sprint" className="flex-1 overflow-hidden rounded-r-xl border border-border border-l-2 border-l-accent bg-surface">
             {sprint ? (
               <>
-                <div className="px-5 pt-4 pb-3.5 border-b border-[#E8E4DE]">
+                <div className="border-b border-border px-5 pt-4 pb-3.5">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-1.5">
                       <DropdownMenu>
@@ -694,13 +698,13 @@ export function SprintPlanningView({
 
                   {/* Capacity bar */}
                   {(sprint.capacity ?? sprintPoints) > 0 && (
-                    <div className="mt-3 h-1.5 w-full rounded-[3px] bg-[#F0EDE7] overflow-hidden">
+                    <div className="mt-3 h-1.5 w-full overflow-hidden rounded-[3px] bg-surface-inset">
                       <div
                         className={cn(
                           "h-full rounded-[3px] transition-all",
                           sprint.capacity && sprintPoints > sprint.capacity
                             ? "bg-danger"
-                            : "bg-[#C17B5A]",
+                            : "bg-accent",
                         )}
                         style={{
                           width: `${Math.min(100, (sprintPoints / (sprint.capacity ?? sprintPoints)) * 100)}%`,
@@ -742,14 +746,14 @@ export function SprintPlanningView({
                   ))}
 
                   {/* Drop zone placeholder */}
-                  <div className="flex items-center justify-center flex-1 min-h-20 mx-5 my-3 rounded-lg border-2 border-dashed border-[#E8E4DE] text-xs text-[#C4C0BA]">
+                  <div className="mx-5 my-3 flex min-h-20 flex-1 items-center justify-center rounded-lg border-2 border-dashed border-border text-xs text-text-muted">
                     Drag issues here from backlog
                   </div>
                 </div>
 
                 {/* Team Load — per-person progress bars */}
                 {teamLoad.length > 0 && (
-                  <div className="border-t border-[#E8E4DE] px-5 py-3.5">
+                  <div className="border-t border-border px-5 py-3.5">
                     <div className="flex items-center justify-between mb-2.5">
                       <span className="text-[11px] font-medium uppercase tracking-[0.05em] text-text-secondary">
                         Team Load
@@ -761,14 +765,14 @@ export function SprintPlanningView({
                     <div className="flex flex-col gap-2">
                       {teamLoad.map((entry) => (
                         <div key={entry.userId} className="flex items-center gap-2">
-                          <div className="w-[22px] h-[22px] flex items-center justify-center shrink-0 rounded-full bg-[#E8E4DE]">
+                          <div className="flex h-[22px] w-[22px] items-center justify-center shrink-0 rounded-full bg-avatar">
                             <span className="text-[9px] font-semibold text-text-secondary">
                               {getInitials(entry.fullName)}
                             </span>
                           </div>
-                          <div className="flex-1 h-1.5 rounded-[3px] bg-[#F0EDE7] overflow-hidden">
+                          <div className="flex-1 h-1.5 overflow-hidden rounded-[3px] bg-surface-inset">
                             <div
-                              className="h-full rounded-[3px] bg-[#C17B5A] transition-all"
+                              className="h-full rounded-[3px] bg-accent transition-all"
                               style={{
                                 width: `${(entry.points / maxTeamPoints) * 100}%`,
                               }}

--- a/src/components/teams/team-card.tsx
+++ b/src/components/teams/team-card.tsx
@@ -6,7 +6,7 @@ export function TeamCard({ team }: { team: TeamWithMembers }) {
   const initial = team.name.charAt(0).toUpperCase();
 
   return (
-    <div className="flex flex-col rounded-2xl overflow-clip bg-white border border-[#2E2E2C]/8">
+    <div className="flex flex-col overflow-clip rounded-2xl border border-border-input bg-surface">
       <div className="flex items-center justify-between py-4.5 px-6 bg-muted/30">
         <div className="flex items-center gap-3">
           <Avatar size="sm" className="shrink-0 size-8">
@@ -23,7 +23,7 @@ export function TeamCard({ team }: { team: TeamWithMembers }) {
             </span>
           </div>
         </div>
-        <span className="text-xs font-medium font-mono text-[#8B4049]">
+        <span className="text-xs font-medium font-mono text-danger-muted">
           {team.activeIssueCount} active {team.activeIssueCount === 1 ? "issue" : "issues"}
         </span>
       </div>

--- a/src/components/timeline/timeline-view.tsx
+++ b/src/components/timeline/timeline-view.tsx
@@ -58,7 +58,7 @@ export function TimelineView({ issues }: { issues: TimelineIssue[] }) {
             className={cn(
               "px-3 py-1.5 rounded-lg text-xs font-medium transition-colors",
               scale === s
-                ? "bg-primary text-white"
+                ? "bg-primary text-background"
                 : "text-text-secondary hover:bg-surface-hover"
             )}
           >
@@ -83,7 +83,7 @@ export function TimelineView({ issues }: { issues: TimelineIssue[] }) {
                 key={issue.id}
                 className={cn(
                   "flex items-center gap-2 px-4 border-b border-border/20",
-                  i % 2 === 1 && "bg-[#F0EDE7]/50"
+                  i % 2 === 1 && "bg-surface-inset/50"
                 )}
                 style={{ height: ROW_HEIGHT }}
               >
@@ -166,7 +166,7 @@ export function TimelineView({ issues }: { issues: TimelineIssue[] }) {
                 i % 2 === 1 ? (
                   <div
                     key={`row-bg-${i}`}
-                    className="absolute left-0 w-full bg-[#F0EDE7]/50"
+                    className="absolute left-0 w-full bg-surface-inset/50"
                     style={{
                       top: i * ROW_HEIGHT,
                       height: ROW_HEIGHT,
@@ -183,7 +183,7 @@ export function TimelineView({ issues }: { issues: TimelineIssue[] }) {
                     left: (todayCol - 1) * colWidth + colWidth / 2,
                   }}
                 >
-                  <div className="absolute -top-0 left-1/2 -translate-x-1/2 bg-primary text-white text-[9px] font-mono font-semibold px-1.5 py-0.5 rounded-b">
+                  <div className="absolute -top-0 left-1/2 -translate-x-1/2 rounded-b bg-primary px-1.5 py-0.5 font-mono text-[9px] font-semibold text-background">
                     TODAY
                   </div>
                 </div>
@@ -243,7 +243,7 @@ export function TimelineView({ issues }: { issues: TimelineIssue[] }) {
                       />
                       {issue.assignee && initials && (
                         <div
-                          className="relative z-10 size-5 rounded-full bg-white/90 flex items-center justify-center shrink-0"
+                          className="relative z-10 flex size-5 shrink-0 items-center justify-center rounded-full bg-surface/90"
                           title={
                             issue.assignee.full_name ?? undefined
                           }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils/cn";
 
 const buttonVariants = {
   variant: {
-    default: "bg-primary text-white hover:bg-primary-hover",
+    default: "bg-primary text-background hover:bg-primary-hover",
     secondary: "bg-surface border border-border text-text hover:bg-surface-hover",
     ghost: "bg-transparent text-text hover:bg-surface-hover",
     danger: "bg-danger text-white hover:bg-danger/90",

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -12,7 +12,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded border border-border ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-white",
+      "peer h-4 w-4 shrink-0 rounded border border-border ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-background",
       className,
     )}
     {...props}

--- a/src/components/ui/delete-confirmation-modal.tsx
+++ b/src/components/ui/delete-confirmation-modal.tsx
@@ -30,10 +30,10 @@ export function DeleteConfirmationModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogPortal>
         <DialogOverlay />
-        <DialogPrimitive.Content className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[420px] rounded-2xl bg-white pt-8 pb-6 px-8 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+        <DialogPrimitive.Content className="fixed left-1/2 top-1/2 z-50 w-[420px] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border-input bg-surface px-8 pt-8 pb-6 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
           <div className="flex flex-col items-center gap-5">
             {/* Warning icon */}
-            <div className="size-10 rounded-full bg-[#8B404918] flex items-center justify-center">
+            <div className="flex size-10 items-center justify-center rounded-full bg-danger-muted/10">
               <svg
                 width="18"
                 height="18"
@@ -41,19 +41,19 @@ export function DeleteConfirmationModal({
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <circle cx="9" cy="9" r="7.5" stroke="#C45A3C" strokeWidth="1.5" />
-                <path d="M9 5V10" stroke="#C45A3C" strokeWidth="1.5" strokeLinecap="round" />
-                <path d="M9 12.5V13" stroke="#C45A3C" strokeWidth="1.5" strokeLinecap="round" />
+                <circle cx="9" cy="9" r="7.5" stroke="var(--color-danger)" strokeWidth="1.5" />
+                <path d="M9 5V10" stroke="var(--color-danger)" strokeWidth="1.5" strokeLinecap="round" />
+                <path d="M9 12.5V13" stroke="var(--color-danger)" strokeWidth="1.5" strokeLinecap="round" />
               </svg>
             </div>
 
             {/* Title */}
-            <DialogPrimitive.Title className="text-[17px]/5.5 font-semibold text-[#2E2E2C] text-center">
+            <DialogPrimitive.Title className="text-center text-[17px]/5.5 font-semibold text-text">
               {title}
             </DialogPrimitive.Title>
 
             {/* Description */}
-            <DialogPrimitive.Description className="text-center text-[13px]/5 text-[#A3A39E] opacity-60 -mt-2">
+            <DialogPrimitive.Description className="-mt-2 text-center text-[13px]/5 text-text-muted">
               {description}
             </DialogPrimitive.Description>
 
@@ -63,7 +63,7 @@ export function DeleteConfirmationModal({
                 type="button"
                 onClick={() => onOpenChange(false)}
                 disabled={loading}
-                className="flex-1 rounded-lg py-2.5 px-5 border border-[#2E2E2C14] text-[13px] font-medium text-[#2E2E2C] hover:bg-[#F6F5F1] transition-colors disabled:opacity-50"
+                className="flex-1 rounded-lg border border-border-input px-5 py-2.5 text-[13px] font-medium text-text transition-colors hover:bg-surface-hover disabled:opacity-50"
               >
                 Cancel
               </button>
@@ -71,7 +71,7 @@ export function DeleteConfirmationModal({
                 type="button"
                 onClick={onConfirm}
                 disabled={loading}
-                className="flex-1 rounded-lg py-2.5 px-5 bg-[#8B4049] text-[13px] font-medium text-white hover:bg-[#7A3640] transition-colors disabled:opacity-50"
+                className="flex-1 rounded-lg bg-danger-muted px-5 py-2.5 text-[13px] font-medium text-white transition-colors hover:bg-danger-muted-hover disabled:opacity-50"
               >
                 {loading ? "Deleting..." : confirmLabel}
               </button>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-overlay backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -19,7 +19,7 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-24">
-      <div className="size-16 rounded-full bg-[#2E2E2C14] flex items-center justify-center mb-5">
+      <div className="mb-5 flex size-16 items-center justify-center rounded-full bg-border-input">
         <Icon className="size-7 text-text-muted opacity-20" />
       </div>
       <h3 className="text-[17px] font-semibold text-text mb-1">{title}</h3>
@@ -30,12 +30,12 @@ export function EmptyState({
         <>
           <button
             onClick={onAction}
-            className="rounded-lg py-2.5 px-6 bg-[#2E2E2C] text-white text-[13px] font-medium hover:bg-[#1E1E1C] transition-colors"
+            className="rounded-lg bg-primary px-6 py-2.5 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover"
           >
             {actionLabel}
           </button>
           {secondaryLabel && (
-            <p className="text-xs text-[#6B6B60] mt-3">{secondaryLabel}</p>
+            <p className="mt-3 text-xs text-text-muted">{secondaryLabel}</p>
           )}
         </>
       )}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -17,7 +17,7 @@ const SheetOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/20 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -18,7 +18,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitive.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
       )}
     />
   </SwitchPrimitive.Root>

--- a/src/components/ui/theme-toaster.tsx
+++ b/src/components/ui/theme-toaster.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { Toaster } from "sonner";
+import { useTheme } from "@/providers/theme-provider";
+
+export function ThemeToaster() {
+  const { resolvedTheme } = useTheme();
+
+  return <Toaster position="bottom-right" theme={resolvedTheme} />;
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -17,7 +17,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-2 py-1 text-xs text-white shadow-lg animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 overflow-hidden rounded-md bg-primary px-2 py-1 text-xs text-background shadow-lg animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/src/components/views/view-card.tsx
+++ b/src/components/views/view-card.tsx
@@ -66,7 +66,7 @@ export function ViewCard({
   return (
     <Link
       href={`/${workspaceSlug}/views/${view.id}`}
-      className="flex flex-col rounded-xl bg-white border border-border/50 p-5 gap-2 hover:border-border transition-colors"
+      className="flex flex-col gap-2 rounded-xl border border-border-input bg-surface p-5 transition-colors hover:border-border"
       style={{ borderLeftWidth: "4px", borderLeftColor: borderColor }}
     >
       <div className="flex items-start justify-between">

--- a/src/components/views/view-issue-table.tsx
+++ b/src/components/views/view-issue-table.tsx
@@ -14,7 +14,7 @@ export function ViewIssueTable({ issues }: { issues: IssueWithDetails[] }) {
   }
 
   return (
-    <div className="border border-border/50 rounded-xl overflow-hidden bg-white">
+    <div className="overflow-hidden rounded-xl border border-border-input bg-surface">
       <table className="w-full">
         <thead>
           <tr className="border-b border-border/50">

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,39 @@
+export type ThemeMode = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "flow-theme";
+export const THEME_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+
+export function isThemeMode(value: string | null): value is ThemeMode {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+export function resolveTheme(
+  theme: ThemeMode,
+  prefersDark: boolean,
+): ResolvedTheme {
+  if (theme === "system") {
+    return prefersDark ? "dark" : "light";
+  }
+
+  return theme;
+}
+
+export function getThemeScript() {
+  return `(() => {
+    const storageKey = ${JSON.stringify(THEME_STORAGE_KEY)};
+    const mediaQuery = ${JSON.stringify(THEME_MEDIA_QUERY)};
+    const root = document.documentElement;
+    const stored = window.localStorage.getItem(storageKey);
+    const theme =
+      stored === "light" || stored === "dark" || stored === "system"
+        ? stored
+        : "system";
+    const prefersDark = window.matchMedia(mediaQuery).matches;
+    const resolved =
+      theme === "system" ? (prefersDark ? "dark" : "light") : theme;
+
+    root.classList.toggle("dark", resolved === "dark");
+    root.style.colorScheme = resolved;
+  })();`;
+}

--- a/src/lib/utils/priorities.ts
+++ b/src/lib/utils/priorities.ts
@@ -4,8 +4,8 @@ export const PRIORITY_CONFIG: Record<
   IssuePriority,
   { label: string; color: string; bgColor: string }
 > = {
-  0: { label: "P0", color: "#DC2626", bgColor: "#FEF2F2" },
-  1: { label: "P1", color: "#D97706", bgColor: "#FFFBEB" },
-  2: { label: "P2", color: "#16A34A", bgColor: "#F0FDF4" },
-  3: { label: "P3", color: "#78716C", bgColor: "#F5F0EB" },
+  0: { label: "P0", color: "var(--color-danger)", bgColor: "var(--color-danger-light)" },
+  1: { label: "P1", color: "var(--color-warning)", bgColor: "var(--color-warning-light)" },
+  2: { label: "P2", color: "var(--color-success)", bgColor: "var(--color-success-light)" },
+  3: { label: "P3", color: "var(--color-text-secondary)", bgColor: "var(--color-surface-hover)" },
 };

--- a/src/lib/utils/statuses.ts
+++ b/src/lib/utils/statuses.ts
@@ -4,10 +4,10 @@ export const STATUS_CONFIG: Record<
   IssueStatus,
   { label: string; color: string; bgColor: string }
 > = {
-  todo: { label: "Todo", color: "#78716C", bgColor: "#F5F0EB" },
-  in_progress: { label: "In Progress", color: "#D97706", bgColor: "#FFFBEB" },
-  in_review: { label: "In Review", color: "#7C3AED", bgColor: "#F5F3FF" },
-  done: { label: "Done", color: "#16A34A", bgColor: "#F0FDF4" },
+  todo: { label: "Todo", color: "var(--color-text-secondary)", bgColor: "var(--color-surface-hover)" },
+  in_progress: { label: "In Progress", color: "var(--color-accent)", bgColor: "var(--color-accent-light)" },
+  in_review: { label: "In Review", color: "var(--color-purple)", bgColor: "var(--color-purple-light)" },
+  done: { label: "Done", color: "var(--color-success)", bgColor: "var(--color-success-light)" },
 };
 
 export const STATUS_ORDER: IssueStatus[] = [

--- a/src/providers/theme-provider.tsx
+++ b/src/providers/theme-provider.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import {
+  isThemeMode,
+  resolveTheme,
+  THEME_MEDIA_QUERY,
+  THEME_STORAGE_KEY,
+  type ResolvedTheme,
+  type ThemeMode,
+} from "@/lib/theme";
+
+interface ThemeContextValue {
+  theme: ThemeMode;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: ThemeMode) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getStoredTheme(): ThemeMode {
+  if (typeof window === "undefined") {
+    return "system";
+  }
+
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return isThemeMode(stored) ? stored : "system";
+}
+
+function applyTheme(theme: ThemeMode) {
+  const root = document.documentElement;
+  const prefersDark = window.matchMedia(THEME_MEDIA_QUERY).matches;
+  const resolved = resolveTheme(theme, prefersDark);
+
+  root.classList.toggle("dark", resolved === "dark");
+  root.style.colorScheme = resolved;
+
+  return resolved;
+}
+
+export function ThemeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [theme, setTheme] = useState<ThemeMode>(() => getStoredTheme());
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => {
+    if (typeof document === "undefined") {
+      return "light";
+    }
+
+    return document.documentElement.classList.contains("dark") ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(THEME_MEDIA_QUERY);
+
+    const syncTheme = () => {
+      setResolvedTheme(applyTheme(theme));
+    };
+
+    syncTheme();
+
+    if (theme === "system") {
+      mediaQuery.addEventListener("change", syncTheme);
+      return () => mediaQuery.removeEventListener("change", syncTheme);
+    }
+
+    return undefined;
+  }, [theme]);
+
+  useEffect(() => {
+    if (theme === "system") {
+      window.localStorage.removeItem(THEME_STORAGE_KEY);
+      return;
+    }
+
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        theme,
+        resolvedTheme,
+        setTheme,
+        toggleTheme: () => setTheme(resolvedTheme === "dark" ? "light" : "dark"),
+      }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+
+  return context;
+}


### PR DESCRIPTION
## Summary
- add app-wide light/dark/system theme plumbing with a no-flash bootstrap and header theme toggle
- map the warm dark palette into the global theme tokens and update shared shell, cards, forms, modals, charts, and issue surfaces to use them
- polish authenticated pages and auth flows so dashboard, board, analytics, my issues, settings, and related UI render consistently in dark mode

## Verification
- targeted eslint on the new theme bootstrap files
- Playwright verification on dashboard, board, analytics, my issues, and settings/general in dark mode
- fresh browser console check with no errors on the verified session