### PR TITLE
Implement Teams Collaboration Hub

### DIFF
--- a/src/app/(app)/[workspaceSlug]/teams/[teamId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/teams/[teamId]/page.tsx
@@ -1,0 +1,82 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { enrichIssues } from "@/lib/queries/issues";
+import { getWorkspaceBySlug } from "@/lib/queries/workspaces";
+import { getWorkspaceMembers } from "@/lib/queries/members";
+import {
+  getTeamActivities,
+  getTeamById,
+  getTeamIssues,
+  getTeamProjects,
+} from "@/lib/queries/teams";
+import type { IssueWithDetails } from "@/lib/queries/issues";
+import { TeamDetailClient } from "@/components/teams/team-detail-client";
+
+export default async function TeamDetailPage({
+  params,
+}: {
+  params: Promise<{ workspaceSlug: string; teamId: string }>;
+}) {
+  const { workspaceSlug, teamId } = await params;
+
+  const result = await getWorkspaceBySlug(workspaceSlug);
+  if (!result?.workspace) {
+    notFound();
+  }
+
+  const workspace = result.workspace;
+
+  const [team, issues, activities, projects, workspaceMembers] = await Promise.all([
+    getTeamById(teamId),
+    getTeamIssues(teamId),
+    getTeamActivities(teamId),
+    getTeamProjects(teamId),
+    getWorkspaceMembers(workspace.id),
+  ]);
+
+  if (!team || team.workspace_id !== workspace.id) {
+    notFound();
+  }
+
+  const activityIssueMap: Record<string, IssueWithDetails> = {};
+  for (const issue of issues) {
+    activityIssueMap[issue.id] = issue;
+  }
+
+  const missingIssueIds = [
+    ...new Set(
+      activities
+        .filter((activity) => activity.entity_type === "issue" && activity.action !== "deleted")
+        .map((activity) => activity.entity_id)
+    ),
+  ].filter((issueId) => !activityIssueMap[issueId]);
+
+  if (missingIssueIds.length > 0) {
+    const supabase = await createClient();
+    const { data: rawIssues } = await supabase
+      .from("issues")
+      .select("*")
+      .in("id", missingIssueIds);
+
+    if (rawIssues && rawIssues.length > 0) {
+      const enriched = await enrichIssues(rawIssues, supabase);
+      for (const issue of enriched) {
+        activityIssueMap[issue.id] = issue;
+      }
+    }
+  }
+
+  return (
+    <TeamDetailClient
+      workspaceName={workspace.name}
+      workspaceSlug={workspaceSlug}
+      team={team}
+      issues={issues}
+      activities={activities}
+      activityIssueMap={activityIssueMap}
+      projects={projects}
+      workspaceMembers={workspaceMembers}
+      canManageTeams={result.role !== "member"}
+    />
+  );
+}

--- a/src/app/(app)/[workspaceSlug]/teams/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/teams/page.tsx
@@ -1,11 +1,9 @@
 import { notFound } from "next/navigation";
-import { Users } from "lucide-react";
 import { getWorkspaceBySlug } from "@/lib/queries/workspaces";
 import { getTeamsWithMembers } from "@/lib/queries/teams";
-import { TeamsList } from "@/components/teams/teams-list";
-import { EmptyState } from "@/components/ui/empty-state";
+import { getWorkspaceMembers } from "@/lib/queries/members";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
-import { InviteMemberButton } from "@/components/teams/invite-member-button";
+import { TeamsPageClient } from "@/components/teams/teams-page-client";
 
 export default async function TeamsPage({
   params,
@@ -16,26 +14,21 @@ export default async function TeamsPage({
   const result = await getWorkspaceBySlug(workspaceSlug);
   if (!result?.workspace) notFound();
 
-  const teams = await getTeamsWithMembers(result.workspace.id);
+  const [teams, workspaceMembers] = await Promise.all([
+    getTeamsWithMembers(result.workspace.id),
+    getWorkspaceMembers(result.workspace.id),
+  ]);
 
   return (
     <div className="flex flex-col py-6 px-8 gap-5">
       <Breadcrumb workspaceName={result.workspace.name} pageName="Teams" />
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold tracking-[-0.02em] text-text">
-          Teams
-        </h1>
-        <InviteMemberButton workspaceId={result.workspace.id} />
-      </div>
-      {teams.length > 0 ? (
-        <TeamsList teams={teams} />
-      ) : (
-        <EmptyState
-          icon={Users}
-          title="No teams yet"
-          description="Create teams to organize your workspace members."
-        />
-      )}
+      <TeamsPageClient
+        teams={teams}
+        workspaceId={result.workspace.id}
+        workspaceSlug={workspaceSlug}
+        workspaceMembers={workspaceMembers}
+        canManageTeams={result.role !== "member"}
+      />
     </div>
   );
 }

--- a/src/components/dashboard/recent-activity-card.tsx
+++ b/src/components/dashboard/recent-activity-card.tsx
@@ -36,23 +36,29 @@ interface RecentActivityCardProps {
   activities: ActivityWithActor[];
   workspaceSlug: string;
   onIssueClick?: (id: string) => void;
+  title?: string;
+  showInboxLink?: boolean;
 }
 
 export function RecentActivityCard({
   activities,
   workspaceSlug,
   onIssueClick,
+  title = "Recent Activity",
+  showInboxLink = true,
 }: RecentActivityCardProps) {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold text-text">Recent Activity</h2>
-        <Link
-          href={`/${workspaceSlug}/inbox`}
-          className="text-[13px] font-medium text-text-secondary hover:text-text transition-colors"
-        >
-          Inbox &rarr;
-        </Link>
+        <h2 className="text-base font-semibold text-text">{title}</h2>
+        {showInboxLink && (
+          <Link
+            href={`/${workspaceSlug}/inbox`}
+            className="text-[13px] font-medium text-text-secondary hover:text-text transition-colors"
+          >
+            Inbox &rarr;
+          </Link>
+        )}
       </div>
 
       {activities.length === 0 ? (

--- a/src/components/issues/create-issue-modal.tsx
+++ b/src/components/issues/create-issue-modal.tsx
@@ -20,6 +20,10 @@ import { cn } from "@/lib/utils/cn";
 import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { STATUS_CONFIG, STATUS_ORDER } from "@/lib/utils/statuses";
 import type { IssuePriority, IssueStatus } from "@/lib/types";
+import {
+  dedupeMembersByDisplayLabel,
+  dedupeMembersByUserId,
+} from "@/lib/utils/members";
 
 interface CreateIssueModalProps {
   open: boolean;
@@ -140,6 +144,10 @@ export function CreateIssueModal({
   const filteredLabels = labels.filter((l) => {
     return !selectedProjectId || !l.project_id || l.project_id === selectedProjectId;
   });
+  const uniqueMembers = dedupeMembersByDisplayLabel(
+    dedupeMembersByUserId(members),
+    defaultAssigneeId
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -188,7 +196,7 @@ export function CreateIssueModal({
                   defaultValue={defaultAssigneeId ?? ""}
                 >
                   <option value="">Unassigned</option>
-                  {members.map((m) => (
+                  {uniqueMembers.map((m) => (
                     <option key={m.user_id} value={m.user_id}>
                       {m.profile.full_name ?? m.profile.email}
                     </option>

--- a/src/components/issues/issue-detail-panel.tsx
+++ b/src/components/issues/issue-detail-panel.tsx
@@ -22,6 +22,10 @@ import type { ChecklistItem } from "./issue-checklist";
 import type { IssueWithDetails } from "@/lib/queries/issues";
 import type { IssuePriority, IssueStatus } from "@/lib/types";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import {
+  dedupeMembersByDisplayLabel,
+  dedupeMembersByUserId,
+} from "@/lib/utils/members";
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -61,8 +65,11 @@ export function IssueDetailPanel({
   const [saving, setSaving] = useState(false);
 
   // Track current issue id to avoid stale saves
-  const issueRef = useRef(issue);
-  issueRef.current = issue;
+  const issueRef = useRef<IssueWithDetails | null>(issue);
+
+  useEffect(() => {
+    issueRef.current = issue;
+  }, [issue]);
 
   // ── Sync state from issue prop ─────────────────────────────
   useEffect(() => {
@@ -117,6 +124,15 @@ export function IssueDetailPanel({
     [router]
   );
 
+  // ── Copy permalink ─────────────────────────────────────────
+  const copyPermalink = useCallback(() => {
+    if (!issue) return;
+    const url = `${window.location.origin}${pathname}?issue=${issue.issue_key}`;
+    navigator.clipboard.writeText(url).then(() => {
+      toast.success("Link copied");
+    });
+  }, [issue, pathname]);
+
   // ── Keyboard shortcuts ─────────────────────────────────────
   useEffect(() => {
     if (!open) return;
@@ -162,18 +178,14 @@ export function IssueDetailPanel({
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, save]);
-
-  // ── Copy permalink ─────────────────────────────────────────
-  const copyPermalink = useCallback(() => {
-    if (!issue) return;
-    const url = `${window.location.origin}${pathname}?issue=${issue.issue_key}`;
-    navigator.clipboard.writeText(url).then(() => {
-      toast.success("Link copied");
-    });
-  }, [issue, pathname]);
+  }, [open, save, copyPermalink]);
 
   if (!issue) return null;
+
+  const uniqueMembers = dedupeMembersByDisplayLabel(
+    dedupeMembersByUserId(members),
+    assigneeId
+  );
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -363,7 +375,7 @@ export function IssueDetailPanel({
                   className="flex h-8 w-full rounded-lg border border-border bg-surface px-2.5 text-xs text-text focus:outline-none focus:ring-2 focus:ring-primary/10 focus:border-border-strong transition-colors"
                 >
                   <option value="">Unassigned</option>
-                  {members.map((m) => (
+                  {uniqueMembers.map((m) => (
                     <option key={m.user_id} value={m.user_id}>
                       {m.profile.full_name ?? m.profile.email}
                     </option>

--- a/src/components/teams/add-team-member-combobox.tsx
+++ b/src/components/teams/add-team-member-combobox.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import * as Popover from "@radix-ui/react-popover";
+import { ChevronDown, Plus } from "lucide-react";
+import type { WorkspaceMember } from "@/lib/queries/members";
+import { getInitials } from "@/lib/utils/format";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface AddTeamMemberComboboxProps {
+  members: WorkspaceMember[];
+  disabled?: boolean;
+  onSelect: (userId: string) => Promise<void> | void;
+}
+
+export function AddTeamMemberCombobox({
+  members,
+  disabled = false,
+  onSelect,
+}: AddTeamMemberComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const filteredMembers = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return members;
+
+    return members.filter((member) => {
+      const nameMatch = member.profile.full_name?.toLowerCase().includes(trimmed);
+      const emailMatch = member.profile.email.toLowerCase().includes(trimmed);
+      return nameMatch || emailMatch;
+    });
+  }, [members, query]);
+
+  async function handleSelect(userId: string) {
+    await onSelect(userId);
+    setOpen(false);
+    setQuery("");
+  }
+
+  return (
+    <Popover.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+          setQuery("");
+        }
+      }}
+    >
+      <Popover.Trigger asChild>
+        <Button variant="secondary" disabled={disabled || members.length === 0}>
+          <Plus className="h-4 w-4" />
+          Add member
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+      </Popover.Trigger>
+
+      <Popover.Portal>
+        <Popover.Content
+          side="bottom"
+          align="end"
+          sideOffset={8}
+          className="z-50 w-[320px] rounded-xl border border-border bg-surface p-3 shadow-xl"
+        >
+          <div className="space-y-3">
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search workspace members..."
+            />
+
+            <div className="max-h-72 overflow-y-auto rounded-lg border border-border-subtle">
+              {filteredMembers.length === 0 ? (
+                <div className="px-3 py-5 text-sm text-text-muted">
+                  No members available.
+                </div>
+              ) : (
+                <div className="divide-y divide-border-subtle">
+                  {filteredMembers.map((member) => (
+                    <button
+                      key={member.user_id}
+                      type="button"
+                      onClick={() => handleSelect(member.user_id)}
+                      className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-surface-hover"
+                    >
+                      <Avatar size="sm">
+                        <AvatarImage
+                          src={member.profile.avatar_url ?? undefined}
+                          alt={member.profile.full_name ?? member.profile.email}
+                        />
+                        <AvatarFallback>
+                          {getInitials(
+                            member.profile.full_name,
+                            member.profile.email
+                          )}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-text">
+                          {member.profile.full_name ?? member.profile.email}
+                        </p>
+                        <p className="truncate text-xs text-text-muted">
+                          {member.profile.email}
+                        </p>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/src/components/teams/team-card.tsx
+++ b/src/components/teams/team-card.tsx
@@ -1,35 +1,186 @@
-import type { TeamWithMembers } from "@/lib/queries/teams";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { TeamMemberRow } from "./team-member-row";
+"use client";
 
-export function TeamCard({ team }: { team: TeamWithMembers }) {
-  const initial = team.name.charAt(0).toUpperCase();
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import type { TeamWithMembers } from "@/lib/queries/teams";
+import { deleteTeam } from "@/lib/actions/teams";
+import { getInitials } from "@/lib/utils/format";
+import { STATUS_ORDER, STATUS_CONFIG } from "@/lib/utils/statuses";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { DeleteConfirmationModal } from "@/components/ui/delete-confirmation-modal";
+import { TeamFormModal } from "@/components/teams/team-form-modal";
+
+interface TeamCardProps {
+  team: TeamWithMembers;
+  workspaceSlug: string;
+  canManageTeams: boolean;
+}
+
+export function TeamCard({
+  team,
+  workspaceSlug,
+  canManageTeams,
+}: TeamCardProps) {
+  const router = useRouter();
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const totalIssues = Object.values(team.issueCounts).reduce((sum, count) => sum + count, 0);
+
+  async function handleDelete() {
+    setDeleting(true);
+    const result = await deleteTeam(team.id);
+    setDeleting(false);
+
+    if (result.error) {
+      toast.error(result.error);
+      return;
+    }
+
+    toast.success("Team deleted");
+    setDeleteOpen(false);
+    router.refresh();
+  }
 
   return (
-    <div className="flex flex-col overflow-clip rounded-2xl border border-border-input bg-surface">
-      <div className="flex items-center justify-between py-4.5 px-6 bg-muted/30">
-        <div className="flex items-center gap-3">
-          <Avatar size="sm" className="shrink-0 size-8">
-            <AvatarFallback className="text-[13px] font-semibold">
-              {initial}
-            </AvatarFallback>
-          </Avatar>
-          <div className="flex flex-col gap-px">
-            <span className="text-base font-semibold text-text">
-              {team.name}
-            </span>
-            <span className="text-[11px] text-text font-mono opacity-30">
-              {team.members.length} {team.members.length === 1 ? "member" : "members"}
-            </span>
+    <>
+      <div className="relative">
+        <button
+          type="button"
+          aria-label={`Open ${team.name}`}
+          onClick={() => router.push(`/${workspaceSlug}/teams/${team.id}`)}
+          className="w-full cursor-pointer rounded-[22px] border border-border bg-surface p-5 text-left transition-colors hover:bg-surface-hover/60"
+        >
+          <div className="pr-10">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold text-text">{team.name}</h2>
+                <p className="mt-1 text-xs font-mono text-text-muted">
+                  {team.members.length} {team.members.length === 1 ? "member" : "members"}
+                </p>
+              </div>
+              <span className="rounded-full bg-surface-hover px-2.5 py-1 text-[11px] font-mono text-text-muted">
+                {team.activeIssueCount} active
+              </span>
+            </div>
+
+            <div className="mt-5 flex items-center gap-2">
+              <div className="flex items-center">
+                {team.members.slice(0, 5).map((member, index) => (
+                  <Avatar
+                    key={member.id}
+                    size="sm"
+                    className={index > 0 ? "-ml-2 border-2 border-surface" : "border-2 border-surface"}
+                  >
+                    <AvatarImage
+                      src={member.profile.avatar_url ?? undefined}
+                      alt={member.profile.full_name ?? member.profile.email}
+                    />
+                    <AvatarFallback className="text-[10px]">
+                      {getInitials(member.profile.full_name, member.profile.email)}
+                    </AvatarFallback>
+                  </Avatar>
+                ))}
+                {team.members.length > 5 && (
+                  <div className="-ml-2 flex h-7 w-7 items-center justify-center rounded-full border-2 border-surface bg-surface-hover text-[10px] font-mono text-text-muted">
+                    +{team.members.length - 5}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="mt-5">
+              <div className="flex h-2 overflow-hidden rounded-full bg-surface-hover">
+                {totalIssues === 0 ? (
+                  <div className="h-full w-full bg-surface-hover" />
+                ) : (
+                  STATUS_ORDER.map((status) => {
+                    const count = team.issueCounts[status];
+                    if (count === 0) return null;
+
+                    return (
+                      <div
+                        key={status}
+                        className="h-full"
+                        style={{
+                          width: `${(count / totalIssues) * 100}%`,
+                          backgroundColor: STATUS_CONFIG[status].color,
+                        }}
+                      />
+                    );
+                  })
+                )}
+              </div>
+              <div className="mt-2 flex flex-wrap gap-3 text-[11px] font-mono text-text-muted">
+                {STATUS_ORDER.map((status) => (
+                  <span key={status} className="inline-flex items-center gap-1.5">
+                    <span
+                      className="h-1.5 w-1.5 rounded-full"
+                      style={{ backgroundColor: STATUS_CONFIG[status].color }}
+                    />
+                    <span>{team.issueCounts[status]}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
           </div>
-        </div>
-        <span className="text-xs font-medium font-mono text-danger-muted">
-          {team.activeIssueCount} active {team.activeIssueCount === 1 ? "issue" : "issues"}
-        </span>
+        </button>
+
+        {canManageTeams && (
+          <div className="absolute right-4 top-4 z-10">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={`Manage ${team.name}`}
+                  className="rounded-lg p-1.5 text-text-muted transition-colors hover:bg-surface hover:text-text"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={() => setEditOpen(true)}>
+                  <Pencil className="mr-2 h-4 w-4 text-text-muted" />
+                  Edit
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => setDeleteOpen(true)}
+                  className="text-danger focus:text-danger"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
       </div>
-      {team.members.map((member) => (
-        <TeamMemberRow key={member.id} member={member} />
-      ))}
-    </div>
+
+      <TeamFormModal
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        mode="edit"
+        team={team}
+      />
+
+      <DeleteConfirmationModal
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        title="Delete team?"
+        description={`Projects linked to ${team.name} will be unassigned, but preserved.`}
+        onConfirm={handleDelete}
+        loading={deleting}
+        confirmLabel="Delete Team"
+      />
+    </>
   );
 }

--- a/src/components/teams/team-detail-client.tsx
+++ b/src/components/teams/team-detail-client.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { DeleteConfirmationModal } from "@/components/ui/delete-confirmation-modal";
+import { IssueDetailPanel } from "@/components/issues/issue-detail-panel";
+import { RecentActivityCard } from "@/components/dashboard/recent-activity-card";
+import { useIssueFromUrl } from "@/lib/hooks/use-issue-from-url";
+import { addTeamMember, deleteTeam, removeTeamMember } from "@/lib/actions/teams";
+import type { WorkspaceMember } from "@/lib/queries/members";
+import type { IssueWithDetails } from "@/lib/queries/issues";
+import type {
+  IssueStatusCounts,
+  TeamMemberWithProfile,
+  TeamProject,
+  TeamWithMembers,
+} from "@/lib/queries/teams";
+import type { ActivityWithActor } from "@/lib/utils/activities";
+import { sortMembersByDisplayName } from "@/lib/utils/members";
+import { AddTeamMemberCombobox } from "@/components/teams/add-team-member-combobox";
+import { TeamFormModal } from "@/components/teams/team-form-modal";
+import { TeamMemberWorkloadBar } from "@/components/teams/team-member-workload-bar";
+
+interface TeamDetailClientProps {
+  workspaceName: string;
+  workspaceSlug: string;
+  team: TeamWithMembers;
+  issues: IssueWithDetails[];
+  activities: ActivityWithActor[];
+  activityIssueMap: Record<string, IssueWithDetails>;
+  projects: TeamProject[];
+  workspaceMembers: WorkspaceMember[];
+  canManageTeams: boolean;
+}
+
+function emptyIssueCounts(): IssueStatusCounts {
+  return {
+    todo: 0,
+    in_progress: 0,
+    in_review: 0,
+    done: 0,
+  };
+}
+
+export function TeamDetailClient({
+  workspaceName,
+  workspaceSlug,
+  team,
+  issues,
+  activities,
+  activityIssueMap,
+  projects,
+  workspaceMembers,
+  canManageTeams,
+}: TeamDetailClientProps) {
+  const router = useRouter();
+  const [currentTeam, setCurrentTeam] = useState(team);
+  const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deletePending, setDeletePending] = useState(false);
+  const [memberToRemove, setMemberToRemove] = useState<TeamWithMembers["members"][number] | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setCurrentTeam(team);
+  }, [team]);
+
+  const openIssue = useCallback((issue: IssueWithDetails) => {
+    setSelectedIssue(issue);
+    setDetailOpen(true);
+  }, []);
+
+  const allIssues = useMemo(
+    () => [...issues, ...Object.values(activityIssueMap)],
+    [activityIssueMap, issues]
+  );
+
+  useIssueFromUrl(allIssues, openIssue);
+
+  const availableMembers = workspaceMembers.filter(
+    (member) =>
+      !currentTeam.members.some((teamMember) => teamMember.user_id === member.user_id)
+  );
+
+  const handleIssueClick = useCallback(
+    (id: string) => {
+      const issue = issues.find((entry) => entry.id === id) ?? activityIssueMap[id] ?? null;
+      if (issue) {
+        openIssue(issue);
+      }
+    },
+    [activityIssueMap, issues, openIssue]
+  );
+
+  async function handleAddMember(userId: string) {
+    const result = await addTeamMember(currentTeam.id, userId);
+    if (result.error) {
+      toast.error(result.error);
+      return;
+    }
+
+    if (!result.data) {
+      toast.error("Unable to add member");
+      return;
+    }
+
+    const workspaceMember = workspaceMembers.find((member) => member.user_id === userId);
+    if (workspaceMember) {
+      const nextMember: TeamMemberWithProfile = {
+        id: result.data.id,
+        user_id: workspaceMember.user_id,
+        profile: workspaceMember.profile,
+        issueCounts: emptyIssueCounts(),
+        activeTaskCount: 0,
+      };
+
+      setCurrentTeam((existing) => {
+        if (existing.members.some((member) => member.user_id === userId)) {
+          return existing;
+        }
+
+        return {
+          ...existing,
+          members: sortMembersByDisplayName([...existing.members, nextMember]),
+        };
+      });
+    }
+
+    toast.success("Member added");
+    router.refresh();
+  }
+
+  async function handleDeleteTeam() {
+    setDeletePending(true);
+    const result = await deleteTeam(currentTeam.id);
+    setDeletePending(false);
+
+    if (result.error) {
+      toast.error(result.error);
+      return;
+    }
+
+    setDeleteOpen(false);
+    toast.success("Team deleted");
+    window.location.assign(`/${workspaceSlug}/teams`);
+  }
+
+  function handleRemoveMember() {
+    if (!memberToRemove) return;
+
+    startTransition(async () => {
+      const removedMember = memberToRemove;
+      const result = await removeTeamMember(currentTeam.id, removedMember.user_id);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+
+      setCurrentTeam((existing) => ({
+        ...existing,
+        members: existing.members.filter(
+          (member) => member.user_id !== removedMember.user_id
+        ),
+        issueCounts: {
+          todo: Math.max(0, existing.issueCounts.todo - removedMember.issueCounts.todo),
+          in_progress: Math.max(
+            0,
+            existing.issueCounts.in_progress - removedMember.issueCounts.in_progress
+          ),
+          in_review: Math.max(
+            0,
+            existing.issueCounts.in_review - removedMember.issueCounts.in_review
+          ),
+          done: Math.max(0, existing.issueCounts.done - removedMember.issueCounts.done),
+        },
+        activeIssueCount: Math.max(
+          0,
+          existing.activeIssueCount - removedMember.activeTaskCount
+        ),
+      }));
+      toast.success("Member removed");
+      setMemberToRemove(null);
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      <div className="flex flex-col py-6 px-8 gap-5">
+        <div className="text-[13px] py-3 flex items-center gap-2">
+          <span className="text-text-secondary">{workspaceName}</span>
+          <span className="text-text-muted">/</span>
+          <Link
+            href={`/${workspaceSlug}/teams`}
+            className="text-text-secondary transition-colors hover:text-text"
+          >
+            Teams
+          </Link>
+          <span className="text-text-muted">/</span>
+          <span className="text-text font-medium">{currentTeam.name}</span>
+        </div>
+
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-[-0.02em] text-text">
+              {currentTeam.name}
+            </h1>
+            <p className="mt-1 text-sm text-text-muted">
+              {currentTeam.members.length}{" "}
+              {currentTeam.members.length === 1 ? "member" : "members"} ·{" "}
+              {currentTeam.activeIssueCount} active{" "}
+              {currentTeam.activeIssueCount === 1 ? "issue" : "issues"}
+            </p>
+          </div>
+
+          {canManageTeams && (
+            <div className="flex items-center gap-2">
+              <Button variant="secondary" onClick={() => setEditOpen(true)}>
+                Edit Team
+              </Button>
+              <Button variant="danger" onClick={() => setDeleteOpen(true)}>
+                Delete Team
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <Tabs defaultValue="overview">
+          <TabsList>
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="members">Members</TabsTrigger>
+            <TabsTrigger value="projects">Projects</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="overview" className="mt-6">
+            <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+              <div className="rounded-2xl border border-border bg-surface p-5">
+                <div className="mb-4">
+                  <h2 className="text-base font-semibold text-text">Member Workload</h2>
+                  <p className="mt-1 text-sm text-text-muted">
+                    Current distribution of assigned work across the team.
+                  </p>
+                </div>
+
+                {currentTeam.members.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-border p-8 text-center text-sm text-text-muted">
+                    No members on this team yet.
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    {currentTeam.members.map((member) => (
+                      <TeamMemberWorkloadBar
+                        key={member.id}
+                        member={member}
+                        issues={issues}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <RecentActivityCard
+                activities={activities}
+                workspaceSlug={workspaceSlug}
+                onIssueClick={handleIssueClick}
+                title="Team Activity"
+                showInboxLink={false}
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="members" className="mt-6">
+            <div className="rounded-2xl border border-border bg-surface p-5">
+              <div className="mb-4 flex items-center justify-between gap-4">
+                <div>
+                  <h2 className="text-base font-semibold text-text">Members</h2>
+                  <p className="mt-1 text-sm text-text-muted">
+                    Full roster and workload visibility for this team.
+                  </p>
+                </div>
+                {canManageTeams && (
+                  <AddTeamMemberCombobox
+                    members={availableMembers}
+                    disabled={isPending}
+                    onSelect={handleAddMember}
+                  />
+                )}
+              </div>
+
+              {currentTeam.members.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-border p-8 text-center text-sm text-text-muted">
+                  Add workspace members to start collaborating as a team.
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {currentTeam.members.map((member) => (
+                    <TeamMemberWorkloadBar
+                      key={member.id}
+                      member={member}
+                      issues={issues}
+                      trailing={
+                        canManageTeams ? (
+                          <button
+                            type="button"
+                            onClick={() => setMemberToRemove(member)}
+                            aria-label={`Remove ${member.profile.email}`}
+                            className="text-xs font-medium text-text-muted transition-colors hover:text-danger"
+                          >
+                            Remove
+                          </button>
+                        ) : null
+                      }
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="projects" className="mt-6">
+            <div className="rounded-2xl border border-border bg-surface p-5">
+              <div className="mb-4">
+                <h2 className="text-base font-semibold text-text">Projects</h2>
+                <p className="mt-1 text-sm text-text-muted">
+                  Projects currently linked to this team.
+                </p>
+              </div>
+
+              {projects.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-border p-8 text-center text-sm text-text-muted">
+                  This team does not have any linked projects yet. Associate a team when
+                  creating a project or update the project settings later.
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {projects.map((project) => (
+                    <Link
+                      key={project.id}
+                      href={`/${workspaceSlug}/projects/${project.id}/board`}
+                      className="flex items-center justify-between rounded-xl border border-border px-4 py-3 transition-colors hover:bg-surface-hover"
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <span
+                          className="h-2.5 w-2.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: project.color }}
+                        />
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-text">
+                            {project.name}
+                          </p>
+                          {project.description && (
+                            <p className="truncate text-xs text-text-muted">
+                              {project.description}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <span className="text-xs font-medium text-text-secondary">
+                        Open board
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      <IssueDetailPanel
+        issue={selectedIssue}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        members={workspaceMembers}
+      />
+
+      <TeamFormModal
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        mode="edit"
+        team={currentTeam}
+        onSuccess={({ team: updatedTeam }) => {
+          setCurrentTeam((existing) => ({
+            ...existing,
+            ...updatedTeam,
+          }));
+        }}
+      />
+
+      <DeleteConfirmationModal
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        title="Delete team?"
+        description={`Projects linked to ${currentTeam.name} will be preserved and unlinked from the team.`}
+        onConfirm={handleDeleteTeam}
+        loading={deletePending}
+        confirmLabel="Delete Team"
+      />
+
+      <DeleteConfirmationModal
+        open={!!memberToRemove}
+        onOpenChange={(open) => {
+          if (!open) {
+            setMemberToRemove(null);
+          }
+        }}
+        title="Remove team member?"
+        description={`${memberToRemove?.profile.full_name ?? memberToRemove?.profile.email ?? "This member"} will be removed from ${currentTeam.name}.`}
+        onConfirm={handleRemoveMember}
+        loading={isPending}
+        confirmLabel="Remove Member"
+      />
+    </>
+  );
+}

--- a/src/components/teams/team-form-modal.tsx
+++ b/src/components/teams/team-form-modal.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useWorkspace } from "@/providers/workspace-provider";
+import { createTeam, updateTeam } from "@/lib/actions/teams";
+import type { WorkspaceMember } from "@/lib/queries/members";
+import type { IssueStatusCounts, TeamMemberWithProfile, TeamWithMembers } from "@/lib/queries/teams";
+import type { Tables } from "@/lib/types";
+import { getInitials } from "@/lib/utils/format";
+import { sortMembersByDisplayName } from "@/lib/utils/members";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface TeamFormModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  team?: TeamWithMembers;
+  workspaceMembers?: WorkspaceMember[];
+  onSuccess?: (payload: {
+    team: Tables<"teams">;
+    members: TeamMemberWithProfile[];
+  }) => void;
+}
+
+function emptyIssueCounts(): IssueStatusCounts {
+  return {
+    todo: 0,
+    in_progress: 0,
+    in_review: 0,
+    done: 0,
+  };
+}
+
+export function TeamFormModal({
+  open,
+  onOpenChange,
+  mode,
+  team,
+  workspaceMembers = [],
+  onSuccess,
+}: TeamFormModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <TeamFormModalContent
+          key={`${mode}-${team?.id ?? "create"}`}
+          onOpenChange={onOpenChange}
+          mode={mode}
+          team={team}
+          workspaceMembers={workspaceMembers}
+          onSuccess={onSuccess}
+        />
+      ) : null}
+    </Dialog>
+  );
+}
+
+function TeamFormModalContent({
+  onOpenChange,
+  mode,
+  team,
+  workspaceMembers = [],
+  onSuccess,
+}: Omit<TeamFormModalProps, "open">) {
+  const router = useRouter();
+  const { workspace } = useWorkspace();
+  const [name, setName] = useState(team?.name ?? "");
+  const [memberQuery, setMemberQuery] = useState("");
+  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filteredMembers = useMemo(() => {
+    if (mode !== "create") return [];
+
+    const query = memberQuery.trim().toLowerCase();
+    if (!query) return workspaceMembers;
+
+    return workspaceMembers.filter((member) => {
+      const nameMatch = member.profile.full_name?.toLowerCase().includes(query);
+      const emailMatch = member.profile.email.toLowerCase().includes(query);
+      return nameMatch || emailMatch;
+    });
+  }, [memberQuery, mode, workspaceMembers]);
+
+  const selectedMembers = workspaceMembers.filter((member) =>
+    selectedMemberIds.includes(member.user_id)
+  );
+
+  function toggleMember(userId: string) {
+    setSelectedMemberIds((current) =>
+      current.includes(userId)
+        ? current.filter((id) => id !== userId)
+        : [...current, userId]
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const formData = new FormData();
+    formData.set("name", name.trim());
+
+    const result =
+      mode === "create"
+        ? await (() => {
+            formData.set("workspaceId", workspace.id);
+            formData.set("memberIds", selectedMemberIds.join(","));
+            return createTeam(formData);
+          })()
+        : await updateTeam(team!.id, formData);
+
+    if (result.error) {
+      setError(result.error);
+      setLoading(false);
+      return;
+    }
+
+    if (!result.data) {
+      setError("Team update failed");
+      setLoading(false);
+      return;
+    }
+
+    const nextMembers =
+      mode === "create"
+        ? sortMembersByDisplayName(
+            workspaceMembers
+              .filter((member) => selectedMemberIds.includes(member.user_id))
+              .map((member) => ({
+                id: `${result.data.id}:${member.user_id}`,
+                user_id: member.user_id,
+                profile: member.profile,
+                issueCounts: emptyIssueCounts(),
+                activeTaskCount: 0,
+              }))
+          )
+        : (team?.members ?? []);
+
+    onSuccess?.({
+      team: result.data,
+      members: nextMembers,
+    });
+    toast.success(mode === "create" ? "Team created" : "Team updated");
+    setLoading(false);
+    onOpenChange(false);
+    router.refresh();
+  }
+
+  const title = mode === "create" ? "Create Team" : "Edit Team";
+
+  return (
+    <DialogContent className="sm:max-w-[560px]">
+      <DialogHeader>
+        <DialogTitle>{title}</DialogTitle>
+      </DialogHeader>
+
+      <form onSubmit={handleSubmit}>
+        <div className="space-y-5 py-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="team-name">Team Name</Label>
+            <Input
+              id="team-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Platform"
+              autoFocus
+              required
+            />
+          </div>
+
+          {mode === "create" && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="team-members">Initial Members</Label>
+                <Input
+                  id="team-members"
+                  value={memberQuery}
+                  onChange={(e) => setMemberQuery(e.target.value)}
+                  placeholder="Search workspace members..."
+                />
+              </div>
+
+              {selectedMembers.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {selectedMembers.map((member) => (
+                    <button
+                      key={member.user_id}
+                      type="button"
+                      onClick={() => toggleMember(member.user_id)}
+                      className="inline-flex items-center gap-2 rounded-full border border-border bg-surface-hover px-2.5 py-1 text-xs font-medium text-text transition-colors hover:bg-surface"
+                    >
+                      <span>{member.profile.full_name ?? member.profile.email}</span>
+                      <span className="text-text-muted">&times;</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              <div className="max-h-64 overflow-y-auto rounded-xl border border-border bg-surface">
+                {filteredMembers.length === 0 ? (
+                  <div className="px-4 py-6 text-sm text-text-muted">
+                    No members match that search.
+                  </div>
+                ) : (
+                  <div className="divide-y divide-border-subtle">
+                    {filteredMembers.map((member) => {
+                      const selected = selectedMemberIds.includes(member.user_id);
+
+                      return (
+                        <button
+                          key={member.user_id}
+                          type="button"
+                          onClick={() => toggleMember(member.user_id)}
+                          className={`flex w-full items-center gap-3 px-4 py-3 text-left transition-colors ${
+                            selected ? "bg-surface-hover" : "hover:bg-surface-hover/70"
+                          }`}
+                        >
+                          <Avatar size="sm">
+                            <AvatarImage
+                              src={member.profile.avatar_url ?? undefined}
+                              alt={member.profile.full_name ?? member.profile.email}
+                            />
+                            <AvatarFallback>
+                              {getInitials(
+                                member.profile.full_name,
+                                member.profile.email
+                              )}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium text-text">
+                              {member.profile.full_name ?? member.profile.email}
+                            </p>
+                            <p className="truncate text-xs text-text-muted">
+                              {member.profile.email}
+                            </p>
+                          </div>
+                          <div
+                            className={`flex h-5 w-5 items-center justify-center rounded border text-xs ${
+                              selected
+                                ? "border-primary bg-primary text-background"
+                                : "border-border text-transparent"
+                            }`}
+                          >
+                            ✓
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {error && <p className="text-sm text-danger">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={loading || !name.trim()}>
+            {loading
+              ? mode === "create"
+                ? "Creating..."
+                : "Saving..."
+              : mode === "create"
+                ? "Create Team"
+                : "Save Changes"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  );
+}

--- a/src/components/teams/team-member-workload-bar.tsx
+++ b/src/components/teams/team-member-workload-bar.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { IssueWithDetails } from "@/lib/queries/issues";
+import type { TeamMemberWithProfile } from "@/lib/queries/teams";
+import { getInitials } from "@/lib/utils/format";
+import { STATUS_CONFIG, STATUS_ORDER } from "@/lib/utils/statuses";
+
+interface TeamMemberWorkloadBarProps {
+  member: TeamMemberWithProfile;
+  issues: IssueWithDetails[];
+  trailing?: React.ReactNode;
+}
+
+export function TeamMemberWorkloadBar({
+  member,
+  issues,
+  trailing,
+}: TeamMemberWorkloadBarProps) {
+  const memberIssues = issues.filter((issue) => issue.assignee_id === member.user_id);
+  const counts = STATUS_ORDER.reduce(
+    (acc, status) => {
+      acc[status] = memberIssues.filter((issue) => issue.status === status).length;
+      return acc;
+    },
+    {
+      todo: 0,
+      in_progress: 0,
+      in_review: 0,
+      done: 0,
+    }
+  );
+  const total = memberIssues.length;
+
+  return (
+    <div className="rounded-2xl border border-border bg-surface p-4">
+      <div className="flex items-start gap-3">
+        <Avatar size="sm">
+          <AvatarImage
+            src={member.profile.avatar_url ?? undefined}
+            alt={member.profile.full_name ?? member.profile.email}
+          />
+          <AvatarFallback>
+            {getInitials(member.profile.full_name, member.profile.email)}
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-text">
+                {member.profile.full_name ?? member.profile.email}
+              </p>
+              <p className="truncate text-xs text-text-muted">
+                {member.profile.email}
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="rounded-full bg-surface-hover px-2 py-1 text-[11px] font-mono text-text-muted">
+                {total} {total === 1 ? "issue" : "issues"}
+              </span>
+              {trailing}
+            </div>
+          </div>
+
+          <div className="mt-3">
+            <div className="flex h-2 overflow-hidden rounded-full bg-surface-hover">
+              {total === 0 ? (
+                <div className="h-full w-full bg-surface-hover" />
+              ) : (
+                STATUS_ORDER.map((status) => {
+                  const count = counts[status];
+                  if (count === 0) return null;
+
+                  return (
+                    <div
+                      key={status}
+                      className="h-full"
+                      style={{
+                        width: `${(count / total) * 100}%`,
+                        backgroundColor: STATUS_CONFIG[status].color,
+                      }}
+                    />
+                  );
+                })
+              )}
+            </div>
+
+            <div className="mt-2 flex flex-wrap gap-3 text-[11px] font-mono text-text-muted">
+              {STATUS_ORDER.map((status) => (
+                <span key={status} className="inline-flex items-center gap-1.5">
+                  <span
+                    className="h-1.5 w-1.5 rounded-full"
+                    style={{ backgroundColor: STATUS_CONFIG[status].color }}
+                  />
+                  <span>
+                    {STATUS_CONFIG[status].label} {counts[status]}
+                  </span>
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/teams/teams-list.tsx
+++ b/src/components/teams/teams-list.tsx
@@ -1,22 +1,24 @@
 import type { TeamWithMembers } from "@/lib/queries/teams";
 import { TeamCard } from "./team-card";
 
-export function TeamsList({ teams }: { teams: TeamWithMembers[] }) {
-  if (teams.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-20">
-        <h2 className="text-lg font-medium text-text">No teams yet</h2>
-        <p className="mt-1 text-sm text-text-muted">
-          Create teams to organize your workspace members.
-        </p>
-      </div>
-    );
-  }
-
+export function TeamsList({
+  teams,
+  workspaceSlug,
+  canManageTeams,
+}: {
+  teams: TeamWithMembers[];
+  workspaceSlug: string;
+  canManageTeams: boolean;
+}) {
   return (
-    <div className="flex flex-col gap-5">
+    <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
       {teams.map((team) => (
-        <TeamCard key={team.id} team={team} />
+        <TeamCard
+          key={team.id}
+          team={team}
+          workspaceSlug={workspaceSlug}
+          canManageTeams={canManageTeams}
+        />
       ))}
     </div>
   );

--- a/src/components/teams/teams-page-client.tsx
+++ b/src/components/teams/teams-page-client.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Users } from "lucide-react";
+import type { WorkspaceMember } from "@/lib/queries/members";
+import type { IssueStatusCounts, TeamWithMembers } from "@/lib/queries/teams";
+import { InviteMemberButton } from "@/components/teams/invite-member-button";
+import { TeamFormModal } from "@/components/teams/team-form-modal";
+import { TeamsList } from "@/components/teams/teams-list";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
+
+interface TeamsPageClientProps {
+  teams: TeamWithMembers[];
+  workspaceId: string;
+  workspaceSlug: string;
+  workspaceMembers: WorkspaceMember[];
+  canManageTeams: boolean;
+}
+
+function emptyIssueCounts(): IssueStatusCounts {
+  return {
+    todo: 0,
+    in_progress: 0,
+    in_review: 0,
+    done: 0,
+  };
+}
+
+export function TeamsPageClient({
+  teams,
+  workspaceId,
+  workspaceSlug,
+  workspaceMembers,
+  canManageTeams,
+}: TeamsPageClientProps) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [currentTeams, setCurrentTeams] = useState(teams);
+
+  useEffect(() => {
+    setCurrentTeams(teams);
+  }, [teams]);
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-[-0.02em] text-text">
+          Teams
+        </h1>
+        <div className="flex items-center gap-2">
+          <InviteMemberButton workspaceId={workspaceId} />
+          {canManageTeams && (
+            <Button onClick={() => setCreateOpen(true)}>Create Team</Button>
+          )}
+        </div>
+      </div>
+
+      {currentTeams.length > 0 ? (
+        <TeamsList
+          teams={currentTeams}
+          workspaceSlug={workspaceSlug}
+          canManageTeams={canManageTeams}
+        />
+      ) : (
+        <EmptyState
+          icon={Users}
+          title="No teams yet"
+          description="Create teams to organize your workspace members."
+        />
+      )}
+
+      <TeamFormModal
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        mode="create"
+        workspaceMembers={workspaceMembers}
+        onSuccess={({ team, members }) => {
+          setCurrentTeams((existing) => {
+            const nextTeam: TeamWithMembers = {
+              ...team,
+              members,
+              issueCounts: emptyIssueCounts(),
+              activeIssueCount: 0,
+            };
+
+            return [...existing, nextTeam].sort((a, b) => a.name.localeCompare(b.name));
+          });
+        }}
+      />
+    </>
+  );
+}

--- a/src/lib/actions/teams.ts
+++ b/src/lib/actions/teams.ts
@@ -1,0 +1,373 @@
+"use server";
+
+import { refresh, revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createActivity } from "@/lib/actions/activities";
+import type { ActionResponse, Tables } from "@/lib/types";
+
+async function requireTeamManager(workspaceId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { supabase, user: null, error: "Not authenticated" } as const;
+  }
+
+  const { data: membership } = await supabase
+    .from("workspace_members")
+    .select("role")
+    .eq("workspace_id", workspaceId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!membership || membership.role === "member") {
+    return {
+      supabase,
+      user,
+      error: "Only workspace owners and admins can manage teams",
+    } as const;
+  }
+
+  return { supabase, user, error: null } as const;
+}
+
+async function getTeamContext(teamId: string) {
+  const supabase = await createClient();
+  const { data: team } = await supabase
+    .from("teams")
+    .select("*")
+    .eq("id", teamId)
+    .maybeSingle();
+
+  return { supabase, team } as const;
+}
+
+function parseMemberIds(value: FormDataEntryValue | null): string[] {
+  if (typeof value !== "string" || !value.trim()) {
+    return [];
+  }
+
+  return [...new Set(value.split(",").map((id) => id.trim()).filter(Boolean))];
+}
+
+export async function createTeam(
+  formData: FormData
+): Promise<ActionResponse<Tables<"teams">>> {
+  const workspaceId = formData.get("workspaceId") as string | null;
+  const name = (formData.get("name") as string | null)?.trim();
+  const memberIds = parseMemberIds(formData.get("memberIds"));
+
+  if (!workspaceId || !name) {
+    return { error: "Workspace and team name are required" };
+  }
+
+  const auth = await requireTeamManager(workspaceId);
+  if (auth.error) {
+    return { error: auth.error };
+  }
+
+  const { supabase, user } = auth;
+
+  const { data: team, error } = await supabase
+    .from("teams")
+    .insert({
+      workspace_id: workspaceId,
+      name,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  if (memberIds.length > 0) {
+    const { data: workspaceMembers } = await supabase
+      .from("workspace_members")
+      .select("user_id")
+      .eq("workspace_id", workspaceId)
+      .in("user_id", memberIds);
+
+    const validMemberIds = (workspaceMembers ?? []).map((member) => member.user_id);
+    if (validMemberIds.length > 0) {
+      const { error: memberError } = await supabase.from("team_members").insert(
+        validMemberIds.map((userId) => ({
+          team_id: team.id,
+          user_id: userId,
+        }))
+      );
+
+      if (memberError) {
+        await supabase.from("teams").delete().eq("id", team.id);
+        return { error: memberError.message };
+      }
+    }
+  }
+
+  try {
+    await createActivity({
+      supabase,
+      workspaceId,
+      actorId: user.id,
+      action: "created",
+      entityType: "team",
+      entityId: team.id,
+      metadata: {
+        name: team.name,
+        member_count: memberIds.length,
+      },
+    });
+  } catch {
+    // Activity logging should not block the primary operation
+  }
+
+  revalidatePath("/", "layout");
+  refresh();
+  return { data: team };
+}
+
+export async function updateTeam(
+  teamId: string,
+  formData: FormData
+): Promise<ActionResponse<Tables<"teams">>> {
+  const nextName = (formData.get("name") as string | null)?.trim();
+  if (!nextName) {
+    return { error: "Team name is required" };
+  }
+
+  const context = await getTeamContext(teamId);
+  if (!context.team) {
+    return { error: "Team not found" };
+  }
+
+  const auth = await requireTeamManager(context.team.workspace_id);
+  if (auth.error) {
+    return { error: auth.error };
+  }
+
+  const { supabase, user } = auth;
+  const previousName = context.team.name;
+
+  const { data: team, error } = await supabase
+    .from("teams")
+    .update({ name: nextName })
+    .eq("id", teamId)
+    .select()
+    .single();
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  try {
+    await createActivity({
+      supabase,
+      workspaceId: team.workspace_id,
+      actorId: user.id,
+      action: "updated",
+      entityType: "team",
+      entityId: team.id,
+      metadata: {
+        name: team.name,
+        previous_name: previousName,
+        changes: { name: team.name },
+      },
+    });
+  } catch {
+    // Activity logging should not block the primary operation
+  }
+
+  revalidatePath("/", "layout");
+  refresh();
+  return { data: team };
+}
+
+export async function deleteTeam(
+  teamId: string
+): Promise<ActionResponse<void>> {
+  const context = await getTeamContext(teamId);
+  if (!context.team) {
+    return { error: "Team not found" };
+  }
+
+  const auth = await requireTeamManager(context.team.workspace_id);
+  if (auth.error) {
+    return { error: auth.error };
+  }
+
+  const { supabase, user } = auth;
+
+  const { error: unlinkError } = await supabase
+    .from("projects")
+    .update({ team_id: null })
+    .eq("team_id", teamId);
+
+  if (unlinkError) {
+    return { error: unlinkError.message };
+  }
+
+  await supabase.from("team_members").delete().eq("team_id", teamId);
+
+  const { error } = await supabase
+    .from("teams")
+    .delete()
+    .eq("id", teamId);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  try {
+    await createActivity({
+      supabase,
+      workspaceId: context.team.workspace_id,
+      actorId: user.id,
+      action: "deleted",
+      entityType: "team",
+      entityId: teamId,
+      metadata: { name: context.team.name },
+    });
+  } catch {
+    // Activity logging should not block the primary operation
+  }
+
+  revalidatePath("/", "layout");
+  return { data: undefined };
+}
+
+export async function addTeamMember(
+  teamId: string,
+  userId: string
+): Promise<ActionResponse<Tables<"team_members">>> {
+  const context = await getTeamContext(teamId);
+  if (!context.team) {
+    return { error: "Team not found" };
+  }
+
+  const auth = await requireTeamManager(context.team.workspace_id);
+  if (auth.error) {
+    return { error: auth.error };
+  }
+
+  const { supabase, user } = auth;
+
+  const { data: workspaceMember } = await supabase
+    .from("workspace_members")
+    .select("user_id")
+    .eq("workspace_id", context.team.workspace_id)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (!workspaceMember) {
+    return { error: "Member is not part of this workspace" };
+  }
+
+  const { data: existingMember } = await supabase
+    .from("team_members")
+    .select("*")
+    .eq("team_id", teamId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (existingMember) {
+    return { data: existingMember };
+  }
+
+  const { data: teamMember, error } = await supabase
+    .from("team_members")
+    .insert({
+      team_id: teamId,
+      user_id: userId,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  try {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("full_name, email")
+      .eq("id", userId)
+      .maybeSingle();
+
+    await createActivity({
+      supabase,
+      workspaceId: context.team.workspace_id,
+      actorId: user.id,
+      action: "added_member",
+      entityType: "team",
+      entityId: teamId,
+      metadata: {
+        name: context.team.name,
+        member_name: profile?.full_name ?? profile?.email ?? "member",
+        member_id: userId,
+      },
+    });
+  } catch {
+    // Activity logging should not block the primary operation
+  }
+
+  revalidatePath("/", "layout");
+  refresh();
+  return { data: teamMember };
+}
+
+export async function removeTeamMember(
+  teamId: string,
+  userId: string
+): Promise<ActionResponse<void>> {
+  const context = await getTeamContext(teamId);
+  if (!context.team) {
+    return { error: "Team not found" };
+  }
+
+  const auth = await requireTeamManager(context.team.workspace_id);
+  if (auth.error) {
+    return { error: auth.error };
+  }
+
+  const { supabase, user } = auth;
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name, email")
+    .eq("id", userId)
+    .maybeSingle();
+
+  const { error } = await supabase
+    .from("team_members")
+    .delete()
+    .eq("team_id", teamId)
+    .eq("user_id", userId);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  try {
+    await createActivity({
+      supabase,
+      workspaceId: context.team.workspace_id,
+      actorId: user.id,
+      action: "removed_member",
+      entityType: "team",
+      entityId: teamId,
+      metadata: {
+        name: context.team.name,
+        member_name: profile?.full_name ?? profile?.email ?? "member",
+        member_id: userId,
+      },
+    });
+  } catch {
+    // Activity logging should not block the primary operation
+  }
+
+  revalidatePath("/", "layout");
+  refresh();
+  return { data: undefined };
+}

--- a/src/lib/queries/activities.ts
+++ b/src/lib/queries/activities.ts
@@ -1,8 +1,73 @@
 import { createClient } from "@/lib/supabase/server";
 import type { ActivityWithActor } from "@/lib/utils/activities";
+import type { Json } from "@/lib/types";
 
 export type { ActivityWithActor } from "@/lib/utils/activities";
 export { formatActivityAction } from "@/lib/utils/activities";
+
+export async function hydrateActivities(
+  activities: {
+    id: string;
+    workspace_id: string;
+    actor_id: string;
+    action: string;
+    entity_type: string;
+    entity_id: string;
+    metadata: Json;
+    created_at: string;
+  }[],
+  supabase: Awaited<ReturnType<typeof createClient>>
+): Promise<ActivityWithActor[]> {
+  if (activities.length === 0) return [];
+
+  const actorIds = [...new Set(activities.map((activity) => activity.actor_id))];
+  const actorMap = new Map<
+    string,
+    { id: string; full_name: string | null; email: string; avatar_url: string | null }
+  >();
+
+  if (actorIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, full_name, email, avatar_url")
+      .in("id", actorIds);
+
+    for (const profile of profiles ?? []) {
+      actorMap.set(profile.id, profile);
+    }
+  }
+
+  const projectIds = [
+    ...new Set(
+      activities
+        .map((activity) => (activity.metadata as Record<string, unknown>)?.project_id)
+        .filter(Boolean)
+    ),
+  ] as string[];
+  const projectMap = new Map<string, string>();
+
+  if (projectIds.length > 0) {
+    const { data: projects } = await supabase
+      .from("projects")
+      .select("id, name")
+      .in("id", projectIds);
+
+    for (const project of projects ?? []) {
+      projectMap.set(project.id, project.name);
+    }
+  }
+
+  return activities.map((activity) => {
+    const metadata = activity.metadata as Record<string, unknown>;
+    const projectId = metadata?.project_id as string | undefined;
+
+    return {
+      ...activity,
+      actor: actorMap.get(activity.actor_id) ?? null,
+      project_name: projectId ? projectMap.get(projectId) ?? null : null,
+    };
+  });
+}
 
 export async function getRecentActivities(
   workspaceId: string,
@@ -17,52 +82,5 @@ export async function getRecentActivities(
     .order("created_at", { ascending: false })
     .limit(limit);
 
-  if (!activities || activities.length === 0) return [];
-
-  // Batch-fetch actor profiles
-  const actorIds = [...new Set(activities.map((a) => a.actor_id))];
-  const actorMap = new Map<
-    string,
-    { id: string; full_name: string | null; email: string; avatar_url: string | null }
-  >();
-
-  if (actorIds.length > 0) {
-    const { data: profiles } = await supabase
-      .from("profiles")
-      .select("id, full_name, email, avatar_url")
-      .in("id", actorIds);
-    for (const p of profiles ?? []) {
-      actorMap.set(p.id, p);
-    }
-  }
-
-  // Batch-fetch project names from metadata
-  const projectIds = [
-    ...new Set(
-      activities
-        .map((a) => (a.metadata as Record<string, unknown>)?.project_id)
-        .filter(Boolean)
-    ),
-  ] as string[];
-  const projectMap = new Map<string, string>();
-
-  if (projectIds.length > 0) {
-    const { data: projects } = await supabase
-      .from("projects")
-      .select("id, name")
-      .in("id", projectIds);
-    for (const p of projects ?? []) {
-      projectMap.set(p.id, p.name);
-    }
-  }
-
-  return activities.map((activity) => {
-    const meta = activity.metadata as Record<string, unknown>;
-    const projectId = meta?.project_id as string | undefined;
-    return {
-      ...activity,
-      actor: actorMap.get(activity.actor_id) ?? null,
-      project_name: projectId ? projectMap.get(projectId) ?? null : null,
-    };
-  });
+  return hydrateActivities(activities ?? [], supabase);
 }

--- a/src/lib/queries/members.ts
+++ b/src/lib/queries/members.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { dedupeMembersByUserId, sortMembersByDisplayName } from "@/lib/utils/members";
 
 export type WorkspaceMember = {
   id: string;
@@ -33,12 +34,16 @@ export async function getWorkspaceMembers(
     profileMap.set(p.id, p);
   }
 
-  return members
+  return sortMembersByDisplayName(
+    dedupeMembersByUserId(
+      members
     .filter((m) => profileMap.has(m.user_id))
     .map((m) => ({
       ...m,
       profile: profileMap.get(m.user_id)!,
-    }));
+    }))
+    )
+  );
 }
 
 export async function getWorkspaceTeams(workspaceId: string) {

--- a/src/lib/queries/teams.ts
+++ b/src/lib/queries/teams.ts
@@ -1,4 +1,24 @@
 import { createClient } from "@/lib/supabase/server";
+import { hydrateActivities } from "@/lib/queries/activities";
+import { enrichIssues, type IssueWithDetails } from "@/lib/queries/issues";
+import type { ActivityWithActor } from "@/lib/utils/activities";
+import type { IssueStatus, Tables } from "@/lib/types";
+import { dedupeMembersByUserId, sortMembersByDisplayName } from "@/lib/utils/members";
+
+export type IssueStatusCounts = Record<IssueStatus, number>;
+
+function emptyIssueCounts(): IssueStatusCounts {
+  return {
+    todo: 0,
+    in_progress: 0,
+    in_review: 0,
+    done: 0,
+  };
+}
+
+function getActiveIssueCount(counts: IssueStatusCounts) {
+  return counts.todo + counts.in_progress + counts.in_review;
+}
 
 export type TeamMemberWithProfile = {
   id: string;
@@ -10,48 +30,57 @@ export type TeamMemberWithProfile = {
     avatar_url: string | null;
   };
   activeTaskCount: number;
+  issueCounts: IssueStatusCounts;
 };
 
 export type TeamWithMembers = {
   id: string;
   name: string;
   workspace_id: string;
+  created_at: string;
+  updated_at: string;
   members: TeamMemberWithProfile[];
+  issueCounts: IssueStatusCounts;
   activeIssueCount: number;
 };
 
-export async function getTeamsWithMembers(
-  workspaceId: string
-): Promise<TeamWithMembers[]> {
-  const supabase = await createClient();
+export type TeamProject = Pick<
+  Tables<"projects">,
+  "id" | "workspace_id" | "name" | "description" | "color" | "team_id" | "updated_at"
+>;
 
-  const { data: teams } = await supabase
-    .from("teams")
-    .select("*")
-    .eq("workspace_id", workspaceId)
-    .order("name");
+type TeamStatsBundle = {
+  membersByTeam: Map<string, TeamMemberWithProfile[]>;
+  countsByTeam: Map<string, IssueStatusCounts>;
+  activeCountByTeam: Map<string, number>;
+};
 
-  if (!teams || teams.length === 0) return [];
-
-  // Batch-fetch team members
-  const teamIds = teams.map((t) => t.id);
-  const { data: teamMembers } = await supabase
+async function getTeamStats(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  workspaceId: string,
+  teamIds: string[]
+): Promise<TeamStatsBundle> {
+  const { data: rawTeamMembers } = await supabase
     .from("team_members")
     .select("*")
     .in("team_id", teamIds);
 
-  if (!teamMembers || teamMembers.length === 0) {
-    return teams.map((t) => ({
-      id: t.id,
-      name: t.name,
-      workspace_id: t.workspace_id,
-      members: [],
-      activeIssueCount: 0,
-    }));
+  const teamMembers = [...new Map(
+    (rawTeamMembers ?? []).map((teamMember) => [
+      `${teamMember.team_id}:${teamMember.user_id}`,
+      teamMember,
+    ])
+  ).values()];
+
+  if (teamMembers.length === 0) {
+    return {
+      membersByTeam: new Map(),
+      countsByTeam: new Map(),
+      activeCountByTeam: new Map(),
+    };
   }
 
-  // Batch-fetch profiles
-  const userIds = [...new Set(teamMembers.map((tm) => tm.user_id))];
+  const userIds = [...new Set(teamMembers.map((teamMember) => teamMember.user_id))];
   const { data: profiles } = await supabase
     .from("profiles")
     .select("id, full_name, email, avatar_url")
@@ -61,53 +90,215 @@ export async function getTeamsWithMembers(
     string,
     { id: string; full_name: string | null; email: string; avatar_url: string | null }
   >();
-  for (const p of profiles ?? []) {
-    profileMap.set(p.id, p);
+  for (const profile of profiles ?? []) {
+    profileMap.set(profile.id, profile);
   }
 
-  // Batch-fetch active issue counts per user
   const { data: issues } = await supabase
     .from("issues")
-    .select("assignee_id")
+    .select("assignee_id, status")
     .eq("workspace_id", workspaceId)
-    .neq("status", "done")
     .in("assignee_id", userIds);
 
-  const taskCountMap = new Map<string, number>();
-  for (const issue of issues ?? []) {
-    if (issue.assignee_id) {
-      taskCountMap.set(
-        issue.assignee_id,
-        (taskCountMap.get(issue.assignee_id) ?? 0) + 1
-      );
-    }
+  const issueCountsByUser = new Map<string, IssueStatusCounts>();
+  for (const userId of userIds) {
+    issueCountsByUser.set(userId, emptyIssueCounts());
   }
 
-  // Group team members by team
+  for (const issue of issues ?? []) {
+    if (!issue.assignee_id) continue;
+
+    const counts = issueCountsByUser.get(issue.assignee_id) ?? emptyIssueCounts();
+    counts[issue.status as IssueStatus] += 1;
+    issueCountsByUser.set(issue.assignee_id, counts);
+  }
+
   const membersByTeam = new Map<string, TeamMemberWithProfile[]>();
-  for (const tm of teamMembers) {
-    const profile = profileMap.get(tm.user_id);
+  for (const teamMember of teamMembers) {
+    const profile = profileMap.get(teamMember.user_id);
     if (!profile) continue;
 
-    if (!membersByTeam.has(tm.team_id)) {
-      membersByTeam.set(tm.team_id, []);
-    }
-    membersByTeam.get(tm.team_id)!.push({
-      id: tm.id,
-      user_id: tm.user_id,
+    const issueCounts = issueCountsByUser.get(teamMember.user_id) ?? emptyIssueCounts();
+    const member: TeamMemberWithProfile = {
+      id: teamMember.id,
+      user_id: teamMember.user_id,
       profile,
-      activeTaskCount: taskCountMap.get(tm.user_id) ?? 0,
-    });
+      issueCounts,
+      activeTaskCount: getActiveIssueCount(issueCounts),
+    };
+
+    const currentMembers = membersByTeam.get(teamMember.team_id) ?? [];
+    currentMembers.push(member);
+    membersByTeam.set(teamMember.team_id, currentMembers);
   }
 
-  return teams.map((t) => {
-    const members = membersByTeam.get(t.id) ?? [];
-    return {
-      id: t.id,
-      name: t.name,
-      workspace_id: t.workspace_id,
-      members,
-      activeIssueCount: members.reduce((sum, m) => sum + m.activeTaskCount, 0),
-    };
-  });
+  const countsByTeam = new Map<string, IssueStatusCounts>();
+  const activeCountByTeam = new Map<string, number>();
+
+  for (const [teamId, members] of membersByTeam) {
+    const uniqueMembers = sortMembersByDisplayName(dedupeMembersByUserId(members));
+    membersByTeam.set(teamId, uniqueMembers);
+
+    const counts = uniqueMembers.reduce<IssueStatusCounts>((acc, member) => {
+      acc.todo += member.issueCounts.todo;
+      acc.in_progress += member.issueCounts.in_progress;
+      acc.in_review += member.issueCounts.in_review;
+      acc.done += member.issueCounts.done;
+      return acc;
+    }, emptyIssueCounts());
+
+    countsByTeam.set(teamId, counts);
+    activeCountByTeam.set(teamId, getActiveIssueCount(counts));
+  }
+
+  return { membersByTeam, countsByTeam, activeCountByTeam };
+}
+
+export async function getTeamsWithMembers(workspaceId: string): Promise<TeamWithMembers[]> {
+  const supabase = await createClient();
+
+  const { data: teams } = await supabase
+    .from("teams")
+    .select("*")
+    .eq("workspace_id", workspaceId)
+    .order("name");
+
+  if (!teams || teams.length === 0) {
+    return [];
+  }
+
+  const teamIds = teams.map((team) => team.id);
+  const { membersByTeam, countsByTeam, activeCountByTeam } = await getTeamStats(
+    supabase,
+    workspaceId,
+    teamIds
+  );
+
+  return teams.map((team) => ({
+    ...team,
+    members: membersByTeam.get(team.id) ?? [],
+    issueCounts: countsByTeam.get(team.id) ?? emptyIssueCounts(),
+    activeIssueCount: activeCountByTeam.get(team.id) ?? 0,
+  }));
+}
+
+export async function getTeamById(teamId: string): Promise<TeamWithMembers | null> {
+  const supabase = await createClient();
+
+  const { data: team } = await supabase
+    .from("teams")
+    .select("*")
+    .eq("id", teamId)
+    .maybeSingle();
+
+  if (!team) {
+    return null;
+  }
+
+  const { membersByTeam, countsByTeam, activeCountByTeam } = await getTeamStats(
+    supabase,
+    team.workspace_id,
+    [team.id]
+  );
+
+  return {
+    ...team,
+    members: membersByTeam.get(team.id) ?? [],
+    issueCounts: countsByTeam.get(team.id) ?? emptyIssueCounts(),
+    activeIssueCount: activeCountByTeam.get(team.id) ?? 0,
+  };
+}
+
+export async function getTeamIssues(teamId: string): Promise<IssueWithDetails[]> {
+  const supabase = await createClient();
+  const team = await getTeamById(teamId);
+
+  if (!team || team.members.length === 0) {
+    return [];
+  }
+
+  const userIds = team.members.map((member) => member.user_id);
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("*")
+    .eq("workspace_id", team.workspace_id)
+    .in("assignee_id", userIds)
+    .order("updated_at", { ascending: false });
+
+  return enrichIssues(issues ?? [], supabase);
+}
+
+export async function getTeamActivities(
+  teamId: string,
+  limit: number = 8
+): Promise<ActivityWithActor[]> {
+  const supabase = await createClient();
+  const team = await getTeamById(teamId);
+
+  if (!team) {
+    return [];
+  }
+
+  const userIds = [...new Set(team.members.map((member) => member.user_id))];
+  let issueIds: string[] = [];
+
+  if (userIds.length > 0) {
+    const { data: issues } = await supabase
+      .from("issues")
+      .select("id")
+      .eq("workspace_id", team.workspace_id)
+      .in("assignee_id", userIds);
+
+    issueIds = (issues ?? []).map((issue) => issue.id);
+  }
+
+  const { data: projects } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("team_id", teamId)
+    .eq("is_archived", false);
+
+  const projectIds = (projects ?? []).map((project) => project.id);
+
+  const { data: activities } = await supabase
+    .from("activities")
+    .select("*")
+    .eq("workspace_id", team.workspace_id)
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  const relevantActivities = (activities ?? [])
+    .filter((activity) => {
+      if (activity.entity_type === "issue") {
+        return issueIds.includes(activity.entity_id);
+      }
+
+      if (activity.entity_type === "team") {
+        return activity.entity_id === teamId;
+      }
+
+      if (activity.entity_type === "project") {
+        return projectIds.includes(activity.entity_id);
+      }
+
+      return false;
+    })
+    .slice(0, limit);
+
+  return hydrateActivities(relevantActivities, supabase);
+}
+
+export async function getTeamProjects(
+  teamId: string
+): Promise<TeamProject[]> {
+  const supabase = await createClient();
+
+  const { data: projects } = await supabase
+    .from("projects")
+    .select("id, workspace_id, name, description, color, team_id, updated_at")
+    .eq("team_id", teamId)
+    .eq("is_archived", false)
+    .order("name");
+
+  return projects ?? [];
 }

--- a/src/lib/utils/activities.ts
+++ b/src/lib/utils/activities.ts
@@ -89,6 +89,28 @@ export function formatActivityAction(activity: ActivityWithActor): string {
       return `${actorName} ${activity.action} project ${name}`;
     }
 
+    case "team": {
+      const name = (meta.name as string) ?? "team";
+      const memberName = (meta.member_name as string) ?? "a member";
+
+      if (activity.action === "created") {
+        return `${actorName} created team ${name}`;
+      }
+      if (activity.action === "updated") {
+        return `${actorName} renamed team to ${name}`;
+      }
+      if (activity.action === "deleted") {
+        return `${actorName} deleted team ${name}`;
+      }
+      if (activity.action === "added_member") {
+        return `${actorName} added ${memberName} to ${name}`;
+      }
+      if (activity.action === "removed_member") {
+        return `${actorName} removed ${memberName} from ${name}`;
+      }
+      return `${actorName} ${activity.action} ${name}`;
+    }
+
     default:
       return `${actorName} ${activity.action}`;
   }

--- a/src/lib/utils/members.ts
+++ b/src/lib/utils/members.ts
@@ -1,0 +1,52 @@
+export type MemberWithUserId = {
+  user_id: string;
+  profile?: {
+    full_name: string | null;
+    email: string;
+  };
+};
+
+export function dedupeMembersByUserId<T extends MemberWithUserId>(members: T[]): T[] {
+  const seen = new Set<string>();
+
+  return members.filter((member) => {
+    if (seen.has(member.user_id)) {
+      return false;
+    }
+
+    seen.add(member.user_id);
+    return true;
+  });
+}
+
+export function dedupeMembersByDisplayLabel<T extends MemberWithUserId>(
+  members: T[],
+  preferredUserId?: string
+): T[] {
+  const byLabel = new Map<string, T>();
+
+  for (const member of members) {
+    const label = (member.profile?.full_name ?? member.profile?.email ?? "").trim().toLowerCase();
+    if (!label) continue;
+
+    const existing = byLabel.get(label);
+    if (!existing) {
+      byLabel.set(label, member);
+      continue;
+    }
+
+    if (member.user_id === preferredUserId) {
+      byLabel.set(label, member);
+    }
+  }
+
+  return Array.from(byLabel.values());
+}
+
+export function sortMembersByDisplayName<T extends MemberWithUserId>(members: T[]): T[] {
+  return [...members].sort((a, b) => {
+    const aLabel = a.profile?.full_name ?? a.profile?.email ?? "";
+    const bLabel = b.profile?.full_name ?? b.profile?.email ?? "";
+    return aLabel.localeCompare(bLabel);
+  });
+}

--- a/tests/teams-collaboration.spec.ts
+++ b/tests/teams-collaboration.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+const WS = "/pw-workspace";
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+async function setCurrentUserRole(role: "owner" | "member") {
+  const { data: workspace } = await admin
+    .from("workspaces")
+    .select("id")
+    .eq("slug", "pw-workspace")
+    .single();
+
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("id")
+    .eq("email", "playwright@test.flow.dev")
+    .single();
+
+  if (!workspace || !profile) {
+    throw new Error("Missing Playwright workspace or profile");
+  }
+
+  const { error } = await admin
+    .from("workspace_members")
+    .update({ role })
+    .eq("workspace_id", workspace.id)
+    .eq("user_id", profile.id);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+test.describe.serial("Teams Collaboration Hub", () => {
+  const teamName = `Collab Hub ${Date.now()}`;
+  const renamedTeamName = `${teamName} Edited`;
+
+  test("renders overview cards, detail tabs, and issue activity drill-in", async ({
+    page,
+  }) => {
+    await page.goto(`${WS}/teams`);
+
+    await expect(page.getByRole("heading", { name: "Teams" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create Team" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open Engineering" })).toBeVisible();
+
+    const engineeringCard = page.getByRole("button", { name: "Open Engineering" });
+    await engineeringCard.click();
+
+    await expect(page).toHaveURL(/\/pw-workspace\/teams\/[0-9a-f-]+$/);
+    await expect(page.getByRole("heading", { name: "Engineering" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Members" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Projects" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Member Workload" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Team Activity" })).toBeVisible();
+
+    await page.getByRole("tab", { name: "Projects" }).click();
+    const projectsPanel = page.getByRole("tabpanel", { name: "Projects" });
+    await expect(projectsPanel.getByRole("link", { name: /API Platform/i })).toBeVisible();
+    await expect(projectsPanel.getByRole("link", { name: /Frontend v2\.4/i })).toBeVisible();
+    await expect(projectsPanel.getByRole("link", { name: /Mobile App/i })).toBeVisible();
+
+    await page.getByRole("tab", { name: "Overview" }).click();
+    const firstActivity = page
+      .getByRole("tabpanel", { name: "Overview" })
+      .getByRole("button")
+      .first();
+    await expect(firstActivity).toBeVisible();
+
+    const activityText = await firstActivity.textContent();
+    const issueKey = activityText?.match(/FLO-\d+/)?.[0];
+
+    expect(issueKey).toBeTruthy();
+    await firstActivity.click();
+
+    await expect(page).toHaveURL(new RegExp(`issue=${issueKey}`));
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`${issueKey}:`, "i") })
+    ).toBeVisible();
+
+    const optionTexts = await page.locator("select option").allTextContents();
+    expect(new Set(optionTexts).size).toBe(optionTexts.length);
+  });
+
+  test("supports team create, rename, add/remove members, and delete", async ({
+    page,
+  }) => {
+    await page.goto(`${WS}/teams`);
+
+    await page.getByRole("button", { name: "Create Team" }).click();
+    await expect(page.getByRole("heading", { name: "Create Team" })).toBeVisible();
+
+    await page.getByLabel("Team Name").fill(teamName);
+    await page.getByLabel("Initial Members").fill("Sarah");
+    await page.getByRole("button", { name: /sarah@test\.flow\.dev/i }).click();
+    await page.getByLabel("Initial Members").fill("Tom");
+    await page.getByRole("button", { name: /tom@test\.flow\.dev/i }).click();
+    await page.getByRole("dialog").getByRole("button", { name: "Create Team" }).click();
+
+    const createdCard = page.getByRole("button", { name: `Open ${teamName}` });
+    await expect(createdCard).toBeVisible();
+    await createdCard.click();
+
+    await expect(page.getByRole("heading", { name: teamName })).toBeVisible();
+
+    await page.getByRole("button", { name: "Edit Team" }).click();
+    await expect(page.getByRole("heading", { name: "Edit Team" })).toBeVisible();
+    await page.getByLabel("Team Name").fill(renamedTeamName);
+    await page.getByRole("button", { name: "Save Changes" }).click();
+
+    await expect(page.getByRole("heading", { name: renamedTeamName })).toBeVisible();
+
+    await page.getByRole("tab", { name: "Members" }).click();
+    await expect(page.getByText("sarah@test.flow.dev")).toBeVisible();
+    await expect(page.getByText("tom@test.flow.dev")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add member" }).click();
+    await page.getByPlaceholder("Search workspace members...").fill("David");
+    await page.getByRole("button", { name: /david@test\.flow\.dev/i }).click();
+    await expect(page.getByText("david@test.flow.dev")).toBeVisible();
+
+    await page
+      .getByRole("button", { name: "Remove sarah@test.flow.dev" })
+      .click();
+    await page.getByRole("button", { name: "Remove Member" }).click();
+    await expect(page.getByText("sarah@test.flow.dev")).not.toBeVisible();
+
+    await page.getByRole("button", { name: "Delete Team" }).click();
+    await page.getByRole("button", { name: "Delete Team" }).last().click();
+
+    await page.waitForURL(/\/pw-workspace\/teams$/, { timeout: 15000 });
+    await expect(page.getByRole("heading", { name: "Teams" })).toBeVisible();
+    await expect(page.getByText(renamedTeamName)).not.toBeVisible();
+  });
+
+  test("hides team management controls for workspace members", async ({ page }) => {
+    await setCurrentUserRole("member");
+
+    try {
+      await page.goto(`${WS}/teams`);
+      await expect(page.getByRole("heading", { name: "Teams" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Create Team" })).toHaveCount(0);
+      await expect(page.getByRole("button", { name: /Manage / })).toHaveCount(0);
+
+      const designCard = page.getByRole("button", { name: "Open Design" });
+      await designCard.click();
+
+      await expect(page.getByRole("heading", { name: "Design" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Edit Team" })).toHaveCount(0);
+      await expect(page.getByRole("button", { name: "Delete Team" })).toHaveCount(0);
+
+      await page.getByRole("tab", { name: "Members" }).click();
+      await expect(page.getByRole("button", { name: "Add member" })).toHaveCount(0);
+      await expect(page.getByRole("button", { name: "Remove" })).toHaveCount(0);
+    } finally {
+      await setCurrentUserRole("owner");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- turn the Teams area into a collaboration hub with team CRUD and detail pages
- add member management, workload visualization, project links, and scoped team activity drill-in
- fix duplicate assignee entries and cover the workflow with Playwright E2E tests

## Testing
- npx playwright test tests/teams-collaboration.spec.ts --project=authenticated

Fixes #25