### PR TITLE
Implement sub-issue hierarchy

### DIFF
--- a/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/my-issues-content.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useMemo, useCallback, Suspense, useSyncExternalStore } from "react";
+import {
+  useState,
+  useMemo,
+  useCallback,
+  Suspense,
+  useSyncExternalStore,
+} from "react";
 import { ChevronDown } from "lucide-react";
 import { IssueList } from "@/components/issues/issue-list";
 import { BoardView } from "@/components/board/board-view";
@@ -20,6 +26,7 @@ import { cn } from "@/lib/utils/cn";
 import { STATUS_ORDER } from "@/lib/utils/statuses";
 import type { IssueWithDetails } from "@/lib/queries/issues";
 import type { IssueStatus } from "@/lib/types";
+import { getIssueClient } from "@/lib/queries/issues-client";
 
 type ViewMode = "list" | "board";
 type SortKey = "priority" | "due_date" | "created_at" | "title" | "status";
@@ -39,6 +46,7 @@ const STORAGE_EVENT = "flow-my-issues-preferences";
 interface MyIssuesContentProps {
   issues: IssueWithDetails[];
   members?: { user_id: string; profile: { id: string; full_name: string | null; email: string; avatar_url: string | null } }[];
+  sprints?: { id: string; name: string; status: string; project_id?: string }[];
   labels?: { id: string; name: string; color: string }[];
   projects?: { id: string; name: string; color: string }[];
 }
@@ -68,6 +76,7 @@ function getStoredSortKey(): SortKey {
 function MyIssuesContentInner({
   issues,
   members = [],
+  sprints = [],
   labels = [],
   projects = [],
 }: MyIssuesContentProps) {
@@ -81,16 +90,22 @@ function MyIssuesContentInner({
     getStoredSortKey,
     () => "priority",
   );
-  const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
+  const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
+  const [selectedIssueFallback, setSelectedIssueFallback] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
   const openIssue = useCallback(
     (issue: IssueWithDetails) => {
-      setSelectedIssue(issue);
+      setSelectedIssueId(issue.id);
+      setSelectedIssueFallback(issue);
       setDetailOpen(true);
     },
     []
   );
+
+  const selectedIssue = selectedIssueId
+    ? issues.find((issue) => issue.id === selectedIssueId) ?? selectedIssueFallback
+    : null;
 
   useIssueFromUrl(issues, openIssue);
 
@@ -121,8 +136,8 @@ function MyIssuesContentInner({
   }
 
   const handleIssueClick = useCallback(
-    (id: string) => {
-      const issue = issues.find((i) => i.id === id);
+    async (id: string) => {
+      const issue = issues.find((i) => i.id === id) ?? (await getIssueClient(id));
       if (issue) openIssue(issue);
     },
     [issues, openIssue]
@@ -250,6 +265,7 @@ function MyIssuesContentInner({
             showProject={true}
             onIssueClick={handleIssueClick}
             issueFilter={issueFilterFn}
+            showHierarchy={false}
           />
         )
       ) : hasActiveFilters ? (
@@ -274,10 +290,14 @@ function MyIssuesContentInner({
 
       {/* Issue detail panel */}
       <IssueDetailPanel
+        key={selectedIssue?.id ?? "issue-detail-empty"}
         issue={selectedIssue}
         open={detailOpen}
         onOpenChange={setDetailOpen}
         members={members}
+        sprints={sprints}
+        labels={labels}
+        onIssueNavigate={handleIssueClick}
       />
     </>
   );

--- a/src/app/(app)/[workspaceSlug]/my-issues/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/my-issues/page.tsx
@@ -69,7 +69,13 @@ export default async function MyIssuesPage({
       </div>
 
       {/* View toggle, sort dropdown, and issue list/board */}
-      <MyIssuesContent issues={issues} members={members} labels={labels} projects={projects} />
+      <MyIssuesContent
+        issues={issues}
+        members={members}
+        sprints={sprints}
+        labels={labels}
+        projects={projects}
+      />
     </div>
   );
 }

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/board-with-detail.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/board-with-detail.tsx
@@ -7,11 +7,13 @@ import { useIssueFromUrl } from "@/lib/hooks/use-issue-from-url";
 import { FilterBar } from "@/components/filters/filter-bar";
 import { useIssueFilters } from "@/lib/hooks/use-issue-filters";
 import type { IssueWithDetails } from "@/lib/queries/issues";
+import { getIssueClient } from "@/lib/queries/issues-client";
 
 interface BoardWithDetailProps {
   initialIssues: IssueWithDetails[];
   projectId: string;
   members?: { user_id: string; profile: { id: string; full_name: string | null; email: string; avatar_url: string | null } }[];
+  sprints?: { id: string; name: string; status: string; project_id?: string }[];
   labels?: { id: string; name: string; color: string }[];
 }
 
@@ -19,18 +21,25 @@ function BoardWithDetailInner({
   initialIssues,
   projectId,
   members = [],
+  sprints = [],
   labels = [],
 }: BoardWithDetailProps) {
-  const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
+  const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
+  const [selectedIssueFallback, setSelectedIssueFallback] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
   const openIssue = useCallback(
     (issue: IssueWithDetails) => {
-      setSelectedIssue(issue);
+      setSelectedIssueId(issue.id);
+      setSelectedIssueFallback(issue);
       setDetailOpen(true);
     },
     []
   );
+
+  const selectedIssue = selectedIssueId
+    ? initialIssues.find((issue) => issue.id === selectedIssueId) ?? selectedIssueFallback
+    : null;
 
   const {
     filters,
@@ -48,8 +57,10 @@ function BoardWithDetailInner({
   });
 
   const handleIssueClick = useCallback(
-    (id: string) => {
-      const issue = initialIssues.find((i) => i.id === id);
+    async (id: string) => {
+      const issue =
+        initialIssues.find((item) => item.id === id) ??
+        (await getIssueClient(id));
       if (issue) openIssue(issue);
     },
     [initialIssues, openIssue]
@@ -81,10 +92,14 @@ function BoardWithDetailInner({
         issueFilter={issueFilterFn}
       />
       <IssueDetailPanel
+        key={selectedIssue?.id ?? "issue-detail-empty"}
         issue={selectedIssue}
         open={detailOpen}
         onOpenChange={setDetailOpen}
         members={members}
+        sprints={sprints}
+        labels={labels}
+        onIssueNavigate={handleIssueClick}
       />
     </>
   );

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/page.tsx
@@ -60,6 +60,7 @@ export default async function BoardPage({
           initialIssues={issues}
           projectId={projectId}
           members={members}
+          sprints={sprints}
           labels={labels}
         />
       </div>

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/list-view-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/list-view-content.tsx
@@ -7,15 +7,18 @@ import { useIssueFromUrl } from "@/lib/hooks/use-issue-from-url";
 import { FilterBar } from "@/components/filters/filter-bar";
 import { useIssueFilters } from "@/lib/hooks/use-issue-filters";
 import type { IssueWithDetails } from "@/lib/queries/issues";
+import { getIssueClient } from "@/lib/queries/issues-client";
 
 interface ListViewContentProps {
   issues: IssueWithDetails[];
   members: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  sprints: { id: string; name: string; status: string; project_id?: string }[];
   labels: { id: string; name: string; color: string }[];
 }
 
-function ListViewContentInner({ issues, members, labels }: ListViewContentProps) {
-  const [selectedIssue, setSelectedIssue] = useState<IssueWithDetails | null>(null);
+function ListViewContentInner({ issues, members, sprints, labels }: ListViewContentProps) {
+  const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
+  const [selectedIssueFallback, setSelectedIssueFallback] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
   const {
@@ -35,15 +38,20 @@ function ListViewContentInner({ issues, members, labels }: ListViewContentProps)
 
   const openIssue = useCallback(
     (issue: IssueWithDetails) => {
-      setSelectedIssue(issue);
+      setSelectedIssueId(issue.id);
+      setSelectedIssueFallback(issue);
       setDetailOpen(true);
     },
     []
   );
 
+  const selectedIssue = selectedIssueId
+    ? issues.find((issue) => issue.id === selectedIssueId) ?? selectedIssueFallback
+    : null;
+
   const handleIssueClick = useCallback(
-    (id: string) => {
-      const issue = issues.find((i) => i.id === id);
+    async (id: string) => {
+      const issue = issues.find((i) => i.id === id) ?? (await getIssueClient(id));
       if (issue) openIssue(issue);
     },
     [issues, openIssue]
@@ -72,12 +80,17 @@ function ListViewContentInner({ issues, members, labels }: ListViewContentProps)
         issues={filteredIssues}
         showProject={false}
         onIssueClick={handleIssueClick}
+        treeMode
       />
       <IssueDetailPanel
+        key={selectedIssue?.id ?? "issue-detail-empty"}
         issue={selectedIssue}
         open={detailOpen}
         onOpenChange={setDetailOpen}
         members={members}
+        sprints={sprints}
+        labels={labels}
+        onIssueNavigate={handleIssueClick}
       />
     </>
   );

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/list-with-detail.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/list-with-detail.tsx
@@ -41,6 +41,7 @@ export function ListWithDetail({ issues, members = [] }: ListWithDetailProps) {
         onIssueClick={handleIssueClick}
       />
       <IssueDetailPanel
+        key={selectedIssue?.id ?? "issue-detail-empty"}
         issue={selectedIssue}
         open={detailOpen}
         onOpenChange={setDetailOpen}

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/page.tsx
@@ -54,7 +54,12 @@ export default async function ListPage({
       />
 
       {hasIssues && (
-        <ListViewContent issues={issues} members={members} labels={labels} />
+        <ListViewContent
+          issues={issues}
+          members={members}
+          sprints={sprints}
+          labels={labels}
+        />
       )}
     </div>
   );

--- a/src/components/board/board-card.tsx
+++ b/src/components/board/board-card.tsx
@@ -23,8 +23,12 @@ export interface BoardCardProps {
   labels: { id: string; name: string; color: string }[];
   projectName?: string;
   projectColor?: string;
+  parent?: { id: string; issue_key: string; title: string } | null;
+  subIssueDoneCount?: number;
+  subIssueTotalCount?: number;
   isDragOverlay?: boolean;
   onClick?: (id: string) => void;
+  onParentClick?: (id: string) => void;
 }
 
 export function BoardCard({
@@ -38,8 +42,12 @@ export function BoardCard({
   labels,
   projectName,
   projectColor,
+  parent,
+  subIssueDoneCount = 0,
+  subIssueTotalCount = 0,
   isDragOverlay = false,
   onClick,
+  onParentClick,
 }: BoardCardProps) {
   const sortable = useSortable({ id, disabled: isDragOverlay });
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
@@ -56,6 +64,10 @@ export function BoardCard({
   const isDone = status === "done";
   const isOverdue =
     !isDone && dueDate && new Date(dueDate) < new Date(new Date().toDateString());
+  const subIssueProgress =
+    subIssueTotalCount > 0
+      ? Math.max(0, Math.min(100, (subIssueDoneCount / subIssueTotalCount) * 100))
+      : 0;
 
   return (
     <div
@@ -75,11 +87,18 @@ export function BoardCard({
       {/* Header: issue key + priority dot */}
       <div className="flex items-center justify-between">
         <span className="text-xs font-mono text-text-muted">{issueKey}</span>
-        <span
-          className="w-2.5 h-2.5 rounded-full shrink-0"
-          style={{ backgroundColor: priorityConfig.color }}
-          title={priorityConfig.label}
-        />
+        <div className="flex items-center gap-2">
+          {subIssueTotalCount > 0 && (
+            <span className="rounded-full border border-border bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+              {subIssueDoneCount}/{subIssueTotalCount}
+            </span>
+          )}
+          <span
+            className="w-2.5 h-2.5 rounded-full shrink-0"
+            style={{ backgroundColor: priorityConfig.color }}
+            title={priorityConfig.label}
+          />
+        </div>
       </div>
 
       {/* Title */}
@@ -102,6 +121,43 @@ export function BoardCard({
               {label.name}
             </span>
           ))}
+        </div>
+      )}
+
+      {subIssueTotalCount > 0 && (
+        <div className="mt-2 space-y-1">
+          <div className="flex items-center justify-between text-[10px] text-text-muted">
+            <span>Sub-issues</span>
+            <span>
+              {subIssueDoneCount}/{subIssueTotalCount} done
+            </span>
+          </div>
+          <div className="h-1 rounded-full bg-surface-hover">
+            <div
+              className="h-full rounded-full bg-primary transition-[width]"
+              style={{ width: `${subIssueProgress}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {parent && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onParentClick?.(parent.id);
+            }}
+            disabled={!onParentClick}
+            className={cn(
+              "inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-surface-hover px-2 py-1 text-[10px] font-medium text-text-secondary transition-colors",
+              onParentClick ? "hover:bg-border" : "cursor-default",
+            )}
+          >
+            <span className="truncate">parent:</span>
+            <span className="font-mono">{parent.issue_key}</span>
+          </button>
         </div>
       )}
 

--- a/src/components/board/board-column.tsx
+++ b/src/components/board/board-column.tsx
@@ -16,24 +16,28 @@ interface BoardColumnProps {
   status: IssueStatus;
   issues: IssueWithDetails[];
   showProject?: boolean;
+  showHierarchy?: boolean;
   projectId: string;
   quickAddActive: boolean;
   onQuickAddOpen: () => void;
   onQuickAddClose: () => void;
   onQuickAddCreated: () => void;
   onIssueClick?: (id: string) => void;
+  onParentClick?: (id: string) => void;
 }
 
 export function BoardColumn({
   status,
   issues,
   showProject = false,
+  showHierarchy = true,
   projectId,
   quickAddActive,
   onQuickAddOpen,
   onQuickAddClose,
   onQuickAddCreated,
   onIssueClick,
+  onParentClick,
 }: BoardColumnProps) {
   const { setNodeRef } = useDroppable({ id: status });
   const config = STATUS_CONFIG[status];
@@ -96,7 +100,11 @@ export function BoardColumn({
               labels={issue.labels}
               projectName={showProject ? issue.project?.name : undefined}
               projectColor={showProject ? issue.project?.color : undefined}
+              parent={showHierarchy ? issue.parent : null}
+              subIssueDoneCount={showHierarchy ? issue.sub_issues_done_count : 0}
+              subIssueTotalCount={showHierarchy ? issue.sub_issues_count : 0}
               onClick={onIssueClick}
+              onParentClick={onParentClick}
             />
           ))}
 

--- a/src/components/board/board-view.tsx
+++ b/src/components/board/board-view.tsx
@@ -122,14 +122,15 @@ export function BoardView({
     }
 
     return issues.map((issue) => {
-      const parent =
-        issue.parent_id && issueMap.has(issue.parent_id)
+      const parent = issue.parent_id
+        ? issueMap.has(issue.parent_id)
           ? {
               id: issue.parent_id,
               issue_key: issueMap.get(issue.parent_id)!.issue_key,
               title: issueMap.get(issue.parent_id)!.title,
             }
-          : issue.parent;
+          : issue.parent
+        : null;
       const stats = childStats.get(issue.id);
 
       return {

--- a/src/components/board/board-view.tsx
+++ b/src/components/board/board-view.tsx
@@ -26,6 +26,7 @@ interface BoardViewProps {
   initialIssues: IssueWithDetails[];
   projectId: string;
   showProject?: boolean;
+  showHierarchy?: boolean;
   onIssueClick?: (id: string) => void;
   issueFilter?: (issue: IssueWithDetails) => boolean;
 }
@@ -83,6 +84,7 @@ export function BoardView({
   initialIssues,
   projectId,
   showProject = false,
+  showHierarchy = true,
   onIssueClick,
   issueFilter,
 }: BoardViewProps) {
@@ -103,13 +105,49 @@ export function BoardView({
     }),
   );
 
+  const hierarchyIssues = useMemo(() => {
+    if (!showHierarchy) return issues;
+
+    const issueMap = new Map(issues.map((issue) => [issue.id, issue]));
+    const childStats = new Map<string, { done: number; total: number }>();
+
+    for (const issue of issues) {
+      if (!issue.parent_id) continue;
+      const stats = childStats.get(issue.parent_id) ?? { done: 0, total: 0 };
+      stats.total += 1;
+      if (issue.status === "done") {
+        stats.done += 1;
+      }
+      childStats.set(issue.parent_id, stats);
+    }
+
+    return issues.map((issue) => {
+      const parent =
+        issue.parent_id && issueMap.has(issue.parent_id)
+          ? {
+              id: issue.parent_id,
+              issue_key: issueMap.get(issue.parent_id)!.issue_key,
+              title: issueMap.get(issue.parent_id)!.title,
+            }
+          : issue.parent;
+      const stats = childStats.get(issue.id);
+
+      return {
+        ...issue,
+        parent,
+        sub_issues_count: stats?.total ?? issue.sub_issues_count,
+        sub_issues_done_count: stats?.done ?? issue.sub_issues_done_count,
+      };
+    });
+  }, [issues, showHierarchy]);
+
   // Group and sort issues into columns, applying optional filter for display
   const columns = useMemo(() => {
     const map = new Map<IssueStatus, IssueWithDetails[]>();
     for (const s of STATUS_ORDER) {
       map.set(s, []);
     }
-    for (const issue of issues) {
+    for (const issue of hierarchyIssues) {
       if (issueFilter && !issueFilter(issue)) continue;
       const col = map.get(issue.status as IssueStatus);
       if (col) col.push(issue);
@@ -118,10 +156,10 @@ export function BoardView({
       col.sort((a, b) => a.sort_order - b.sort_order);
     }
     return map;
-  }, [issues, issueFilter]);
+  }, [hierarchyIssues, issueFilter]);
 
   const activeIssue = activeId
-    ? issues.find((i) => i.id === activeId) ?? null
+    ? hierarchyIssues.find((i) => i.id === activeId) ?? null
     : null;
 
   // --- Drag Handlers ---
@@ -139,12 +177,12 @@ export function BoardView({
       const { active, over } = event;
       if (!over) return;
 
-      const activeIssueStatus = issues.find(
+      const activeIssueStatus = hierarchyIssues.find(
         (i) => i.id === active.id,
       )?.status as IssueStatus | undefined;
       const overColumn = findColumnOfOver(
         over.id,
-        issues,
+        hierarchyIssues,
         over.data?.current as Record<string, unknown> | undefined,
       );
 
@@ -158,7 +196,7 @@ export function BoardView({
         ),
       );
     },
-    [issues, setIssues],
+    [hierarchyIssues, setIssues],
   );
 
   const handleDragEnd = useCallback(
@@ -169,18 +207,18 @@ export function BoardView({
       if (!over) return;
 
       const activeIssueId = active.id as string;
-      const activeIssue = issues.find((i) => i.id === activeIssueId);
+      const activeIssue = hierarchyIssues.find((i) => i.id === activeIssueId);
       if (!activeIssue) return;
 
       const targetColumn = findColumnOfOver(
         over.id,
-        issues,
+        hierarchyIssues,
         over.data?.current as Record<string, unknown> | undefined,
       );
       if (!targetColumn) return;
 
       const newStatus = targetColumn;
-      const columnIssues = issues
+      const columnIssues = hierarchyIssues
         .filter((i) => i.status === newStatus && i.id !== activeIssueId)
         .sort((a, b) => a.sort_order - b.sort_order);
 
@@ -219,7 +257,7 @@ export function BoardView({
 
       // Rebalance if needed
       if (needsRebalance(columnIssues, targetIndex)) {
-        const allColumnIssues = issues
+        const allColumnIssues = hierarchyIssues
           .filter((i) => i.status === newStatus || i.id === activeIssueId)
           .filter((i) => i.status === newStatus)
           .sort((a, b) => a.sort_order - b.sort_order);
@@ -243,7 +281,7 @@ export function BoardView({
         );
       }
     },
-    [issues, setIssues],
+    [hierarchyIssues, setIssues],
   );
 
   const handleDragCancel = useCallback(() => {
@@ -271,12 +309,14 @@ export function BoardView({
             status={status}
             issues={columns.get(status) ?? []}
             showProject={showProject}
+            showHierarchy={showHierarchy}
             projectId={projectId}
             quickAddActive={quickAddStatus === status}
             onQuickAddOpen={() => setQuickAddStatus(status)}
             onQuickAddClose={() => setQuickAddStatus(null)}
             onQuickAddCreated={handleQuickAddCreated}
             onIssueClick={onIssueClick}
+            onParentClick={onIssueClick}
           />
         ))}
       </div>
@@ -298,7 +338,11 @@ export function BoardView({
             projectColor={
               showProject ? activeIssue.project?.color : undefined
             }
+            parent={showHierarchy ? activeIssue.parent : null}
+            subIssueDoneCount={showHierarchy ? activeIssue.sub_issues_done_count : 0}
+            subIssueTotalCount={showHierarchy ? activeIssue.sub_issues_count : 0}
             isDragOverlay
+            onParentClick={onIssueClick}
           />
         ) : null}
       </DragOverlay>

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -65,6 +65,7 @@ export function DashboardContent({
         </div>
       </div>
       <IssueDetailPanel
+        key={selectedIssue?.id ?? "issue-detail-empty"}
         issue={selectedIssue}
         open={detailOpen}
         onOpenChange={setDetailOpen}

--- a/src/components/dashboard/recent-activity-card.tsx
+++ b/src/components/dashboard/recent-activity-card.tsx
@@ -22,6 +22,8 @@ function getActorInitials(
 function getActivityIcon(activity: ActivityWithActor) {
   if (activity.action === "created") return Plus;
   if (activity.action === "deleted") return Trash2;
+  if (activity.action === "added_sub_issue") return Plus;
+  if (activity.action === "removed_from_parent") return Trash2;
   if (activity.action === "updated") {
     const meta = activity.metadata as Record<string, unknown>;
     const changes = meta?.changes as Record<string, unknown> | undefined;

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -129,6 +129,7 @@ export function InboxClient({
 
       {/* Issue detail panel */}
       <IssueDetailPanel
+        key={selectedIssue?.id ?? "issue-detail-empty"}
         issue={selectedIssue}
         open={detailOpen}
         onOpenChange={setDetailOpen}

--- a/src/components/issues/comment-thread.tsx
+++ b/src/components/issues/comment-thread.tsx
@@ -48,6 +48,8 @@ function getActivityIcon(activity: ActivityWithActor) {
 
   if (activity.action === "created") return Plus;
   if (activity.action === "commented") return MessageSquare;
+  if (activity.action === "added_sub_issue") return Plus;
+  if (activity.action === "removed_from_parent") return Trash2;
   if (field === "status" || changes?.status) return ArrowRight;
   if (field === "assignee" || changes?.assignee_id) return UserCheck;
   return Pencil;

--- a/src/components/issues/create-issue-modal.tsx
+++ b/src/components/issues/create-issue-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { X } from "lucide-react";
 import { toast } from "sonner";
@@ -20,11 +20,14 @@ import { cn } from "@/lib/utils/cn";
 import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { STATUS_CONFIG, STATUS_ORDER } from "@/lib/utils/statuses";
 import type { IssuePriority, IssueStatus } from "@/lib/types";
+import { ParentIssuePicker } from "./parent-issue-picker";
+import type { ParentIssueSearchResult } from "@/lib/queries/search";
 
 interface CreateIssueModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   defaultProjectId?: string;
+  defaultParentIssue?: ParentIssueSearchResult | null;
   defaultAssigneeId?: string;
   defaultStatus?: IssueStatus;
   projects?: { id: string; name: string; color: string }[];
@@ -38,6 +41,7 @@ export function CreateIssueModal({
   open,
   onOpenChange,
   defaultProjectId,
+  defaultParentIssue,
   defaultAssigneeId,
   defaultStatus,
   projects = [],
@@ -50,73 +54,79 @@ export function CreateIssueModal({
   const { workspace } = useWorkspace();
   const [priority, setPriority] = useState<IssuePriority>(3);
   const [status, setStatus] = useState<IssueStatus>(defaultStatus ?? "todo");
-  const [selectedProjectId, setSelectedProjectId] = useState<string>(defaultProjectId ?? "");
+  const [selectedProjectId, setSelectedProjectId] = useState<string>(
+    defaultParentIssue?.project_id ?? defaultProjectId ?? "",
+  );
+  const [selectedSprintId, setSelectedSprintId] = useState<string>(
+    defaultParentIssue?.sprint_id ?? "",
+  );
+  const [selectedParent, setSelectedParent] = useState<ParentIssueSearchResult | null>(
+    defaultParentIssue ?? null,
+  );
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<{ title?: string; projectId?: string }>({});
   const [showLabelPicker, setShowLabelPicker] = useState(false);
 
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
+  function resetFormState() {
+    setPriority(3);
+    setStatus(defaultStatus ?? "todo");
+    setSelectedProjectId(defaultParentIssue?.project_id ?? defaultProjectId ?? "");
+    setSelectedSprintId(defaultParentIssue?.sprint_id ?? "");
+    setSelectedParent(defaultParentIssue ?? null);
+    setSelectedLabels([]);
+    setError(null);
+    setFieldErrors({});
+    setShowLabelPicker(false);
+  }
 
-      const form = e.currentTarget;
-      const formData = new FormData(form);
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
 
-      // Custom validation
-      const title = (formData.get("title") as string)?.trim();
-      const projectId = formData.get("projectId") as string;
-      const errors: { title?: string; projectId?: string } = {};
-      if (!title) errors.title = "Title is required";
-      if (!projectId) errors.projectId = "Please select a project";
-      if (Object.keys(errors).length > 0) {
-        setFieldErrors(errors);
-        return;
-      }
-      setFieldErrors({});
+    const form = e.currentTarget;
+    const formData = new FormData(form);
 
-      setLoading(true);
-      setError(null);
-      formData.set("workspaceId", workspace.id);
-      formData.set("priority", String(priority));
-      formData.set("status", status);
-      formData.set("labelIds", selectedLabels.join(","));
-      formData.set("sortOrder", String(initialSortOrder));
-
-      const result = await createIssue(formData);
-
-      if ("error" in result && result.error) {
-        setError(result.error);
-        setLoading(false);
-        return;
-      }
-
-      setLoading(false);
-      onOpenChange(false);
-      setPriority(3);
-      setStatus(defaultStatus ?? "todo");
-      setSelectedLabels([]);
-      if ("data" in result && result.data) {
-        toast.success(`Issue ${result.data.issue_key} created`);
-      }
-      router.refresh();
-    },
-    [workspace.id, priority, status, selectedLabels, defaultStatus, onOpenChange, router],
-  );
-
-  // Reset state on open
-  useEffect(() => {
-    if (open) {
-      setPriority(3);
-      setStatus(defaultStatus ?? "todo");
-      setSelectedProjectId(defaultProjectId ?? "");
-      setSelectedLabels([]);
-      setError(null);
-      setFieldErrors({});
-      setShowLabelPicker(false);
+    const title = (formData.get("title") as string)?.trim();
+    const projectId = selectedProjectId;
+    const errors: { title?: string; projectId?: string } = {};
+    if (!title) errors.title = "Title is required";
+    if (!projectId) errors.projectId = "Please select a project";
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
     }
-  }, [open]);
+    setFieldErrors({});
+
+    setLoading(true);
+    setError(null);
+    formData.set("workspaceId", workspace.id);
+    formData.set("projectId", selectedProjectId);
+    formData.set("sprintId", selectedSprintId);
+    formData.set("priority", String(priority));
+    formData.set("status", status);
+    formData.set("labelIds", selectedLabels.join(","));
+    formData.set("sortOrder", String(initialSortOrder));
+    if (selectedParent) {
+      formData.set("parentId", selectedParent.id);
+    }
+
+    const result = await createIssue(formData);
+
+    if ("error" in result && result.error) {
+      setError(result.error);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+    resetFormState();
+    onOpenChange(false);
+    if ("data" in result && result.data) {
+      toast.success(`Issue ${result.data.issue_key} created`);
+    }
+    router.refresh();
+  }
 
   function toggleLabel(labelId: string) {
     setSelectedLabels((prev) =>
@@ -130,8 +140,9 @@ export function CreateIssueModal({
     setSelectedLabels((prev) => prev.filter((id) => id !== labelId));
   }
 
-  const activeSprints = sprints.filter((s) => {
-    const statusOk = s.status === "active" || s.status === "planning";
+  const availableSprints = sprints.filter((s) => {
+    const statusOk =
+      s.status === "active" || s.status === "planning" || s.id === selectedSprintId;
     const projectOk =
       !selectedProjectId || !s.project_id || s.project_id === selectedProjectId;
     return statusOk && projectOk;
@@ -143,7 +154,10 @@ export function CreateIssueModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[520px]">
+      <DialogContent
+        className="sm:max-w-[520px]"
+        onOpenAutoFocus={resetFormState}
+      >
         <DialogHeader>
           <DialogTitle>New Issue</DialogTitle>
         </DialogHeader>
@@ -256,6 +270,29 @@ export function CreateIssueModal({
               </div>
             </div>
 
+            <div className="space-y-1.5">
+              <Label>Parent Issue</Label>
+              <ParentIssuePicker
+                projectId={selectedProjectId}
+                value={selectedParent}
+                onChange={(nextParent) => {
+                  setSelectedParent(nextParent);
+                  if (nextParent) {
+                    const projectChanged = nextParent.project_id !== selectedProjectId;
+                    setSelectedProjectId(nextParent.project_id);
+                    setSelectedSprintId(nextParent.sprint_id ?? "");
+                    if (projectChanged) {
+                      setSelectedLabels([]);
+                    }
+                    if (fieldErrors.projectId) {
+                      setFieldErrors((prev) => ({ ...prev, projectId: undefined }));
+                    }
+                  }
+                }}
+                placeholder="Search for a parent issue..."
+              />
+            </div>
+
             {/* Project & Sprint row */}
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-1.5">
@@ -265,8 +302,10 @@ export function CreateIssueModal({
                   name="projectId"
                   className="flex h-9 w-full rounded-lg border border-border bg-surface px-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/10 focus:border-border-strong transition-colors"
                   value={selectedProjectId}
+                  disabled={Boolean(selectedParent)}
                   onChange={(e) => {
                     setSelectedProjectId(e.target.value);
+                    setSelectedSprintId("");
                     setSelectedLabels([]);
                     if (fieldErrors.projectId) setFieldErrors((prev) => ({ ...prev, projectId: undefined }));
                   }}
@@ -283,6 +322,11 @@ export function CreateIssueModal({
                 {fieldErrors.projectId && (
                   <p className="text-sm text-danger">{fieldErrors.projectId}</p>
                 )}
+                {selectedParent && (
+                  <p className="text-xs text-text-muted">
+                    Locked to the selected parent issue&apos;s project.
+                  </p>
+                )}
               </div>
 
               <div className="space-y-1.5">
@@ -291,10 +335,11 @@ export function CreateIssueModal({
                   id="issue-sprint"
                   name="sprintId"
                   className="flex h-9 w-full rounded-lg border border-border bg-surface px-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/10 focus:border-border-strong transition-colors"
-                  defaultValue=""
+                  value={selectedSprintId}
+                  onChange={(e) => setSelectedSprintId(e.target.value)}
                 >
                   <option value="">No sprint</option>
-                  {activeSprints.map((s) => (
+                  {availableSprints.map((s) => (
                     <option key={s.id} value={s.id}>
                       {s.name}
                     </option>

--- a/src/components/issues/create-issue-modal.tsx
+++ b/src/components/issues/create-issue-modal.tsx
@@ -68,6 +68,7 @@ export function CreateIssueModal({
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<{ title?: string; projectId?: string }>({});
   const [showLabelPicker, setShowLabelPicker] = useState(false);
+  const sprintLocked = Boolean(selectedParent);
 
   function resetFormState() {
     setPriority(3);
@@ -100,9 +101,12 @@ export function CreateIssueModal({
 
     setLoading(true);
     setError(null);
+    const resolvedSprintId = selectedParent
+      ? (selectedParent.sprint_id ?? "")
+      : selectedSprintId;
     formData.set("workspaceId", workspace.id);
     formData.set("projectId", selectedProjectId);
-    formData.set("sprintId", selectedSprintId);
+    formData.set("sprintId", resolvedSprintId);
     formData.set("priority", String(priority));
     formData.set("status", status);
     formData.set("labelIds", selectedLabels.join(","));
@@ -336,6 +340,7 @@ export function CreateIssueModal({
                   name="sprintId"
                   className="flex h-9 w-full rounded-lg border border-border bg-surface px-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/10 focus:border-border-strong transition-colors"
                   value={selectedSprintId}
+                  disabled={sprintLocked}
                   onChange={(e) => setSelectedSprintId(e.target.value)}
                 >
                   <option value="">No sprint</option>
@@ -345,6 +350,12 @@ export function CreateIssueModal({
                     </option>
                   ))}
                 </select>
+                {sprintLocked && (
+                  <p className="text-xs text-text-muted">
+                    Inherited from the selected parent issue. You can move the
+                    sub-issue after creation.
+                  </p>
+                )}
               </div>
             </div>
 

--- a/src/components/issues/issue-detail-panel.tsx
+++ b/src/components/issues/issue-detail-panel.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
-import { Copy } from "lucide-react";
+import { Copy, Plus } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -15,11 +15,17 @@ import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { STATUS_CONFIG, STATUS_ORDER } from "@/lib/utils/statuses";
 import { formatDate } from "@/lib/utils/dates";
 import { updateIssue } from "@/lib/actions/issues";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils/format";
 import { TiptapEditor } from "./tiptap-editor";
 import { IssueChecklist } from "./issue-checklist";
 import { CommentThread } from "./comment-thread";
+import { CreateIssueModal } from "./create-issue-modal";
+import { ParentIssuePicker } from "./parent-issue-picker";
 import type { ChecklistItem } from "./issue-checklist";
 import type { IssueWithDetails } from "@/lib/queries/issues";
+import { getSubIssuesClient } from "@/lib/queries/issues-client";
+import type { ParentIssueSearchResult } from "@/lib/queries/search";
 import type { IssuePriority, IssueStatus } from "@/lib/types";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 
@@ -33,7 +39,24 @@ interface IssueDetailPanelProps {
     user_id: string;
     profile: { full_name: string | null; email: string };
   }[];
+  sprints?: { id: string; name: string; status: string; project_id?: string }[];
+  labels?: { id: string; name: string; color: string; project_id?: string }[];
+  onIssueNavigate?: (issueId: string) => void;
   syncUrl?: boolean;
+}
+
+function toParentIssueValue(
+  issue: IssueWithDetails | null,
+): ParentIssueSearchResult | null {
+  if (!issue?.parent) return null;
+
+  return {
+    id: issue.parent.id,
+    issue_key: issue.parent.issue_key,
+    title: issue.parent.title,
+    project_id: issue.project_id,
+    sprint_id: null,
+  };
 }
 
 // ─── Component ───────────────────────────────────────────────
@@ -43,6 +66,9 @@ export function IssueDetailPanel({
   open,
   onOpenChange,
   members = [],
+  sprints = [],
+  labels = [],
+  onIssueNavigate,
   syncUrl = true,
 }: IssueDetailPanelProps) {
   const router = useRouter();
@@ -50,36 +76,57 @@ export function IssueDetailPanel({
   const searchParams = useSearchParams();
 
   // ── Local field state ──────────────────────────────────────
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [status, setStatus] = useState<IssueStatus>("todo");
-  const [priority, setPriority] = useState<IssuePriority>(3);
-  const [assigneeId, setAssigneeId] = useState("");
-  const [dueDate, setDueDate] = useState("");
-  const [storyPoints, setStoryPoints] = useState("");
-  const [checklist, setChecklist] = useState<ChecklistItem[]>([]);
+  const [title, setTitle] = useState(issue?.title ?? "");
+  const [description, setDescription] = useState(issue?.description ?? "");
+  const [status, setStatus] = useState<IssueStatus>(
+    (issue?.status as IssueStatus) ?? "todo",
+  );
+  const [priority, setPriority] = useState<IssuePriority>(
+    (issue?.priority as IssuePriority) ?? 3,
+  );
+  const [assigneeId, setAssigneeId] = useState(issue?.assignee_id ?? "");
+  const [dueDate, setDueDate] = useState(issue?.due_date ?? "");
+  const [storyPoints, setStoryPoints] = useState(
+    issue?.story_points != null ? String(issue.story_points) : "",
+  );
+  const [checklist, setChecklist] = useState<ChecklistItem[]>(() => {
+    const raw = issue?.checklist as unknown;
+    return Array.isArray(raw) ? (raw as ChecklistItem[]) : [];
+  });
+  const [parentIssue, setParentIssue] = useState<ParentIssueSearchResult | null>(
+    toParentIssueValue(issue),
+  );
+  const [subIssues, setSubIssues] = useState<IssueWithDetails[]>([]);
+  const [createSubIssueOpen, setCreateSubIssueOpen] = useState(false);
   const [saving, setSaving] = useState(false);
 
   // Track current issue id to avoid stale saves
   const issueRef = useRef(issue);
-  issueRef.current = issue;
-
-  // ── Sync state from issue prop ─────────────────────────────
   useEffect(() => {
-    if (issue) {
-      setTitle(issue.title);
-      setDescription(issue.description ?? "");
-      setStatus(issue.status as IssueStatus);
-      setPriority(issue.priority as IssuePriority);
-      setAssigneeId(issue.assignee_id ?? "");
-      setDueDate(issue.due_date ?? "");
-      setStoryPoints(
-        issue.story_points != null ? String(issue.story_points) : ""
-      );
-      const raw = (issue as Record<string, unknown>).checklist;
-      setChecklist(Array.isArray(raw) ? (raw as ChecklistItem[]) : []);
-    }
+    issueRef.current = issue;
   }, [issue]);
+
+  useEffect(() => {
+    if (!open || !issue || issue.parent_id) {
+      return;
+    }
+
+    let cancelled = false;
+
+    getSubIssuesClient(issue.id)
+      .then((items) => {
+        if (cancelled) return;
+        setSubIssues(items);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setSubIssues([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, issue, createSubIssueOpen]);
 
   // ── URL sync ───────────────────────────────────────────────
   useEffect(() => {
@@ -104,7 +151,7 @@ export function IssueDetailPanel({
   const save = useCallback(
     async (updates: Parameters<typeof updateIssue>[1]) => {
       const current = issueRef.current;
-      if (!current) return;
+      if (!current) return { error: "Issue not found" };
       setSaving(true);
       const result = await updateIssue(current.id, updates);
       setSaving(false);
@@ -113,9 +160,19 @@ export function IssueDetailPanel({
       } else {
         router.refresh();
       }
+      return result;
     },
     [router]
   );
+
+  // ── Copy permalink ─────────────────────────────────────────
+  const copyPermalink = useCallback(() => {
+    if (!issue) return;
+    const url = `${window.location.origin}${pathname}?issue=${issue.issue_key}`;
+    navigator.clipboard.writeText(url).then(() => {
+      toast.success("Link copied");
+    });
+  }, [issue, pathname]);
 
   // ── Keyboard shortcuts ─────────────────────────────────────
   useEffect(() => {
@@ -130,7 +187,6 @@ export function IssueDetailPanel({
         target.isContentEditable;
       if (isEditable) return;
 
-      // 1-4 for priority
       if (e.key >= "1" && e.key <= "4") {
         e.preventDefault();
         const p = (Number(e.key) - 1) as IssuePriority;
@@ -139,7 +195,6 @@ export function IssueDetailPanel({
         return;
       }
 
-      // S to cycle status
       if (e.key === "s" || e.key === "S") {
         e.preventDefault();
         setStatus((prev) => {
@@ -151,27 +206,42 @@ export function IssueDetailPanel({
         return;
       }
 
-      // C to copy permalink
-      if (e.key === "c" || e.key === "C") {
-        if (!e.metaKey && !e.ctrlKey) {
-          e.preventDefault();
-          copyPermalink();
-        }
+      if ((e.key === "c" || e.key === "C") && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        copyPermalink();
       }
     }
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, save]);
+  }, [open, save, copyPermalink]);
 
-  // ── Copy permalink ─────────────────────────────────────────
-  const copyPermalink = useCallback(() => {
-    if (!issue) return;
-    const url = `${window.location.origin}${pathname}?issue=${issue.issue_key}`;
-    navigator.clipboard.writeText(url).then(() => {
-      toast.success("Link copied");
-    });
-  }, [issue, pathname]);
+  const hasSubIssues =
+    subIssues.length > 0 || (issue?.sub_issues_count ?? 0) > 0;
+  const subIssueDoneCount =
+    subIssues.length > 0
+      ? subIssues.filter((subIssue) => subIssue.status === "done").length
+      : issue?.sub_issues_done_count ?? 0;
+  const subIssueTotalCount =
+    subIssues.length > 0 ? subIssues.length : issue?.sub_issues_count ?? 0;
+  const subIssueStoryPoints =
+    subIssues.length > 0
+      ? subIssues.reduce((sum, subIssue) => sum + (subIssue.story_points ?? 0), 0)
+      : issue?.sub_issues_story_points ?? 0;
+  const canCreateSubIssues = Boolean(issue && !issue.parent_id && issue.project);
+
+  async function handleParentChange(nextParent: ParentIssueSearchResult | null) {
+    if (nextParent?.id === parentIssue?.id) {
+      return;
+    }
+    if (!nextParent && !parentIssue) {
+      return;
+    }
+    const result = await save({ parent_id: nextParent?.id ?? null });
+    if (!result?.error) {
+      setParentIssue(nextParent);
+    }
+  }
 
   if (!issue) return null;
 
@@ -264,6 +334,85 @@ export function IssueDetailPanel({
                   }}
                 />
               </div>
+
+              {canCreateSubIssues && (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <label className="text-xs font-medium text-text-secondary">
+                        Sub-Issues
+                      </label>
+                      <p className="mt-1 text-xs text-text-muted">
+                        {`${subIssueDoneCount}/${subIssueTotalCount} sub-issues done`}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setCreateSubIssueOpen(true)}
+                      className="inline-flex items-center gap-1 rounded-md border border-border bg-surface px-2.5 py-1.5 text-xs font-medium text-text transition-colors hover:bg-surface-hover"
+                    >
+                      <Plus className="size-3.5" />
+                      Add sub-issue
+                    </button>
+                  </div>
+
+                  {subIssues.length > 0 ? (
+                    <div className="space-y-2">
+                      {subIssues.map((subIssue) => {
+                        const statusConfig =
+                          STATUS_CONFIG[subIssue.status as IssueStatus];
+                        return (
+                          <button
+                            key={subIssue.id}
+                            type="button"
+                            onClick={() => onIssueNavigate?.(subIssue.id)}
+                            disabled={!onIssueNavigate}
+                            className={cn(
+                              "flex w-full items-center gap-3 rounded-xl border border-border bg-surface px-3 py-2.5 text-left transition-colors",
+                              onIssueNavigate
+                                ? "hover:bg-surface-hover"
+                                : "cursor-default",
+                            )}
+                          >
+                            <span
+                              className="size-2 shrink-0 rounded-full"
+                              style={{ backgroundColor: statusConfig?.color }}
+                            />
+                            <div className="min-w-0 flex-1">
+                              <div className="text-[11px] font-mono text-text-muted">
+                                {subIssue.issue_key}
+                              </div>
+                              <div className="truncate text-sm text-text">
+                                {subIssue.title}
+                              </div>
+                            </div>
+                            {subIssue.assignee && (
+                              <Avatar size="sm" className="size-7 text-[10px]">
+                                {subIssue.assignee.avatar_url && (
+                                  <AvatarImage
+                                    src={subIssue.assignee.avatar_url}
+                                    alt={subIssue.assignee.full_name ?? ""}
+                                  />
+                                )}
+                                <AvatarFallback>
+                                  {getInitials(
+                                    subIssue.assignee.full_name,
+                                    subIssue.assignee.email,
+                                  )}
+                                </AvatarFallback>
+                              </Avatar>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <div className="rounded-xl border border-dashed border-border bg-surface px-3 py-4 text-sm text-text-muted">
+                      No sub-issues yet.
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* Comments & Activity */}
               <div className="space-y-1.5">
@@ -384,23 +533,64 @@ export function IssueDetailPanel({
                 />
               </SidebarField>
 
+              <SidebarField label="Parent Issue">
+                {parentIssue && (
+                  <button
+                    type="button"
+                    onClick={() => onIssueNavigate?.(parentIssue.id)}
+                    disabled={!onIssueNavigate}
+                    className={cn(
+                      "flex w-full flex-col items-start rounded-lg border border-border bg-surface px-2.5 py-2 text-left transition-colors",
+                      onIssueNavigate ? "hover:bg-surface-hover" : "cursor-default",
+                    )}
+                  >
+                    <span className="text-[11px] font-mono text-text-muted">
+                      {parentIssue.issue_key}
+                    </span>
+                    <span className="line-clamp-1 text-xs text-text">
+                      {parentIssue.title}
+                    </span>
+                  </button>
+                )}
+                {!hasSubIssues ? (
+                  <ParentIssuePicker
+                    projectId={issue.project_id}
+                    value={parentIssue}
+                    onChange={handleParentChange}
+                    excludeIssueId={issue.id}
+                    placeholder="Search same-project parents..."
+                  />
+                ) : (
+                  <p className="text-xs text-text-muted">
+                    Remove this issue&apos;s sub-issues before assigning it to a parent.
+                  </p>
+                )}
+              </SidebarField>
+
               {/* Story Points */}
               <SidebarField label="Story Points">
-                <Input
-                  type="number"
-                  min={0}
-                  max={100}
-                  placeholder="0"
-                  value={storyPoints}
-                  onChange={(e) => setStoryPoints(e.target.value)}
-                  onBlur={() => {
-                    const pts = storyPoints ? Number(storyPoints) : null;
-                    if (pts !== issue.story_points) {
-                      save({ story_points: pts });
-                    }
-                  }}
-                  className="h-8 text-xs"
-                />
+                <div className="space-y-1.5">
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    placeholder="0"
+                    value={storyPoints}
+                    onChange={(e) => setStoryPoints(e.target.value)}
+                    onBlur={() => {
+                      const pts = storyPoints ? Number(storyPoints) : null;
+                      if (pts !== issue.story_points) {
+                        save({ story_points: pts });
+                      }
+                    }}
+                    className="h-8 text-xs"
+                  />
+                  {hasSubIssues && (
+                    <p className="text-[11px] text-text-muted">
+                      {subIssueStoryPoints} pts from sub-issues
+                    </p>
+                  )}
+                </div>
               </SidebarField>
 
               {/* Labels */}
@@ -448,6 +638,25 @@ export function IssueDetailPanel({
             </div>
           </div>
         </div>
+
+        {issue.project && (
+          <CreateIssueModal
+            open={createSubIssueOpen}
+            onOpenChange={setCreateSubIssueOpen}
+            defaultProjectId={issue.project_id}
+            defaultParentIssue={{
+              id: issue.id,
+              issue_key: issue.issue_key,
+              title: issue.title,
+              project_id: issue.project_id,
+              sprint_id: issue.sprint_id,
+            }}
+            projects={[issue.project]}
+            members={members}
+            sprints={sprints}
+            labels={labels}
+          />
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/src/components/issues/issue-list.tsx
+++ b/src/components/issues/issue-list.tsx
@@ -11,9 +11,81 @@ interface IssueListProps {
   issues: IssueWithDetails[];
   showProject?: boolean;
   onIssueClick?: (id: string) => void;
+  treeMode?: boolean;
 }
 
-export function IssueList({ issues, showProject = true, onIssueClick }: IssueListProps) {
+type TreeRow = {
+  issue: IssueWithDetails;
+  depth: number;
+  hasChildren: boolean;
+};
+
+export function IssueList({
+  issues,
+  showProject = true,
+  onIssueClick,
+  treeMode = false,
+}: IssueListProps) {
+  const [expandedParents, setExpandedParents] = useState<Record<string, boolean>>({});
+
+  const toggleParent = (issueId: string) => {
+    setExpandedParents((prev) => ({ ...prev, [issueId]: !prev[issueId] }));
+  };
+
+  if (treeMode) {
+    const issueMap = new Map(issues.map((issue) => [issue.id, issue]));
+    const childMap = new Map<string, IssueWithDetails[]>();
+
+    for (const issue of issues) {
+      if (!issue.parent_id || !issueMap.has(issue.parent_id)) continue;
+      const children = childMap.get(issue.parent_id) ?? [];
+      children.push(issue);
+      childMap.set(issue.parent_id, children);
+    }
+
+    for (const children of childMap.values()) {
+      children.sort((a, b) => a.sort_order - b.sort_order);
+    }
+
+    const rows: TreeRow[] = [];
+    for (const issue of issues) {
+      if (issue.parent_id && issueMap.has(issue.parent_id)) continue;
+      const children = childMap.get(issue.id) ?? [];
+      rows.push({ issue, depth: 0, hasChildren: children.length > 0 });
+      if (expandedParents[issue.id]) {
+        for (const child of children) {
+          rows.push({ issue: child, depth: 1, hasChildren: false });
+        }
+      }
+    }
+
+    return (
+      <div className="space-y-4 sm:space-y-0">
+        <ListHeader showProject={showProject} />
+        <div className="flex flex-col gap-2 px-4 pb-1 sm:block sm:px-0 sm:pb-0">
+          {rows.map(({ issue, depth, hasChildren }) => (
+            <IssueRow
+              key={issue.id}
+              id={issue.id}
+              issueKey={issue.issue_key}
+              title={issue.title}
+              project={issue.project}
+              priority={issue.priority}
+              dueDate={issue.due_date}
+              status={issue.status}
+              showProject={showProject}
+              onClick={onIssueClick}
+              depth={depth}
+              hasChildren={hasChildren}
+              expanded={expandedParents[issue.id] ?? false}
+              onToggleExpand={toggleParent}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   // Group issues by status
   const grouped = new Map<IssueStatus, IssueWithDetails[]>();
   for (const status of STATUS_ORDER) {
@@ -33,15 +105,7 @@ export function IssueList({ issues, showProject = true, onIssueClick }: IssueLis
 
   return (
     <div className="space-y-4 sm:space-y-0">
-      {/* Column headers */}
-      <div className="hidden items-center gap-3 border-b border-border px-6 py-2 text-[10px] font-medium uppercase tracking-wider text-text-muted sm:flex">
-        <div className="w-4 shrink-0" />
-        <span className="w-[72px] shrink-0">ID</span>
-        <span className="flex-1">Title</span>
-        {showProject && <span className="w-[140px] shrink-0">Project</span>}
-        <span className="w-[72px] text-center shrink-0">Priority</span>
-        <span className="w-[72px] text-right shrink-0">Due</span>
-      </div>
+      <ListHeader showProject={showProject} />
 
       {activeGroups.map((status) => (
         <StatusGroup
@@ -52,6 +116,19 @@ export function IssueList({ issues, showProject = true, onIssueClick }: IssueLis
           onIssueClick={onIssueClick}
         />
       ))}
+    </div>
+  );
+}
+
+function ListHeader({ showProject }: { showProject: boolean }) {
+  return (
+    <div className="hidden items-center gap-3 border-b border-border px-6 py-2 text-[10px] font-medium uppercase tracking-wider text-text-muted sm:flex">
+      <div className="w-4 shrink-0" />
+      <span className="w-[72px] shrink-0">ID</span>
+      <span className="flex-1">Title</span>
+      {showProject && <span className="w-[140px] shrink-0">Project</span>}
+      <span className="w-[72px] text-center shrink-0">Priority</span>
+      <span className="w-[72px] text-right shrink-0">Due</span>
     </div>
   );
 }

--- a/src/components/issues/issue-row.tsx
+++ b/src/components/issues/issue-row.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils/cn";
 import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { formatDate } from "@/lib/utils/dates";
 import type { IssuePriority } from "@/lib/types";
+import { ChevronDown, ChevronRight } from "lucide-react";
 
 interface IssueRowProps {
   id: string;
@@ -14,6 +15,10 @@ interface IssueRowProps {
   status: string;
   showProject?: boolean;
   onClick?: (id: string) => void;
+  depth?: number;
+  hasChildren?: boolean;
+  expanded?: boolean;
+  onToggleExpand?: (id: string) => void;
 }
 
 export function IssueRow({
@@ -26,9 +31,14 @@ export function IssueRow({
   status,
   showProject = true,
   onClick,
+  depth = 0,
+  hasChildren = false,
+  expanded = false,
+  onToggleExpand,
 }: IssueRowProps) {
   const priorityConfig = PRIORITY_CONFIG[priority as IssuePriority];
   const isDone = status === "done";
+  const indent = depth * 16;
 
   const dueDateDisplay = isDone
     ? "Done"
@@ -41,6 +51,8 @@ export function IssueRow({
     dueDate &&
     new Date(dueDate) < new Date(new Date().toDateString());
 
+  const ToggleIcon = expanded ? ChevronDown : ChevronRight;
+
   return (
     <>
       <div
@@ -48,7 +60,24 @@ export function IssueRow({
         className="cursor-pointer rounded-xl border border-border bg-surface px-4 py-3.5 shadow-sm transition-colors hover:bg-surface-hover/70 sm:hidden"
       >
         <div className="flex items-start gap-3">
-          <Checkbox className="mt-0.5 shrink-0" onClick={(e) => e.stopPropagation()} />
+          <div className="mt-0.5 flex items-center gap-1.5">
+            {hasChildren ? (
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToggleExpand?.(id);
+                }}
+                className="rounded p-0.5 text-text-muted transition-colors hover:bg-surface-hover hover:text-text"
+                aria-label={expanded ? "Collapse sub-issues" : "Expand sub-issues"}
+              >
+                <ToggleIcon className="size-3.5" />
+              </button>
+            ) : (
+              <span className="inline-block size-4 shrink-0" />
+            )}
+            <Checkbox className="shrink-0" onClick={(e) => e.stopPropagation()} />
+          </div>
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <span className="text-[11px] font-mono text-text-muted">
@@ -65,9 +94,12 @@ export function IssueRow({
               )}
             </div>
 
-            <p className="mt-2 text-sm font-medium leading-5 text-text">
-              {title}
-            </p>
+            <div className="mt-2 flex items-start gap-2" style={{ paddingLeft: indent }}>
+              {depth > 0 && <span className="mt-1 h-4 w-px shrink-0 bg-border" />}
+              <p className="text-sm font-medium leading-5 text-text">
+                {title}
+              </p>
+            </div>
 
             <div className="mt-3 flex flex-wrap items-center gap-2">
               <span
@@ -100,8 +132,24 @@ export function IssueRow({
         onClick={() => onClick?.(id)}
         className="group hidden cursor-pointer items-center gap-3 border-b border-border px-6 py-2.5 transition-colors last:border-b-0 hover:bg-surface-hover/50 sm:flex"
       >
-        {/* Checkbox */}
-        <Checkbox className="shrink-0" onClick={(e) => e.stopPropagation()} />
+        <div className="flex items-center gap-2 shrink-0">
+          {hasChildren ? (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onToggleExpand?.(id);
+              }}
+              className="rounded p-0.5 text-text-muted transition-colors hover:bg-surface-hover hover:text-text"
+              aria-label={expanded ? "Collapse sub-issues" : "Expand sub-issues"}
+            >
+              <ToggleIcon className="size-3.5" />
+            </button>
+          ) : (
+            <span className="inline-block size-4 shrink-0" />
+          )}
+          <Checkbox className="shrink-0" onClick={(e) => e.stopPropagation()} />
+        </div>
 
         {/* Issue key */}
         <span className="text-xs font-mono text-text-muted w-[72px] shrink-0">
@@ -109,7 +157,10 @@ export function IssueRow({
         </span>
 
         {/* Title */}
-        <span className="text-sm text-text flex-1 truncate">{title}</span>
+        <div className="flex min-w-0 flex-1 items-center gap-2" style={{ paddingLeft: indent }}>
+          {depth > 0 && <span className="h-5 w-px shrink-0 bg-border" />}
+          <span className="text-sm text-text truncate">{title}</span>
+        </div>
 
         {/* Project */}
         {showProject && project && (

--- a/src/components/issues/parent-issue-picker.tsx
+++ b/src/components/issues/parent-issue-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { LoaderCircle, Search, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils/cn";
@@ -33,39 +33,8 @@ export function ParentIssuePicker({
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function handlePointerDown(event: MouseEvent) {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, []);
-
-  useEffect(() => {
-    if (!open || disabled || !projectId) {
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    const timer = window.setTimeout(() => {
-      searchParentIssuesClient(projectId, query, { excludeIssueId }).then((items) => {
-        if (cancelled) return;
-        setResults(items);
-        setLoading(false);
-      });
-    }, 150);
-
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-    };
-  }, [open, query, projectId, excludeIssueId, disabled]);
+  const searchTimeoutRef = useRef<number | null>(null);
+  const requestIdRef = useRef(0);
 
   const searchDisabled = disabled || !projectId;
   const searchPlaceholder = disabled
@@ -73,6 +42,65 @@ export function ParentIssuePicker({
     : projectId
       ? placeholder
       : "Select a project first";
+
+  const cancelPendingSearch = useCallback(() => {
+    requestIdRef.current += 1;
+    if (searchTimeoutRef.current !== null) {
+      window.clearTimeout(searchTimeoutRef.current);
+      searchTimeoutRef.current = null;
+    }
+  }, []);
+
+  const resetSearchState = useCallback(() => {
+    cancelPendingSearch();
+    setLoading(false);
+    setResults([]);
+  }, [cancelPendingSearch]);
+
+  const queueSearch = useCallback((nextQuery: string) => {
+    if (searchDisabled || !projectId) {
+      return;
+    }
+
+    cancelPendingSearch();
+    setLoading(true);
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    searchTimeoutRef.current = window.setTimeout(() => {
+      searchTimeoutRef.current = null;
+
+      searchParentIssuesClient(projectId, nextQuery, { excludeIssueId })
+        .then((items) => {
+          if (requestId !== requestIdRef.current) return;
+          setResults(items);
+          setLoading(false);
+        })
+        .catch(() => {
+          if (requestId !== requestIdRef.current) return;
+          setResults([]);
+          setLoading(false);
+        });
+    }, 150);
+  }, [cancelPendingSearch, excludeIssueId, projectId, searchDisabled]);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        resetSearchState();
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [resetSearchState]);
+
+  useEffect(() => {
+    return () => {
+      cancelPendingSearch();
+    };
+  }, [cancelPendingSearch]);
 
   return (
     <div ref={rootRef} className="space-y-2">
@@ -91,6 +119,7 @@ export function ParentIssuePicker({
             onClick={() => {
               onChange(null);
               setQuery("");
+              resetSearchState();
             }}
             className="shrink-0 rounded-md p-1 text-text-muted transition-colors hover:bg-surface hover:text-text"
             aria-label="Clear parent issue"
@@ -105,12 +134,15 @@ export function ParentIssuePicker({
         <Input
           value={query}
           onChange={(event) => {
-            setQuery(event.target.value);
+            const nextQuery = event.target.value;
+            setQuery(nextQuery);
             setOpen(true);
+            queueSearch(nextQuery);
           }}
           onFocus={() => {
             if (!searchDisabled) {
               setOpen(true);
+              queueSearch(query);
             }
           }}
           placeholder={searchPlaceholder}
@@ -133,6 +165,7 @@ export function ParentIssuePicker({
                   onClick={() => {
                     onChange(result);
                     setQuery("");
+                    resetSearchState();
                     setOpen(false);
                   }}
                   className={cn(

--- a/src/components/issues/parent-issue-picker.tsx
+++ b/src/components/issues/parent-issue-picker.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { LoaderCircle, Search, X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils/cn";
+import {
+  searchParentIssuesClient,
+  type ParentIssueSearchResult,
+} from "@/lib/queries/search";
+
+interface ParentIssuePickerProps {
+  projectId?: string;
+  value: ParentIssueSearchResult | null;
+  onChange: (value: ParentIssueSearchResult | null) => void;
+  excludeIssueId?: string;
+  disabled?: boolean;
+  placeholder?: string;
+  emptyMessage?: string;
+}
+
+export function ParentIssuePicker({
+  projectId,
+  value,
+  onChange,
+  excludeIssueId,
+  disabled = false,
+  placeholder = "Search issues...",
+  emptyMessage = "No matching parent issues",
+}: ParentIssuePickerProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<ParentIssueSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, []);
+
+  useEffect(() => {
+    if (!open || disabled || !projectId) {
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    const timer = window.setTimeout(() => {
+      searchParentIssuesClient(projectId, query, { excludeIssueId }).then((items) => {
+        if (cancelled) return;
+        setResults(items);
+        setLoading(false);
+      });
+    }, 150);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [open, query, projectId, excludeIssueId, disabled]);
+
+  const searchDisabled = disabled || !projectId;
+  const searchPlaceholder = disabled
+    ? "Parent selection unavailable"
+    : projectId
+      ? placeholder
+      : "Select a project first";
+
+  return (
+    <div ref={rootRef} className="space-y-2">
+      {value && (
+        <div className="flex items-center justify-between gap-2 rounded-lg border border-border bg-surface-hover/60 px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-[11px] font-mono text-text-muted">
+              {value.issue_key}
+            </div>
+            <div className="truncate text-sm text-text">
+              {value.title}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              onChange(null);
+              setQuery("");
+            }}
+            className="shrink-0 rounded-md p-1 text-text-muted transition-colors hover:bg-surface hover:text-text"
+            aria-label="Clear parent issue"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      )}
+
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-text-muted" />
+        <Input
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => {
+            if (!searchDisabled) {
+              setOpen(true);
+            }
+          }}
+          placeholder={searchPlaceholder}
+          disabled={searchDisabled}
+          className="h-9 pl-8 pr-9 text-xs"
+        />
+        {loading && (
+          <LoaderCircle className="absolute right-3 top-1/2 size-3.5 -translate-y-1/2 animate-spin text-text-muted" />
+        )}
+      </div>
+
+      {open && !searchDisabled && (
+        <div className="rounded-lg border border-border bg-surface shadow-lg">
+          {results.length > 0 ? (
+            <div className="max-h-56 overflow-y-auto p-1">
+              {results.map((result) => (
+                <button
+                  key={result.id}
+                  type="button"
+                  onClick={() => {
+                    onChange(result);
+                    setQuery("");
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "flex w-full flex-col items-start rounded-md px-3 py-2 text-left transition-colors hover:bg-surface-hover",
+                    value?.id === result.id && "bg-surface-hover",
+                  )}
+                >
+                  <span className="text-[11px] font-mono text-text-muted">
+                    {result.issue_key}
+                  </span>
+                  <span className="line-clamp-1 text-sm text-text">
+                    {result.title}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="px-3 py-2 text-xs text-text-muted">
+              {loading ? "Searching..." : emptyMessage}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/actions/issues.ts
+++ b/src/lib/actions/issues.ts
@@ -198,8 +198,9 @@ export async function createIssue(
   }
 
   const resolvedParent = parentResult.data;
-  const resolvedSprintId =
-    sprintId || resolvedParent?.sprint_id || null;
+  const resolvedSprintId = resolvedParent
+    ? resolvedParent.sprint_id ?? null
+    : sprintId;
 
   const { data, error } = await supabase.rpc("create_issue", {
     p_workspace_id: workspaceId,

--- a/src/lib/actions/issues.ts
+++ b/src/lib/actions/issues.ts
@@ -8,6 +8,155 @@ import {
   createNotificationsForActivity,
 } from "@/lib/actions/activities";
 
+type IssueRecord = Tables<"issues">;
+type HierarchyIssueSummary = Pick<
+  IssueRecord,
+  | "id"
+  | "workspace_id"
+  | "project_id"
+  | "issue_key"
+  | "title"
+  | "sprint_id"
+  | "assignee_id"
+  | "parent_id"
+>;
+
+async function validateParentIssue(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  {
+    parentId,
+    workspaceId,
+    projectId,
+    issueId,
+  }: {
+    parentId: string | null;
+    workspaceId: string;
+    projectId: string;
+    issueId?: string;
+  }
+): Promise<ActionResponse<HierarchyIssueSummary | null>> {
+  if (!parentId) {
+    return { data: null };
+  }
+
+  if (issueId && parentId === issueId) {
+    return { error: "An issue cannot be its own parent" };
+  }
+
+  const { data: parent, error: parentError } = await supabase
+    .from("issues")
+    .select(
+      "id, workspace_id, project_id, issue_key, title, sprint_id, assignee_id, parent_id",
+    )
+    .eq("id", parentId)
+    .maybeSingle();
+
+  if (parentError || !parent) {
+    return { error: "Parent issue not found" };
+  }
+
+  if (parent.workspace_id !== workspaceId) {
+    return { error: "Parent issue must belong to the same workspace" };
+  }
+
+  if (parent.project_id !== projectId) {
+    return { error: "Parent issue must belong to the same project" };
+  }
+
+  if (parent.parent_id) {
+    return { error: "Sub-issues cannot be nested more than one level deep" };
+  }
+
+  if (issueId) {
+    const { count, error: childCountError } = await supabase
+      .from("issues")
+      .select("id", { count: "exact", head: true })
+      .eq("parent_id", issueId);
+
+    if (childCountError) {
+      return { error: childCountError.message };
+    }
+
+    if ((count ?? 0) > 0) {
+      return {
+        error: "Parent issues must be top-level before they can be assigned to another parent",
+      };
+    }
+  }
+
+  return { data: parent };
+}
+
+async function createHierarchyActivities({
+  supabase,
+  workspaceId,
+  actorId,
+  projectId,
+  action,
+  childIssue,
+  parentIssue,
+}: {
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  workspaceId: string;
+  actorId: string;
+  projectId: string;
+  action: "added_sub_issue" | "removed_from_parent";
+  childIssue: Pick<IssueRecord, "id" | "issue_key" | "title">;
+  parentIssue: Pick<IssueRecord, "id" | "issue_key" | "title" | "assignee_id">;
+}) {
+  const metadata = {
+    project_id: projectId,
+    child_issue_id: childIssue.id,
+    child_issue_key: childIssue.issue_key,
+    child_title: childIssue.title,
+    parent_issue_id: parentIssue.id,
+    parent_issue_key: parentIssue.issue_key,
+    parent_title: parentIssue.title,
+  };
+
+  const [parentActivity, childActivity] = await Promise.all([
+    createActivity({
+      supabase,
+      workspaceId,
+      actorId,
+      action,
+      entityType: "issue",
+      entityId: parentIssue.id,
+      metadata: {
+        ...metadata,
+        issue_key: parentIssue.issue_key,
+        title: parentIssue.title,
+      },
+    }),
+    createActivity({
+      supabase,
+      workspaceId,
+      actorId,
+      action,
+      entityType: "issue",
+      entityId: childIssue.id,
+      metadata: {
+        ...metadata,
+        issue_key: childIssue.issue_key,
+        title: childIssue.title,
+      },
+    }),
+  ]);
+
+  if (action === "added_sub_issue" && parentIssue.assignee_id) {
+    await createNotificationsForActivity({
+      supabase,
+      workspaceId,
+      actorId,
+      activityId: parentActivity.id,
+      recipientIds: [parentIssue.assignee_id],
+      type: "general",
+    });
+  }
+
+  return { parentActivity, childActivity };
+}
+
 export async function createIssue(
   formData: FormData
 ): Promise<ActionResponse<Tables<"issues">>> {
@@ -31,12 +180,26 @@ export async function createIssue(
     ? Number(formData.get("storyPoints"))
     : null;
   const sortOrder = Number(formData.get("sortOrder") || 0);
+  const parentId = (formData.get("parentId") as string) || null;
   const labelIdsRaw = formData.get("labelIds") as string;
   const labelIds = labelIdsRaw ? labelIdsRaw.split(",").filter(Boolean) : [];
 
   if (!workspaceId || !projectId || !title) {
     return { error: "Workspace, project, and title are required" };
   }
+
+  const parentResult = await validateParentIssue(supabase, {
+    parentId,
+    workspaceId,
+    projectId,
+  });
+  if (parentResult.error) {
+    return { error: parentResult.error };
+  }
+
+  const resolvedParent = parentResult.data;
+  const resolvedSprintId =
+    sprintId || resolvedParent?.sprint_id || null;
 
   const { data, error } = await supabase.rpc("create_issue", {
     p_workspace_id: workspaceId,
@@ -46,11 +209,12 @@ export async function createIssue(
     p_status: status,
     p_priority: priority,
     p_assignee_id: assigneeId,
-    p_sprint_id: sprintId,
+    p_sprint_id: resolvedSprintId,
     p_due_date: dueDate,
     p_story_points: storyPoints,
     p_sort_order: sortOrder,
     p_label_ids: labelIds,
+    p_parent_id: resolvedParent?.id ?? null,
   });
 
   if (error) {
@@ -74,6 +238,8 @@ export async function createIssue(
         status,
         priority,
         assignee_id: assigneeId,
+        parent_issue_id: resolvedParent?.id ?? null,
+        parent_issue_key: resolvedParent?.issue_key ?? null,
       },
     });
 
@@ -85,6 +251,22 @@ export async function createIssue(
         activityId: activity.id,
         recipientIds: [assigneeId],
         type: "assigned",
+      });
+    }
+
+    if (resolvedParent) {
+      await createHierarchyActivities({
+        supabase,
+        workspaceId,
+        actorId: user.id,
+        projectId,
+        action: "added_sub_issue",
+        childIssue: {
+          id: issue.id,
+          issue_key: issue.issue_key,
+          title: issue.title,
+        },
+        parentIssue: resolvedParent,
       });
     }
   } catch {
@@ -103,6 +285,7 @@ export async function updateIssue(
     status?: IssueStatus;
     priority?: number;
     assignee_id?: string | null;
+    parent_id?: string | null;
     sprint_id?: string | null;
     due_date?: string | null;
     story_points?: number | null;
@@ -116,6 +299,44 @@ export async function updateIssue(
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return { error: "Not authenticated" };
+
+  const { data: currentIssue, error: currentIssueError } = await supabase
+    .from("issues")
+    .select(
+      "id, workspace_id, project_id, issue_key, title, assignee_id, parent_id",
+    )
+    .eq("id", issueId)
+    .single();
+
+  if (currentIssueError || !currentIssue) {
+    return { error: currentIssueError?.message ?? "Issue not found" };
+  }
+
+  let previousParent: HierarchyIssueSummary | null = null;
+  if (currentIssue.parent_id) {
+    const { data: parent } = await supabase
+      .from("issues")
+      .select(
+        "id, workspace_id, project_id, issue_key, title, sprint_id, assignee_id, parent_id",
+      )
+      .eq("id", currentIssue.parent_id)
+      .maybeSingle();
+    previousParent = parent ?? null;
+  }
+
+  let nextParent: HierarchyIssueSummary | null | undefined;
+  if (updates.parent_id !== undefined) {
+    const parentResult = await validateParentIssue(supabase, {
+      parentId: updates.parent_id,
+      workspaceId: currentIssue.workspace_id,
+      projectId: currentIssue.project_id,
+      issueId,
+    });
+    if (parentResult.error) {
+      return { error: parentResult.error };
+    }
+    nextParent = parentResult.data;
+  }
 
   // Set completed_at when moving to done
   const updateData: Record<string, unknown> = { ...updates };
@@ -148,7 +369,7 @@ export async function updateIssue(
         title: data.title,
         issue_key: data.issue_key,
         project_id: data.project_id,
-        changes: updates,
+        changes: updateData,
       },
     });
 
@@ -174,6 +395,40 @@ export async function updateIssue(
         recipientIds: recipients,
         type: notifType,
       });
+    }
+
+    if (updates.parent_id !== undefined && previousParent?.id !== nextParent?.id) {
+      if (previousParent) {
+        await createHierarchyActivities({
+          supabase,
+          workspaceId: data.workspace_id,
+          actorId: user.id,
+          projectId: data.project_id,
+          action: "removed_from_parent",
+          childIssue: {
+            id: data.id,
+            issue_key: data.issue_key,
+            title: data.title,
+          },
+          parentIssue: previousParent,
+        });
+      }
+
+      if (nextParent) {
+        await createHierarchyActivities({
+          supabase,
+          workspaceId: data.workspace_id,
+          actorId: user.id,
+          projectId: data.project_id,
+          action: "added_sub_issue",
+          childIssue: {
+            id: data.id,
+            issue_key: data.issue_key,
+            title: data.title,
+          },
+          parentIssue: nextParent,
+        });
+      }
     }
   } catch {
     // Activity logging should not block the primary operation

--- a/src/lib/hooks/use-realtime-issues.ts
+++ b/src/lib/hooks/use-realtime-issues.ts
@@ -2,12 +2,25 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
-import type { IssueWithDetails } from "@/lib/queries/issues";
+import type {
+  IssueParentSummary,
+  IssueWithDetails,
+} from "@/lib/queries/issues";
 import type { Tables } from "@/lib/types";
 
 interface UseRealtimeIssuesOptions {
   projectId: string;
   initialIssues: IssueWithDetails[];
+}
+
+function toParentSummary(
+  issue: Pick<IssueWithDetails, "id" | "issue_key" | "title">,
+): IssueParentSummary {
+  return {
+    id: issue.id,
+    issue_key: issue.issue_key,
+    title: issue.title,
+  };
 }
 
 export function useRealtimeIssues({
@@ -27,12 +40,15 @@ export function useRealtimeIssues({
       // Only add if not already in state (avoid duplicates from optimistic add)
       setIssues((prev) => {
         if (prev.some((i) => i.id === row.id)) return prev;
+        const parentIssue = row.parent_id
+          ? prev.find((issue) => issue.id === row.parent_id)
+          : null;
         const stub: IssueWithDetails = {
           ...row,
           assignee: null,
           project: null,
           labels: [],
-          parent: null,
+          parent: parentIssue ? toParentSummary(parentIssue) : null,
           sub_issues_count: 0,
           sub_issues_done_count: 0,
           sub_issues_story_points: 0,
@@ -46,19 +62,32 @@ export function useRealtimeIssues({
   const handleUpdate = useCallback(
     (payload: { new: Tables<"issues"> }) => {
       const row = payload.new;
-      setIssues((prev) =>
-        prev.map((issue) => {
+      setIssues((prev) => {
+        const parentIssue = row.parent_id
+          ? prev.find((issue) => issue.id === row.parent_id)
+          : null;
+
+        return prev.map((issue) => {
           if (issue.id !== row.id) return issue;
-          // Merge scalar fields, preserve relations
+
+          const parent = row.parent_id
+            ? parentIssue
+              ? toParentSummary(parentIssue)
+              : issue.parent?.id === row.parent_id
+                ? issue.parent
+                : null
+            : null;
+
           return {
             ...issue,
             ...row,
             assignee: issue.assignee,
             project: issue.project,
             labels: issue.labels,
+            parent,
           };
-        }),
-      );
+        });
+      });
     },
     [],
   );
@@ -66,7 +95,15 @@ export function useRealtimeIssues({
   const handleDelete = useCallback(
     (payload: { old: { id: string } }) => {
       const id = payload.old.id;
-      setIssues((prev) => prev.filter((i) => i.id !== id));
+      setIssues((prev) =>
+        prev
+          .filter((issue) => issue.id !== id)
+          .map((issue) =>
+            issue.parent_id === id
+              ? { ...issue, parent_id: null, parent: null }
+              : issue,
+          ),
+      );
     },
     [],
   );

--- a/src/lib/hooks/use-realtime-issues.ts
+++ b/src/lib/hooks/use-realtime-issues.ts
@@ -32,6 +32,10 @@ export function useRealtimeIssues({
           assignee: null,
           project: null,
           labels: [],
+          parent: null,
+          sub_issues_count: 0,
+          sub_issues_done_count: 0,
+          sub_issues_story_points: 0,
         };
         return [...prev, stub];
       });

--- a/src/lib/mock.ts
+++ b/src/lib/mock.ts
@@ -200,6 +200,7 @@ function mockIssue(
     status: overrides.status,
     priority: overrides.priority,
     assignee_id: overrides.assignee_id ?? MOCK_USER_ID,
+    parent_id: overrides.parent_id ?? null,
     sprint_id: overrides.sprint_id ?? null,
     due_date: overrides.due_date ?? null,
     story_points: overrides.story_points ?? null,
@@ -213,6 +214,10 @@ function mockIssue(
       ? { id: projectRef.id, name: projectRef.name, color: projectRef.color }
       : null,
     labels: overrides.labels ?? [],
+    parent: overrides.parent ?? null,
+    sub_issues_count: overrides.sub_issues_count ?? 0,
+    sub_issues_done_count: overrides.sub_issues_done_count ?? 0,
+    sub_issues_story_points: overrides.sub_issues_story_points ?? 0,
     checklist: [],
   };
 }

--- a/src/lib/queries/issues-client.ts
+++ b/src/lib/queries/issues-client.ts
@@ -1,6 +1,10 @@
 import type { Tables } from "@/lib/types";
-import type { IssueWithDetails } from "@/lib/queries/issues";
+import type {
+  IssueParentSummary,
+  IssueWithDetails,
+} from "@/lib/queries/issues";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/client";
 
 /**
  * Client-side version of enrichIssues for use in browser components.
@@ -81,6 +85,47 @@ export async function enrichIssuesClient(
     }
   }
 
+  const parentIds = [
+    ...new Set(issues.map((issue) => issue.parent_id).filter(Boolean)),
+  ] as string[];
+  const parentMap = new Map<string, IssueParentSummary>();
+
+  if (parentIds.length > 0) {
+    const { data: parents } = await supabase
+      .from("issues")
+      .select("id, issue_key, title")
+      .in("id", parentIds);
+
+    for (const parent of parents ?? []) {
+      parentMap.set(parent.id, parent);
+    }
+  }
+
+  const parentIssueIds = issues.map((issue) => issue.id);
+  const { data: children } = await supabase
+    .from("issues")
+    .select("id, parent_id, status, story_points")
+    .in("parent_id", parentIssueIds);
+
+  const childCounts = new Map<string, number>();
+  const childDoneCounts = new Map<string, number>();
+  const childStoryPoints = new Map<string, number>();
+
+  for (const child of children ?? []) {
+    if (!child.parent_id) continue;
+    childCounts.set(child.parent_id, (childCounts.get(child.parent_id) ?? 0) + 1);
+    if (child.status === "done") {
+      childDoneCounts.set(
+        child.parent_id,
+        (childDoneCounts.get(child.parent_id) ?? 0) + 1,
+      );
+    }
+    childStoryPoints.set(
+      child.parent_id,
+      (childStoryPoints.get(child.parent_id) ?? 0) + (child.story_points ?? 0),
+    );
+  }
+
   return issues.map((issue) => ({
     ...issue,
     assignee: issue.assignee_id
@@ -88,5 +133,42 @@ export async function enrichIssuesClient(
       : null,
     project: projectMap.get(issue.project_id) ?? null,
     labels: issueLabelMap.get(issue.id) ?? [],
+    parent: issue.parent_id ? parentMap.get(issue.parent_id) ?? null : null,
+    sub_issues_count: childCounts.get(issue.id) ?? 0,
+    sub_issues_done_count: childDoneCounts.get(issue.id) ?? 0,
+    sub_issues_story_points: childStoryPoints.get(issue.id) ?? 0,
   }));
+}
+
+export async function getIssueClient(
+  issueId: string
+): Promise<IssueWithDetails | null> {
+  const supabase = createClient();
+
+  const { data: issue } = await supabase
+    .from("issues")
+    .select("*")
+    .eq("id", issueId)
+    .maybeSingle();
+
+  if (!issue) return null;
+
+  const [enriched] = await enrichIssuesClient([issue], supabase);
+  return enriched ?? null;
+}
+
+export async function getSubIssuesClient(
+  parentId: string
+): Promise<IssueWithDetails[]> {
+  const supabase = createClient();
+
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("*")
+    .eq("parent_id", parentId)
+    .order("sort_order", { ascending: true });
+
+  if (!issues || issues.length === 0) return [];
+
+  return enrichIssuesClient(issues, supabase);
 }

--- a/src/lib/queries/issues.ts
+++ b/src/lib/queries/issues.ts
@@ -1,10 +1,20 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Tables, IssueStatus } from "@/lib/types";
 
+export type IssueParentSummary = {
+  id: string;
+  issue_key: string;
+  title: string;
+};
+
 export type IssueWithDetails = Tables<"issues"> & {
   assignee: { id: string; full_name: string | null; email: string; avatar_url: string | null } | null;
   project: { id: string; name: string; color: string } | null;
   labels: { id: string; name: string; color: string }[];
+  parent: IssueParentSummary | null;
+  sub_issues_count: number;
+  sub_issues_done_count: number;
+  sub_issues_story_points: number;
 };
 
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
@@ -88,6 +98,47 @@ export async function enrichIssues(
     }
   }
 
+  const parentIds = [
+    ...new Set(issues.map((issue) => issue.parent_id).filter(Boolean)),
+  ] as string[];
+  const parentMap = new Map<string, IssueParentSummary>();
+
+  if (parentIds.length > 0) {
+    const { data: parents } = await supabase
+      .from("issues")
+      .select("id, issue_key, title")
+      .in("id", parentIds);
+
+    for (const parent of parents ?? []) {
+      parentMap.set(parent.id, parent);
+    }
+  }
+
+  const parentIssueIds = issues.map((issue) => issue.id);
+  const { data: children } = await supabase
+    .from("issues")
+    .select("id, parent_id, status, story_points")
+    .in("parent_id", parentIssueIds);
+
+  const childCounts = new Map<string, number>();
+  const childDoneCounts = new Map<string, number>();
+  const childStoryPoints = new Map<string, number>();
+
+  for (const child of children ?? []) {
+    if (!child.parent_id) continue;
+    childCounts.set(child.parent_id, (childCounts.get(child.parent_id) ?? 0) + 1);
+    if (child.status === "done") {
+      childDoneCounts.set(
+        child.parent_id,
+        (childDoneCounts.get(child.parent_id) ?? 0) + 1,
+      );
+    }
+    childStoryPoints.set(
+      child.parent_id,
+      (childStoryPoints.get(child.parent_id) ?? 0) + (child.story_points ?? 0),
+    );
+  }
+
   return issues.map((issue) => ({
     ...issue,
     assignee: issue.assignee_id
@@ -95,6 +146,10 @@ export async function enrichIssues(
       : null,
     project: projectMap.get(issue.project_id) ?? null,
     labels: issueLabelMap.get(issue.id) ?? [],
+    parent: issue.parent_id ? parentMap.get(issue.parent_id) ?? null : null,
+    sub_issues_count: childCounts.get(issue.id) ?? 0,
+    sub_issues_done_count: childDoneCounts.get(issue.id) ?? 0,
+    sub_issues_story_points: childStoryPoints.get(issue.id) ?? 0,
   }));
 }
 
@@ -159,4 +214,36 @@ export async function getMyIssues(
   if (!issues || issues.length === 0) return [];
 
   return enrichIssues(issues, supabase);
+}
+
+export async function getSubIssues(
+  parentId: string
+): Promise<IssueWithDetails[]> {
+  const supabase = await createClient();
+
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("*")
+    .eq("parent_id", parentId)
+    .order("sort_order", { ascending: true });
+
+  if (!issues || issues.length === 0) return [];
+
+  return enrichIssues(issues, supabase);
+}
+
+export async function getSubIssueProgress(
+  parentId: string
+): Promise<{ done: number; total: number }> {
+  const supabase = await createClient();
+
+  const { data: issues } = await supabase
+    .from("issues")
+    .select("status")
+    .eq("parent_id", parentId);
+
+  const total = issues?.length ?? 0;
+  const done = (issues ?? []).filter((issue) => issue.status === "done").length;
+
+  return { done, total };
 }

--- a/src/lib/queries/search.ts
+++ b/src/lib/queries/search.ts
@@ -8,6 +8,14 @@ export type SearchResult = {
   project: { id: string; name: string; color: string } | null;
 };
 
+export type ParentIssueSearchResult = {
+  id: string;
+  issue_key: string;
+  title: string;
+  project_id: string;
+  sprint_id: string | null;
+};
+
 export async function searchIssuesClient(
   workspaceId: string,
   query: string,
@@ -84,4 +92,36 @@ export async function getRecentIssuesClient(
     status: issue.status,
     project: projectMap.get(issue.project_id) ?? null,
   }));
+}
+
+export async function searchParentIssuesClient(
+  projectId: string,
+  query: string,
+  options?: {
+    excludeIssueId?: string;
+    limit?: number;
+  }
+): Promise<ParentIssueSearchResult[]> {
+  const supabase = createClient();
+  const trimmed = query.trim();
+  const limit = options?.limit ?? 6;
+
+  let request = supabase
+    .from("issues")
+    .select("id, issue_key, title, project_id, sprint_id")
+    .eq("project_id", projectId)
+    .is("parent_id", null)
+    .order("updated_at", { ascending: false })
+    .limit(limit);
+
+  if (options?.excludeIssueId) {
+    request = request.neq("id", options.excludeIssueId);
+  }
+
+  if (trimmed) {
+    request = request.or(`title.ilike.%${trimmed}%,issue_key.ilike.%${trimmed}%`);
+  }
+
+  const { data } = await request;
+  return data ?? [];
 }

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -380,6 +380,7 @@ export type Database = {
           status: "todo" | "in_progress" | "in_review" | "done";
           priority: number;
           assignee_id: string | null;
+          parent_id: string | null;
           sprint_id: string | null;
           due_date: string | null;
           story_points: number | null;
@@ -401,6 +402,7 @@ export type Database = {
           status?: "todo" | "in_progress" | "in_review" | "done";
           priority?: number;
           assignee_id?: string | null;
+          parent_id?: string | null;
           sprint_id?: string | null;
           due_date?: string | null;
           story_points?: number | null;
@@ -422,6 +424,7 @@ export type Database = {
           status?: "todo" | "in_progress" | "in_review" | "done";
           priority?: number;
           assignee_id?: string | null;
+          parent_id?: string | null;
           sprint_id?: string | null;
           due_date?: string | null;
           story_points?: number | null;
@@ -433,6 +436,13 @@ export type Database = {
           updated_at?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: "issues_parent_id_fkey";
+            columns: ["parent_id"];
+            isOneToOne: false;
+            referencedRelation: "issues";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "issues_workspace_id_fkey";
             columns: ["workspace_id"];
@@ -689,6 +699,7 @@ export type Database = {
           p_story_points?: number | null;
           p_sort_order?: number;
           p_label_ids?: string[];
+          p_parent_id?: string | null;
         };
         Returns: Database["public"]["Tables"]["issues"]["Row"];
       };

--- a/src/lib/utils/activities.ts
+++ b/src/lib/utils/activities.ts
@@ -35,6 +35,16 @@ export function formatActivityAction(activity: ActivityWithActor): string {
       if (activity.action === "deleted") {
         return `${actorName} deleted ${label}`;
       }
+      if (activity.action === "added_sub_issue") {
+        const childIssueKey = (meta.child_issue_key as string) ?? issueKey;
+        const parentIssueKey = (meta.parent_issue_key as string) ?? issueKey;
+        return `${actorName} added ${childIssueKey} under ${parentIssueKey}`;
+      }
+      if (activity.action === "removed_from_parent") {
+        const childIssueKey = (meta.child_issue_key as string) ?? issueKey;
+        const parentIssueKey = (meta.parent_issue_key as string) ?? issueKey;
+        return `${actorName} removed ${childIssueKey} from ${parentIssueKey}`;
+      }
       if (activity.action === "updated") {
         // Support both flat format (field/new_value) and nested changes format
         const field = meta.field as string | undefined;

--- a/supabase/migrations/00022_sub_issues.sql
+++ b/supabase/migrations/00022_sub_issues.sql
@@ -1,0 +1,145 @@
+-- 00022_sub_issues.sql
+-- Single-level parent-child hierarchy for issues
+
+alter table public.issues
+  add column parent_id uuid references public.issues(id) on delete set null;
+
+alter table public.issues
+  add constraint issues_parent_not_self check (parent_id is null or parent_id <> id);
+
+create index idx_issues_parent on public.issues (parent_id);
+
+create or replace function public.validate_issue_parent_assignment()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  v_parent public.issues;
+begin
+  if new.parent_id is null then
+    return new;
+  end if;
+
+  if new.parent_id = new.id then
+    raise exception 'Issue cannot be its own parent';
+  end if;
+
+  select *
+  into v_parent
+  from public.issues
+  where id = new.parent_id;
+
+  if v_parent.id is null then
+    raise exception 'Parent issue not found';
+  end if;
+
+  if v_parent.parent_id is not null then
+    raise exception 'Sub-issues cannot have their own sub-issues';
+  end if;
+
+  if v_parent.workspace_id <> new.workspace_id then
+    raise exception 'Parent issue must belong to the same workspace';
+  end if;
+
+  if v_parent.project_id <> new.project_id then
+    raise exception 'Parent issue must belong to the same project';
+  end if;
+
+  if exists (
+    select 1
+    from public.issues
+    where parent_id = new.id
+  ) then
+    raise exception 'Parent issues cannot become sub-issues while they still have children';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists issues_validate_parent on public.issues;
+
+create trigger issues_validate_parent
+  before insert or update of parent_id, project_id, workspace_id
+  on public.issues
+  for each row
+  execute function public.validate_issue_parent_assignment();
+
+drop function if exists public.create_issue(
+  uuid,
+  uuid,
+  text,
+  text,
+  text,
+  int,
+  uuid,
+  uuid,
+  date,
+  int,
+  double precision,
+  uuid[]
+);
+
+create function public.create_issue(
+  p_workspace_id uuid,
+  p_project_id   uuid,
+  p_title        text,
+  p_description  text     default null,
+  p_status       text     default 'todo',
+  p_priority     int      default 3,
+  p_assignee_id  uuid     default null,
+  p_sprint_id    uuid     default null,
+  p_due_date     date     default null,
+  p_story_points int      default null,
+  p_sort_order   float8   default 0,
+  p_label_ids    uuid[]   default '{}',
+  p_parent_id    uuid     default null
+)
+returns public.issues
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_caller   uuid := auth.uid();
+  v_number   int;
+  v_prefix   text;
+  v_issue    public.issues;
+begin
+  if not exists (
+    select 1 from public.workspace_members
+    where workspace_id = p_workspace_id
+      and user_id = v_caller
+  ) then
+    raise exception 'Not a member of this workspace';
+  end if;
+
+  update public.workspaces
+  set issue_counter = issue_counter + 1
+  where id = p_workspace_id
+  returning issue_counter, issue_prefix
+  into v_number, v_prefix;
+
+  insert into public.issues (
+    workspace_id, project_id, issue_number, issue_key,
+    title, description, status, priority,
+    assignee_id, sprint_id, due_date, story_points,
+    sort_order, created_by, parent_id
+  ) values (
+    p_workspace_id, p_project_id, v_number,
+    v_prefix || '-' || v_number,
+    p_title, p_description, p_status, p_priority,
+    p_assignee_id, p_sprint_id, p_due_date, p_story_points,
+    p_sort_order, v_caller, p_parent_id
+  )
+  returning * into v_issue;
+
+  if array_length(p_label_ids, 1) is not null then
+    insert into public.issue_labels (issue_id, label_id)
+    select v_issue.id, unnest(p_label_ids);
+  end if;
+
+  return v_issue;
+end;
+$$;

--- a/tests/sub-issues.spec.ts
+++ b/tests/sub-issues.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const WS = "/pw-workspace";
+const runId = Date.now().toString(36);
+const parentTitle = `Sub-issue parent ${runId}`;
+const firstChildTitle = `Sub-issue child A ${runId}`;
+const secondChildTitle = `Sub-issue child B ${runId}`;
+const thirdChildTitle = `Sub-issue child C ${runId}`;
+
+let parentKey = "";
+let selectedSprintId: string | null = null;
+
+async function openSeedProjectList(page: Page) {
+  await page.goto(`${WS}/projects`);
+  const projectCard = page.locator("main").getByRole("link", {
+    name: /Frontend v2\.4/,
+  });
+  await expect(projectCard).toBeVisible({ timeout: 10000 });
+  const boardHref = await projectCard.getAttribute("href");
+  expect(boardHref).toMatch(/\/board$/);
+  await page.goto(`http://localhost:3000${boardHref}`);
+  await expect(page).toHaveURL(new RegExp(`${WS}/projects/.+/board$`), {
+    timeout: 10000,
+  });
+  await page.getByRole("link", { name: "List" }).click();
+  await expect(page).toHaveURL(/\/list$/, { timeout: 10000 });
+}
+
+async function createChildFromParentDetail(page: Page, title: string, storyPoints: string) {
+  await page.getByRole("button", { name: /Add sub-issue/i }).click();
+  const dialog = page.locator("[role='dialog']").filter({ hasText: "New Issue" }).last();
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText(parentKey)).toBeVisible();
+  await expect(dialog.getByLabel("Project")).toBeDisabled();
+  if (selectedSprintId) {
+    await expect(dialog.getByLabel("Sprint")).toHaveValue(selectedSprintId);
+  }
+  await dialog.getByLabel("Title").fill(title);
+  await dialog.getByLabel("Story Points").fill(storyPoints);
+  await dialog.getByRole("button", { name: "Create Issue" }).click();
+  await expect(dialog).not.toBeVisible({ timeout: 10000 });
+}
+
+test.describe.serial("sub-issues hierarchy", () => {
+  test("creates sub-issues from the detail panel and shows board progress", async ({
+    page,
+  }) => {
+    await openSeedProjectList(page);
+
+    await page.getByRole("button", { name: /New Issue/ }).click();
+    const dialog = page.locator("[role='dialog']").filter({ hasText: "New Issue" }).last();
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Title").fill(parentTitle);
+
+    const sprintSelect = dialog.getByLabel("Sprint");
+    const sprintOptionCount = await sprintSelect.locator("option").count();
+    if (sprintOptionCount > 1) {
+      selectedSprintId = await sprintSelect.locator("option").nth(1).getAttribute("value");
+      if (selectedSprintId) {
+        await sprintSelect.selectOption(selectedSprintId);
+      }
+    }
+
+    await dialog.getByRole("button", { name: "Create Issue" }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(parentTitle)).toBeVisible({ timeout: 10000 });
+
+    await page.getByText(parentTitle).click();
+    const detail = page.locator("[role='dialog']").last();
+    await expect(detail).toBeVisible({ timeout: 10000 });
+    parentKey = (await detail.getByText(/^FLO-\d+$/).first().textContent())?.trim() ?? "";
+    expect(parentKey).toMatch(/^FLO-\d+$/);
+
+    await createChildFromParentDetail(page, firstChildTitle, "3");
+    await expect(detail.getByText(firstChildTitle)).toBeVisible({ timeout: 10000 });
+
+    await createChildFromParentDetail(page, secondChildTitle, "5");
+    await expect(detail.getByText(secondChildTitle)).toBeVisible({ timeout: 10000 });
+    await expect(detail.getByText("0/2 sub-issues done")).toBeVisible();
+    await expect(detail.getByText("8 pts from sub-issues")).toBeVisible();
+
+    await page.getByRole("link", { name: "Board" }).click();
+    await expect(page).toHaveURL(/\/board$/, { timeout: 10000 });
+
+    const parentCard = page.locator(`[aria-label*="${parentTitle}"]`).first();
+    await expect(parentCard).toContainText("0/2");
+
+    const firstChildCard = page.locator(`[aria-label*="${firstChildTitle}"]`).first();
+    await expect(firstChildCard).toContainText(`parent: ${parentKey}`);
+    await expect(
+      page.locator(`[aria-label*="${secondChildTitle}"]`).first(),
+    ).toContainText(`parent: ${parentKey}`);
+
+    await firstChildCard.click();
+    const childDetail = page.locator("[role='dialog']").last();
+    await expect(childDetail.getByText(parentKey)).toBeVisible();
+    await childDetail.getByRole("button", { name: "Done" }).click();
+    await expect(parentCard).toContainText("1/2", { timeout: 10000 });
+  });
+
+  test("renders a collapsible list tree and supports parent selection in the create modal", async ({
+    page,
+  }) => {
+    await openSeedProjectList(page);
+
+    await expect(page.getByText(firstChildTitle)).not.toBeVisible();
+    const expandButton = page.getByLabel("Expand sub-issues").first();
+    await expandButton.click();
+    await expect(page.getByText(firstChildTitle)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(secondChildTitle)).toBeVisible();
+
+    const collapseButton = page.getByLabel("Collapse sub-issues").first();
+    await collapseButton.click();
+    await expect(page.getByText(firstChildTitle)).not.toBeVisible();
+
+    await page.getByRole("button", { name: /New Issue/ }).click();
+    const dialog = page.locator("[role='dialog']").filter({ hasText: "New Issue" }).last();
+    await expect(dialog).toBeVisible();
+
+    const parentSearch = dialog.getByPlaceholder("Search for a parent issue...");
+    await parentSearch.fill(parentTitle);
+    await dialog.getByRole("button", { name: new RegExp(parentKey) }).click();
+    await expect(dialog.getByText(parentKey)).toBeVisible();
+    await expect(dialog.getByLabel("Project")).toBeDisabled();
+    if (selectedSprintId) {
+      await expect(dialog.getByLabel("Sprint")).toHaveValue(selectedSprintId);
+    }
+
+    await dialog.getByLabel("Title").fill(thirdChildTitle);
+    await dialog.getByRole("button", { name: "Create Issue" }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    await page.getByLabel("Expand sub-issues").first().click();
+    await expect(page.getByText(thirdChildTitle)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/sub-issues.spec.ts
+++ b/tests/sub-issues.spec.ts
@@ -32,6 +32,7 @@ async function createChildFromParentDetail(page: Page, title: string, storyPoint
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText(parentKey)).toBeVisible();
   await expect(dialog.getByLabel("Project")).toBeDisabled();
+  await expect(dialog.getByLabel("Sprint")).toBeDisabled();
   if (selectedSprintId) {
     await expect(dialog.getByLabel("Sprint")).toHaveValue(selectedSprintId);
   }
@@ -122,6 +123,7 @@ test.describe.serial("sub-issues hierarchy", () => {
     await dialog.getByRole("button", { name: new RegExp(parentKey) }).click();
     await expect(dialog.getByText(parentKey)).toBeVisible();
     await expect(dialog.getByLabel("Project")).toBeDisabled();
+    await expect(dialog.getByLabel("Sprint")).toBeDisabled();
     if (selectedSprintId) {
       await expect(dialog.getByLabel("Sprint")).toHaveValue(selectedSprintId);
     }


### PR DESCRIPTION
## Summary
- add single-level parent/child issue support in the database, query layer, and server actions
- expose sub-issues throughout the UI, including board badges, list tree mode, detail panel management, and create-flow parent selection
- add activity formatting and Playwright coverage for the new hierarchy flows



Closes #27