### PR TITLE
Fix invites and rework onboarding for project-first setup

### DIFF
--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/board-empty.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/board-empty.tsx
@@ -1,29 +1,76 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { IssueEmptyState } from "@/components/issues/issue-empty-state";
 import { CreateIssueModal } from "@/components/issues/create-issue-modal";
+import { CreateSprintModal } from "@/components/sprints/create-sprint-modal";
+import { Button } from "@/components/ui/button";
 
 interface BoardPageEmptyProps {
+  workspaceId: string;
+  workspaceSlug: string;
   projectId: string;
   projects: { id: string; name: string; color: string }[];
   members: { user_id: string; profile: { full_name: string | null; email: string } }[];
   sprints: { id: string; name: string; status: string }[];
   labels: { id: string; name: string; color: string }[];
+  showFirstRunSetup?: boolean;
 }
 
 export function BoardPageEmpty({
+  workspaceId,
+  workspaceSlug,
   projectId,
   projects,
   members,
   sprints,
   labels,
+  showFirstRunSetup = false,
 }: BoardPageEmptyProps) {
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showCreateSprintModal, setShowCreateSprintModal] = useState(false);
 
   return (
     <>
-      <IssueEmptyState onCreateIssue={() => setShowCreateModal(true)} />
+      {showFirstRunSetup ? (
+        <div className="flex min-h-[calc(100vh-12rem)] items-center justify-center px-6 py-10">
+          <div className="w-full max-w-3xl rounded-[28px] border border-border-input bg-surface px-8 py-10 shadow-sm">
+            <div className="max-w-2xl">
+              <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-text-muted">
+                First-run setup
+              </p>
+              <h1 className="mt-3 font-serif text-4xl leading-tight text-text">
+                Start on the board, then bring the team in.
+              </h1>
+              <p className="mt-4 text-sm leading-6 text-text-secondary">
+                Your workspace is ready. Create the first issue or sprint from the board, and invite teammates once the project has context.
+              </p>
+            </div>
+
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button size="lg" onClick={() => setShowCreateModal(true)}>
+                Create first issue
+              </Button>
+              <Button
+                size="lg"
+                variant="secondary"
+                onClick={() => setShowCreateSprintModal(true)}
+              >
+                Create first sprint
+              </Button>
+              <Link
+                href={`/${workspaceSlug}/settings/members`}
+                className="inline-flex items-center justify-center rounded-lg border border-border-input px-4 py-2.5 text-sm font-medium text-text transition-colors hover:bg-surface-hover"
+              >
+                Invite teammates
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <IssueEmptyState onCreateIssue={() => setShowCreateModal(true)} />
+      )}
       <CreateIssueModal
         open={showCreateModal}
         onOpenChange={setShowCreateModal}
@@ -33,6 +80,12 @@ export function BoardPageEmpty({
         sprints={sprints}
         labels={labels}
         initialSortOrder={1000}
+      />
+      <CreateSprintModal
+        open={showCreateSprintModal}
+        onOpenChange={setShowCreateSprintModal}
+        projectId={projectId}
+        workspaceId={workspaceId}
       />
     </>
   );

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/page.tsx
@@ -6,6 +6,7 @@ import {
   getProjectSprints,
 } from "@/lib/queries/projects";
 import { getWorkspaceMembers } from "@/lib/queries/members";
+import { getWorkspaceBySlug } from "@/lib/queries/workspaces";
 import { getProjectActiveSprintSummary } from "@/lib/queries/sprints";
 import { SprintHeader } from "@/components/sprints/sprint-header";
 import { BoardPageEmpty } from "./board-empty";
@@ -21,23 +22,33 @@ export default async function BoardPage({
   const projectData = await getProjectById(projectId);
   if (!projectData) notFound();
 
-  const [issues, labels, sprints, activeSprintSummary, members] = await Promise.all([
+  const [issues, labels, sprints, activeSprintSummary, members, workspaceResult] = await Promise.all([
     getProjectIssues(projectId),
     getProjectLabels(projectId),
     getProjectSprints(projectId),
     getProjectActiveSprintSummary(projectId),
     getWorkspaceMembers(projectData.workspace_id),
+    getWorkspaceBySlug(workspaceSlug),
   ]);
+
+  const showFirstRunSetup = Boolean(
+    workspaceResult &&
+    workspaceResult.role === "owner" &&
+    workspaceResult.primary_project_id === projectData.id,
+  );
 
   if (issues.length === 0) {
     const projects = [{ id: projectData.id, name: projectData.name, color: projectData.color }];
     return (
       <BoardPageEmpty
+        workspaceId={projectData.workspace_id}
+        workspaceSlug={workspaceSlug}
         projectId={projectData.id}
         projects={projects}
         members={members}
         sprints={sprints}
         labels={labels}
+        showFirstRunSetup={showFirstRunSetup}
       />
     );
   }

--- a/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getWorkspaceBySlug } from "@/lib/queries/workspaces";
 import { getWorkspaceMembers } from "@/lib/queries/members";
+import { getWorkspaceInvites } from "@/lib/queries/invites";
 import { MembersSettings } from "@/components/settings/members-settings";
 
 export default async function WorkspaceMembersPage({
@@ -22,11 +23,17 @@ export default async function WorkspaceMembersPage({
   } = await supabase.auth.getUser();
 
   const members = await getWorkspaceMembers(result.workspace.id);
+  const invites =
+    result.role === "owner" || result.role === "admin"
+      ? await getWorkspaceInvites(result.workspace.id)
+      : [];
 
   return (
     <MembersSettings
       members={members}
+      invites={invites}
       workspaceId={result.workspace.id}
+      workspaceSlug={result.workspace.slug}
       currentUserId={user?.id ?? ""}
       currentUserRole={result.role}
     />

--- a/src/app/(app)/[workspaceSlug]/teams/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/teams/page.tsx
@@ -25,7 +25,9 @@ export default async function TeamsPage({
         <h1 className="text-2xl font-semibold tracking-[-0.02em] text-text">
           Teams
         </h1>
-        <InviteMemberButton workspaceId={result.workspace.id} />
+        {(result.role === "owner" || result.role === "admin") && (
+          <InviteMemberButton workspaceId={result.workspace.id} />
+        )}
       </div>
       {teams.length > 0 ? (
         <TeamsList teams={teams} />

--- a/src/app/(app)/onboarding/onboarding-wizard.tsx
+++ b/src/app/(app)/onboarding/onboarding-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useActionState, useEffect } from "react";
+import { useState, useActionState } from "react";
 import { cn } from "@/lib/utils/cn";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import {
   createWorkspace,
   createProject,
-  createWorkspaceInvite,
   finishOnboarding,
 } from "@/lib/actions/workspaces";
 import type { ActionResponse, Tables } from "@/lib/types";
@@ -40,7 +39,7 @@ function slugify(value: string) {
 function ProgressBar({ step }: { step: number }) {
   return (
     <div className="flex items-center gap-1.5">
-      {[1, 2, 3].map((s) => (
+      {[1, 2].map((s) => (
         <div
           key={s}
           className={cn(
@@ -63,7 +62,7 @@ function TopBar({ step }: { step: number }) {
       <span className="font-serif text-xl text-text">Flow</span>
       <ProgressBar step={step} />
       <span className="uppercase tracking-wider text-xs font-medium text-text-secondary">
-        Step {step} of 3
+        Step {step} of 2
       </span>
     </header>
   );
@@ -86,12 +85,6 @@ function StepWorkspace({
 
   // Keep slug in sync with name unless user manually edits
   const [slugTouched, setSlugTouched] = useState(false);
-
-  useEffect(() => {
-    if (!slugTouched) {
-      setSlug(slugify(name));
-    }
-  }, [name, slugTouched]);
 
   async function action(
     _prev: WorkspaceState,
@@ -123,7 +116,13 @@ function StepWorkspace({
           name="name"
           placeholder="Acme Inc"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => {
+            const nextName = e.target.value;
+            setName(nextName);
+            if (!slugTouched) {
+              setSlug(slugify(nextName));
+            }
+          }}
           required
         />
       </div>
@@ -177,87 +176,7 @@ function StepWorkspace({
 }
 
 // ---------------------------------------------------------------------------
-// Step 2 – Invite
-// ---------------------------------------------------------------------------
-
-function StepInvite({
-  workspace,
-  onContinue,
-}: {
-  workspace: Tables<"workspaces">;
-  onContinue: () => void;
-}) {
-  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [copied, setCopied] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function generate() {
-      const result = await createWorkspaceInvite(workspace.id, "member");
-      if (result.error) {
-        setError(result.error);
-      } else if (result.data) {
-        const origin = typeof window !== "undefined" ? window.location.origin : "";
-        setInviteUrl(`${origin}/invite/${result.data.id}`);
-      }
-      setLoading(false);
-    }
-    generate();
-  }, [workspace.id]);
-
-  async function copyToClipboard() {
-    if (!inviteUrl) return;
-    try {
-      await navigator.clipboard.writeText(inviteUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback: select the input
-    }
-  }
-
-  return (
-    <div className="flex flex-col gap-6">
-      {error && <p className="text-sm text-danger">{error}</p>}
-
-      <div className="flex flex-col gap-2">
-        <Label>Invite Link</Label>
-        <div className="flex gap-2">
-          <Input
-            readOnly
-            value={loading ? "Generating link..." : inviteUrl ?? ""}
-            className="flex-1"
-          />
-          <Button
-            type="button"
-            variant="secondary"
-            size="lg"
-            onClick={copyToClipboard}
-            disabled={loading || !inviteUrl}
-          >
-            {copied ? "Copied!" : "Copy"}
-          </Button>
-        </div>
-      </div>
-
-      <Button type="button" size="lg" className="w-full" onClick={onContinue}>
-        Continue
-      </Button>
-
-      <button
-        type="button"
-        onClick={onContinue}
-        className="text-sm text-text-muted hover:text-text-secondary transition-colors text-center"
-      >
-        Skip for now
-      </button>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Step 3 – First project
+// Step 2 – First project
 // ---------------------------------------------------------------------------
 
 type ProjectState = ActionResponse<Tables<"projects">> | null;
@@ -277,7 +196,7 @@ function StepProject({
     formData.set("color", color);
     const result = await createProject(formData);
     if (result.data) {
-      await finishOnboarding(workspace.slug);
+      await finishOnboarding(workspace.slug, result.data.id);
     }
     return result;
   }
@@ -286,10 +205,6 @@ function StepProject({
     action,
     null,
   );
-
-  async function skip() {
-    await finishOnboarding(workspace.slug);
-  }
 
   return (
     <form action={formAction} className="flex flex-col gap-6">
@@ -340,16 +255,8 @@ function StepProject({
       </div>
 
       <Button type="submit" size="lg" className="w-full" disabled={pending}>
-        {pending ? "Creating..." : "Continue"}
+        {pending ? "Creating..." : "Create Project"}
       </Button>
-
-      <button
-        type="button"
-        onClick={skip}
-        className="text-sm text-text-muted hover:text-text-secondary transition-colors text-center"
-      >
-        Skip for now
-      </button>
     </form>
   );
 }
@@ -364,12 +271,8 @@ const STEP_META: Record<number, { title: string; subtitle: string }> = {
     subtitle: "This is where your team will plan, track, and ship.",
   },
   2: {
-    title: "Invite your team",
-    subtitle: "Share this link with your teammates.",
-  },
-  3: {
     title: "Create your first project",
-    subtitle: "Projects organize your team\u2019s work.",
+    subtitle: "You’ll land on its board so you can start with real work right away.",
   },
 };
 
@@ -404,13 +307,6 @@ export function OnboardingWizard() {
           )}
 
           {step === 2 && workspace && (
-            <StepInvite
-              workspace={workspace}
-              onContinue={() => setStep(3)}
-            />
-          )}
-
-          {step === 3 && workspace && (
             <StepProject workspace={workspace} />
           )}
         </div>

--- a/src/app/(app)/onboarding/page.tsx
+++ b/src/app/(app)/onboarding/page.tsx
@@ -1,12 +1,13 @@
 import { redirect } from "next/navigation";
 import { getUserWorkspace } from "@/lib/queries/workspaces";
 import { OnboardingWizard } from "./onboarding-wizard";
+import { getDefaultSignedInPath } from "@/lib/utils/auth-redirect";
 
 export default async function OnboardingPage() {
   const workspace = await getUserWorkspace();
 
   if (workspace) {
-    redirect(`/${workspace.slug}/dashboard`);
+    redirect(await getDefaultSignedInPath());
   }
 
   return <OnboardingWizard />;

--- a/src/app/(auth)/callback/route.ts
+++ b/src/app/(auth)/callback/route.ts
@@ -1,16 +1,18 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { resolvePostAuthRedirect } from "@/lib/utils/auth-redirect";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/onboarding";
+  const next = searchParams.get("next");
 
   if (code) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      const redirectPath = await resolvePostAuthRedirect(next);
+      return NextResponse.redirect(new URL(redirectPath, origin));
     }
   }
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useActionState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Github } from "lucide-react";
 import { signIn, signInWithOAuth } from "@/lib/actions/auth";
 import type { ActionResponse } from "@/lib/types";
 
 export default function LoginPage() {
+  const searchParams = useSearchParams();
+  const nextPath = searchParams.get("next");
   const [state, formAction, pending] = useActionState<
     ActionResponse | null,
     FormData
@@ -37,6 +40,7 @@ export default function LoginPage() {
 
       {/* Form */}
       <form action={formAction} className="space-y-5">
+        <input type="hidden" name="next" value={nextPath ?? ""} />
         <div className="space-y-2">
           <label
             htmlFor="email"
@@ -101,7 +105,7 @@ export default function LoginPage() {
       <div className="flex gap-3">
         <button
           type="button"
-          onClick={() => signInWithOAuth("google")}
+          onClick={() => signInWithOAuth("google", nextPath)}
           className="flex-1 flex items-center justify-center gap-2 bg-surface border border-border rounded-lg h-12 font-medium text-sm text-text hover:bg-surface-hover transition-colors"
         >
           <svg className="w-5 h-5" viewBox="0 0 24 24">
@@ -127,7 +131,7 @@ export default function LoginPage() {
 
         <button
           type="button"
-          onClick={() => signInWithOAuth("github")}
+          onClick={() => signInWithOAuth("github", nextPath)}
           className="flex-1 flex items-center justify-center gap-2 bg-surface border border-border rounded-lg h-12 font-medium text-sm text-text hover:bg-surface-hover transition-colors"
         >
           <Github className="w-5 h-5" />
@@ -139,7 +143,7 @@ export default function LoginPage() {
       <p className="text-center text-sm text-text-secondary mt-8">
         Don&apos;t have an account?{" "}
         <Link
-          href="/signup"
+          href={nextPath ? `/signup?next=${encodeURIComponent(nextPath)}` : "/signup"}
           className="text-text font-medium hover:underline"
         >
           Sign up

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useActionState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Github } from "lucide-react";
 import { signUp, signInWithOAuth } from "@/lib/actions/auth";
 import type { ActionResponse } from "@/lib/types";
 
 export default function SignUpPage() {
+  const searchParams = useSearchParams();
+  const nextPath = searchParams.get("next");
   const [state, formAction, pending] = useActionState<
     ActionResponse | null,
     FormData
@@ -41,6 +44,7 @@ export default function SignUpPage() {
 
       {/* Form */}
       <form action={formAction} className="space-y-5">
+        <input type="hidden" name="next" value={nextPath ?? ""} />
         <div className="space-y-2">
           <label
             htmlFor="fullName"
@@ -115,7 +119,7 @@ export default function SignUpPage() {
       <div className="flex gap-3">
         <button
           type="button"
-          onClick={() => signInWithOAuth("google")}
+          onClick={() => signInWithOAuth("google", nextPath)}
           className="flex-1 flex items-center justify-center gap-2 bg-surface border border-border rounded-lg h-12 font-medium text-sm text-text hover:bg-surface-hover transition-colors"
         >
           <svg className="w-5 h-5" viewBox="0 0 24 24">
@@ -141,7 +145,7 @@ export default function SignUpPage() {
 
         <button
           type="button"
-          onClick={() => signInWithOAuth("github")}
+          onClick={() => signInWithOAuth("github", nextPath)}
           className="flex-1 flex items-center justify-center gap-2 bg-surface border border-border rounded-lg h-12 font-medium text-sm text-text hover:bg-surface-hover transition-colors"
         >
           <Github className="w-5 h-5" />
@@ -153,7 +157,7 @@ export default function SignUpPage() {
       <p className="text-center text-sm text-text-secondary mt-8">
         Already have an account?{" "}
         <Link
-          href="/login"
+          href={nextPath ? `/login?next=${encodeURIComponent(nextPath)}` : "/login"}
           className="text-text font-medium hover:underline"
         >
           Sign in

--- a/src/app/join/[code]/join-invite-client.tsx
+++ b/src/app/join/[code]/join-invite-client.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { acceptWorkspaceInvite } from "@/lib/actions/invites";
+import { signOutTo } from "@/lib/actions/auth";
+
+interface JoinInviteClientProps {
+  code: string;
+  joinPath: string;
+  mismatch?: boolean;
+}
+
+export function JoinInviteClient({
+  code,
+  joinPath,
+  mismatch = false,
+}: JoinInviteClientProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAccept() {
+    setLoading(true);
+    setError(null);
+
+    const result = await acceptWorkspaceInvite(code);
+    if (result.error) {
+      setError(result.error);
+      setLoading(false);
+      return;
+    }
+
+    if (!result.data) {
+      setError("Unable to complete invite redemption.");
+      setLoading(false);
+      return;
+    }
+
+    router.push(`/${result.data.workspaceSlug}/dashboard`);
+    router.refresh();
+  }
+
+  async function handleSwitchAccount() {
+    setLoading(true);
+    await signOutTo(joinPath);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {error && (
+        <div className="rounded-lg border border-danger/20 bg-danger-light px-4 py-3 text-sm text-danger">
+          {error}
+        </div>
+      )}
+
+      {mismatch ? (
+        <button
+          type="button"
+          onClick={handleSwitchAccount}
+          disabled={loading}
+          className="rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
+        >
+          {loading ? "Switching..." : "Sign out and switch account"}
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={handleAccept}
+          disabled={loading}
+          className="rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
+        >
+          {loading ? "Joining..." : "Join workspace"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/app/join/[code]/page.tsx
+++ b/src/app/join/[code]/page.tsx
@@ -1,0 +1,190 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { buildAuthRedirectUrl } from "@/lib/utils/redirect-path";
+import { getInviteStatus, getJoinInviteRecord } from "@/lib/invites";
+import { JoinInviteClient } from "./join-invite-client";
+
+function InviteStateCard({
+  eyebrow,
+  title,
+  body,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  body: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="mx-auto flex min-h-screen max-w-xl items-center px-4 py-12">
+      <div className="w-full rounded-[28px] border border-border bg-surface px-8 py-8 shadow-sm">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-text-muted">
+          {eyebrow}
+        </p>
+        <h1 className="mt-3 font-serif text-3xl text-text">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-text-secondary">{body}</p>
+        {children ? <div className="mt-6">{children}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+export default async function JoinInvitePage({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}) {
+  const { code } = await params;
+  const joinPath = `/join/${code}`;
+  const inviteRecord = await getJoinInviteRecord(code);
+
+  if (!inviteRecord?.workspace) {
+    return (
+      <InviteStateCard
+        eyebrow="Invite not found"
+        title="This invite link is invalid"
+        body="Ask your workspace admin for a fresh invite link or a targeted email invite."
+      />
+    );
+  }
+
+  const workspace = inviteRecord.workspace;
+  const inviteStatus = getInviteStatus(inviteRecord);
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const currentEmail = user?.email?.trim().toLowerCase() ?? "";
+  const inviteEmail = inviteRecord.email?.trim().toLowerCase() ?? "";
+  const isMismatch =
+    Boolean(user) &&
+    inviteRecord.invite_type === "email" &&
+    inviteEmail.length > 0 &&
+    inviteEmail !== currentEmail;
+
+  const { data: existingMembership } = user
+    ? await supabase
+        .from("workspace_members")
+        .select("id")
+        .eq("workspace_id", inviteRecord.workspace_id)
+        .eq("user_id", user.id)
+        .maybeSingle()
+    : { data: null };
+
+  if (inviteStatus === "revoked") {
+    return (
+      <InviteStateCard
+        eyebrow="Invite revoked"
+        title="This invite has been revoked"
+        body={`The invite to join ${workspace.name} is no longer active. Ask an owner or admin to send a new one.`}
+      />
+    );
+  }
+
+  if (inviteStatus === "expired") {
+    return (
+      <InviteStateCard
+        eyebrow="Invite expired"
+        title="This invite has expired"
+        body={`The invite to join ${workspace.name} is older than the allowed window. Ask for a fresh invite.`}
+      />
+    );
+  }
+
+  if (
+    inviteRecord.invite_type === "email" &&
+    inviteRecord.accepted_at &&
+    inviteRecord.accepted_by &&
+    inviteRecord.accepted_by !== user?.id &&
+    !existingMembership
+  ) {
+    return (
+      <InviteStateCard
+        eyebrow="Invite used"
+        title="This invite has already been accepted"
+        body="Targeted email invites are single-use. Ask the workspace owner or admin for a new invite if you still need access."
+      />
+    );
+  }
+
+  if (!user) {
+    return (
+      <InviteStateCard
+        eyebrow="Workspace invite"
+        title={`Join ${workspace.name}`}
+        body={
+          inviteRecord.invite_type === "email"
+            ? `Sign in or create an account with ${inviteRecord.email} to accept this invite.`
+            : "Sign in or create an account to join this workspace with the link you opened."
+        }
+      >
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Link
+            href={buildAuthRedirectUrl("/login", joinPath)}
+            className="rounded-lg bg-primary px-4 py-2.5 text-center text-sm font-medium text-background transition-colors hover:bg-primary-hover"
+          >
+            Sign in
+          </Link>
+          <Link
+            href={buildAuthRedirectUrl("/signup", joinPath)}
+            className="rounded-lg border border-border-input px-4 py-2.5 text-center text-sm font-medium text-text transition-colors hover:bg-surface-hover"
+          >
+            Create account
+          </Link>
+        </div>
+      </InviteStateCard>
+    );
+  }
+
+  if (existingMembership) {
+    return (
+      <InviteStateCard
+        eyebrow="Already a member"
+        title={`You already belong to ${workspace.name}`}
+        body="No extra onboarding is required. Open the workspace directly."
+      >
+        <Link
+          href={`/${workspace.slug}/dashboard`}
+          className="inline-flex rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-background transition-colors hover:bg-primary-hover"
+        >
+          Open workspace
+        </Link>
+      </InviteStateCard>
+    );
+  }
+
+  if (isMismatch) {
+    return (
+      <InviteStateCard
+        eyebrow="Account mismatch"
+        title="This invite is for a different email"
+        body={`You’re signed in as ${user.email}, but this invite was sent to ${inviteRecord.email}. Switch accounts to continue.`}
+      >
+        <JoinInviteClient
+          code={code}
+          joinPath={joinPath}
+          mismatch
+        />
+      </InviteStateCard>
+    );
+  }
+
+  return (
+    <InviteStateCard
+      eyebrow="Workspace invite"
+      title={`Join ${workspace.name}`}
+      body={
+        inviteRecord.invite_type === "email"
+          ? `You’ve been invited as an ${inviteRecord.role}. Accept the invite to join this workspace.`
+          : "This join link grants member access. Accept the invite to enter the workspace."
+      }
+    >
+      <JoinInviteClient
+        code={code}
+        joinPath={joinPath}
+      />
+    </InviteStateCard>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { LandingPage } from "@/components/landing/landing-page";
+import { getDefaultSignedInPath } from "@/lib/utils/auth-redirect";
 
 export default async function Home() {
   const supabase = await createClient();
@@ -12,18 +13,5 @@ export default async function Home() {
     return <LandingPage />;
   }
 
-  // Check if user has a workspace
-  const { data: membership } = await supabase
-    .from("workspace_members")
-    .select("workspace:workspaces(slug)")
-    .eq("user_id", user.id)
-    .limit(1)
-    .single();
-
-  if (membership?.workspace) {
-    const workspace = membership.workspace as { slug: string };
-    redirect(`/${workspace.slug}/dashboard`);
-  }
-
-  redirect("/onboarding");
+  redirect(await getDefaultSignedInPath());
 }

--- a/src/components/settings/members-settings.tsx
+++ b/src/components/settings/members-settings.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   updateMemberRole,
   removeMember,
-  createWorkspaceInvite,
 } from "@/lib/actions/workspaces";
+import {
+  createWorkspaceEmailInvite,
+  createWorkspaceLinkInvite,
+  regenerateWorkspaceLinkInvite,
+  revokeWorkspaceInvite,
+} from "@/lib/actions/invites";
 import { DeleteConfirmationModal } from "@/components/ui/delete-confirmation-modal";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import type { WorkspaceRole } from "@/lib/types";
+import type { WorkspaceInviteListItem } from "@/lib/invites";
+import { buildInviteUrl, getInviteStatusLabel } from "@/lib/invites";
+import { formatRelative } from "@/lib/utils/dates";
 
 type Member = {
   id: string;
@@ -25,7 +33,9 @@ type Member = {
 
 interface MembersSettingsProps {
   members: Member[];
+  invites: WorkspaceInviteListItem[];
   workspaceId: string;
+  workspaceSlug: string;
   currentUserId: string;
   currentUserRole: WorkspaceRole;
 }
@@ -44,45 +54,96 @@ const ROLE_BADGE_STYLES: Record<WorkspaceRole, string> = {
 
 export function MembersSettings({
   members,
+  invites,
   workspaceId,
+  workspaceSlug,
   currentUserId,
   currentUserRole,
 }: MembersSettingsProps) {
   const router = useRouter();
   const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
   const [inviteLoading, setInviteLoading] = useState(false);
+  const [emailInviteLoading, setEmailInviteLoading] = useState(false);
   const [removingMember, setRemovingMember] = useState<Member | null>(null);
   const [removeLoading, setRemoveLoading] = useState(false);
 
   const canManageMembers = currentUserRole === "owner" || currentUserRole === "admin";
-
-  const handleGenerateInvite = useCallback(async () => {
-    setInviteLoading(true);
-    const result = await createWorkspaceInvite(workspaceId, "member");
-    if ("data" in result && result.data) {
-      const url = `${window.location.origin}/join/${result.data.code}`;
-      setInviteLink(url);
-      navigator.clipboard.writeText(url);
-    }
-    setInviteLoading(false);
-  }, [workspaceId]);
-
-  const handleRoleChange = useCallback(
-    async (memberId: string, newRole: "admin" | "member") => {
-      await updateMemberRole(memberId, newRole);
-      router.refresh();
-    },
-    [router],
+  const activeLinkInvite = useMemo(
+    () => invites.find((invite) => invite.invite_type === "link" && invite.status === "pending") ?? null,
+    [invites],
   );
 
-  const handleRemoveMember = useCallback(async () => {
+  const effectiveInviteLink = inviteLink ?? (activeLinkInvite ? buildInviteUrl(activeLinkInvite.code) : null);
+
+  async function handleGenerateInvite() {
+    setInviteLoading(true);
+    const result = await createWorkspaceLinkInvite(workspaceId);
+    if ("data" in result && result.data) {
+      const url = result.data.url;
+      setInviteLink(url);
+      navigator.clipboard.writeText(url);
+      router.refresh();
+    }
+    setInviteLoading(false);
+  }
+
+  async function handleRoleChange(memberId: string, newRole: "admin" | "member") {
+    await updateMemberRole(memberId, newRole);
+    router.refresh();
+  }
+
+  async function handleRemoveMember() {
     if (!removingMember) return;
     setRemoveLoading(true);
     await removeMember(removingMember.id);
     setRemoveLoading(false);
     setRemovingMember(null);
     router.refresh();
-  }, [removingMember, router]);
+  }
+
+  async function handleCreateEmailInvite() {
+    if (!inviteEmail.trim()) return;
+    setEmailInviteLoading(true);
+    const result = await createWorkspaceEmailInvite({
+      workspaceId,
+      email: inviteEmail,
+      role: currentUserRole === "owner" ? inviteRole : "member",
+    });
+
+    if (result.data) {
+      setInviteEmail("");
+      setInviteLink(result.data.url);
+      await navigator.clipboard.writeText(result.data.url);
+      router.refresh();
+    }
+
+    setEmailInviteLoading(false);
+  }
+
+  async function handleRegenerateLink() {
+    setInviteLoading(true);
+    const result = await regenerateWorkspaceLinkInvite(workspaceId);
+    if (result.data) {
+      setInviteLink(result.data.url);
+      await navigator.clipboard.writeText(result.data.url);
+      router.refresh();
+    }
+    setInviteLoading(false);
+  }
+
+  async function handleRevokeInvite(inviteId: string) {
+    await revokeWorkspaceInvite(inviteId);
+    if (activeLinkInvite?.id === inviteId) {
+      setInviteLink(null);
+    }
+    router.refresh();
+  }
+
+  function copyInvite(url: string) {
+    navigator.clipboard.writeText(url);
+  }
 
   return (
     <div className="max-w-2xl">
@@ -93,32 +154,166 @@ export function MembersSettings({
             Manage who has access to this workspace.
           </p>
         </div>
-        {canManageMembers && (
-          <button
-            type="button"
-            onClick={handleGenerateInvite}
-            disabled={inviteLoading}
-            className="rounded-lg bg-primary px-4 py-2 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
-          >
-            {inviteLoading ? "Generating..." : "Generate invite link"}
-          </button>
-        )}
       </div>
 
-      {inviteLink && (
-        <div className="mt-4 flex items-center gap-3 rounded-[10px] border border-border-input bg-surface-inset px-4 py-3">
-          <span className="flex-1 text-[13px] font-mono text-text truncate">
-            {inviteLink}
-          </span>
-          <button
-            type="button"
-            onClick={() => {
-              navigator.clipboard.writeText(inviteLink);
-            }}
-            className="text-[12px] font-medium text-text-muted hover:text-text transition-colors shrink-0"
-          >
-            Copy
-          </button>
+      {canManageMembers && (
+        <div className="mt-6 space-y-4">
+          <div className="rounded-[14px] border border-border-input bg-surface px-5 py-5">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-[15px] font-semibold text-text">Invite by email</h2>
+              <p className="text-[13px] text-text-muted">
+                Target a specific teammate. If email delivery is not configured, copy the join link directly.
+              </p>
+            </div>
+
+            <div className="mt-4 flex flex-col gap-3 md:flex-row">
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(event) => setInviteEmail(event.target.value)}
+                placeholder="teammate@company.com"
+                className="h-10 flex-1 rounded-lg border border-border-input bg-background px-3 text-[13px] text-text outline-none transition-colors focus:border-border-strong focus:ring-2 focus:ring-primary/10"
+              />
+              {currentUserRole === "owner" && (
+                <select
+                  value={inviteRole}
+                  onChange={(event) => setInviteRole(event.target.value as "admin" | "member")}
+                  className="h-10 rounded-lg border border-border-input bg-background px-3 text-[13px] text-text outline-none transition-colors focus:border-border-strong focus:ring-2 focus:ring-primary/10"
+                >
+                  <option value="member">Member</option>
+                  <option value="admin">Admin</option>
+                </select>
+              )}
+              <button
+                type="button"
+                onClick={handleCreateEmailInvite}
+                disabled={emailInviteLoading}
+                className="rounded-lg bg-primary px-4 py-2 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
+              >
+                {emailInviteLoading ? "Creating..." : "Create invite"}
+              </button>
+            </div>
+          </div>
+
+          <div className="rounded-[14px] border border-border-input bg-surface px-5 py-5">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-[15px] font-semibold text-text">Shareable join link</h2>
+              <p className="text-[13px] text-text-muted">
+                Link invites always grant the member role and expire after 7 days.
+              </p>
+            </div>
+
+            {effectiveInviteLink ? (
+              <div className="mt-4 flex flex-col gap-3 md:flex-row md:items-center">
+                <span className="min-w-0 flex-1 truncate rounded-lg border border-border-input bg-background px-3 py-2 text-[12px] font-mono text-text">
+                  {effectiveInviteLink}
+                </span>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => copyInvite(effectiveInviteLink)}
+                    className="rounded-lg border border-border-input px-3 py-2 text-[12px] font-medium text-text transition-colors hover:bg-surface-hover"
+                  >
+                    Copy
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleRegenerateLink}
+                    disabled={inviteLoading}
+                    className="rounded-lg border border-border-input px-3 py-2 text-[12px] font-medium text-text transition-colors hover:bg-surface-hover disabled:opacity-50"
+                  >
+                    {inviteLoading ? "Regenerating..." : "Regenerate"}
+                  </button>
+                  {activeLinkInvite && (
+                    <button
+                      type="button"
+                      onClick={() => handleRevokeInvite(activeLinkInvite.id)}
+                      className="rounded-lg border border-danger/20 px-3 py-2 text-[12px] font-medium text-danger transition-colors hover:bg-danger-light"
+                    >
+                      Revoke
+                    </button>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={handleGenerateInvite}
+                disabled={inviteLoading}
+                className="mt-4 rounded-lg bg-primary px-4 py-2 text-[13px] font-medium text-background transition-colors hover:bg-primary-hover disabled:opacity-50"
+              >
+                {inviteLoading ? "Generating..." : "Generate join link"}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {canManageMembers && invites.length > 0 && (
+        <div className="mt-6 rounded-[14px] border border-border-input bg-surface px-5 py-5">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-[15px] font-semibold text-text">Invite history</h2>
+              <p className="text-[13px] text-text-muted">
+                Pending, accepted, revoked, and expired workspace invites.
+              </p>
+            </div>
+            <a
+              href={`/${workspaceSlug}/teams`}
+              className="text-[12px] font-medium text-text-muted transition-colors hover:text-text"
+            >
+              Open Teams
+            </a>
+          </div>
+
+          <div className="mt-4 space-y-2">
+            {invites.map((invite) => {
+              const inviteUrl = buildInviteUrl(invite.code);
+              return (
+                <div
+                  key={invite.id}
+                  className="flex flex-col gap-3 rounded-xl border border-border-subtle bg-background px-4 py-3 md:flex-row md:items-center"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-[13px] font-medium text-text">
+                        {invite.invite_type === "email"
+                          ? invite.email
+                          : "Shareable join link"}
+                      </p>
+                      <span className="rounded-full border border-border-input px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted">
+                        {getInviteStatusLabel(invite.status)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-[12px] text-text-muted">
+                      {invite.role === "admin" ? "Admin invite" : "Member invite"} · Created {formatRelative(invite.created_at)}
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    {invite.status === "pending" && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => copyInvite(inviteUrl)}
+                          className="rounded-lg border border-border-input px-3 py-2 text-[12px] font-medium text-text transition-colors hover:bg-surface-hover"
+                        >
+                          Copy
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRevokeInvite(invite.id)}
+                          className="rounded-lg border border-danger/20 px-3 py-2 text-[12px] font-medium text-danger transition-colors hover:bg-danger-light"
+                        >
+                          Revoke
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/src/components/teams/invite-member-button.tsx
+++ b/src/components/teams/invite-member-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { createWorkspaceInvite } from "@/lib/actions/workspaces";
+import { createWorkspaceLinkInvite } from "@/lib/actions/invites";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -22,13 +22,11 @@ export function InviteMemberButton({ workspaceId }: { workspaceId: string }) {
     setInviteLink(null);
     setCopied(false);
     startTransition(async () => {
-      const result = await createWorkspaceInvite(workspaceId, "member");
+      const result = await createWorkspaceLinkInvite(workspaceId);
       if (result.error) {
         setError(result.error);
-      } else if (result.data) {
-        const code = result.data.code;
-        const link = `${window.location.origin}/join/${code}`;
-        setInviteLink(link);
+      } else if (result.data?.url) {
+        setInviteLink(result.data.url);
       }
     });
     setOpen(true);

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -3,6 +3,10 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { ActionResponse } from "@/lib/types";
+import { buildAuthRedirectUrl, normalizeRedirectPath } from "@/lib/utils/redirect-path";
+import {
+  resolvePostAuthRedirect,
+} from "@/lib/utils/auth-redirect";
 
 export async function signUp(formData: FormData): Promise<ActionResponse> {
   const supabase = await createClient();
@@ -10,6 +14,7 @@ export async function signUp(formData: FormData): Promise<ActionResponse> {
   const fullName = formData.get("fullName") as string;
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
+  const nextPath = formData.get("next") as string | null;
 
   if (!email || !password || !fullName) {
     return { error: "All fields are required" };
@@ -31,7 +36,7 @@ export async function signUp(formData: FormData): Promise<ActionResponse> {
     return { error: error.message };
   }
 
-  redirect("/onboarding");
+  redirect(await resolvePostAuthRedirect(nextPath));
 }
 
 export async function signIn(formData: FormData): Promise<ActionResponse> {
@@ -39,6 +44,7 @@ export async function signIn(formData: FormData): Promise<ActionResponse> {
 
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
+  const nextPath = formData.get("next") as string | null;
 
   if (!email || !password) {
     return { error: "Email and password are required" };
@@ -53,13 +59,19 @@ export async function signIn(formData: FormData): Promise<ActionResponse> {
     return { error: error.message };
   }
 
-  redirect("/onboarding");
+  redirect(await resolvePostAuthRedirect(nextPath));
 }
 
 export async function signOut(): Promise<void> {
   const supabase = await createClient();
   await supabase.auth.signOut();
   redirect("/login");
+}
+
+export async function signOutTo(nextPath: string | null | undefined): Promise<void> {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect(buildAuthRedirectUrl("/login", nextPath));
 }
 
 export async function forgotPassword(
@@ -104,13 +116,22 @@ export async function resetPassword(
   redirect("/login");
 }
 
-export async function signInWithOAuth(provider: "google" | "github") {
+export async function signInWithOAuth(
+  provider: "google" | "github",
+  nextPath?: string | null,
+) {
   const supabase = await createClient();
+  const redirectUrl = new URL("/callback", process.env.NEXT_PUBLIC_APP_URL);
+  const safeNextPath = normalizeRedirectPath(nextPath);
+
+  if (safeNextPath) {
+    redirectUrl.searchParams.set("next", safeNextPath);
+  }
 
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
     options: {
-      redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/callback`,
+      redirectTo: redirectUrl.toString(),
     },
   });
 

--- a/src/lib/actions/invites.ts
+++ b/src/lib/actions/invites.ts
@@ -1,0 +1,398 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createActivity } from "@/lib/actions/activities";
+import { buildInviteUrl, canCreateInvite, getInviteStatus, getJoinInviteRecord } from "@/lib/invites";
+import type { ActionResponse, Tables, WorkspaceRole } from "@/lib/types";
+
+type WorkspaceInviteRow = Tables<"workspace_invites">;
+
+type ManagedInviteResult = {
+  invite: WorkspaceInviteRow;
+  url: string;
+};
+
+async function getInviteActorContext(workspaceId: string): Promise<
+  | {
+      supabase: Awaited<ReturnType<typeof createClient>>;
+      user: { id: string };
+      role: WorkspaceRole;
+    }
+  | { error: string }
+> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "Not authenticated" };
+  }
+
+  const { data: membership } = await supabase
+    .from("workspace_members")
+    .select("role")
+    .eq("workspace_id", workspaceId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!membership) {
+    return { error: "Only workspace owners and admins can manage invites" };
+  }
+
+  return {
+    supabase,
+    user: { id: user.id },
+    role: membership.role,
+  };
+}
+
+async function logInviteActivity(params: {
+  actorId: string;
+  invite: WorkspaceInviteRow;
+  action: "created" | "accepted" | "revoked";
+}) {
+  const admin = createAdminClient();
+
+  try {
+    await createActivity({
+      supabase: admin,
+      workspaceId: params.invite.workspace_id,
+      actorId: params.actorId,
+      action: params.action,
+      entityType: "invite",
+      entityId: params.invite.id,
+      metadata: {
+        email: params.invite.email,
+        invite_type: params.invite.invite_type,
+        role: params.invite.role,
+      },
+    });
+  } catch {
+    // Activity logging should not block access changes.
+  }
+}
+
+async function getActiveLinkInvite(workspaceId: string) {
+  const supabase = await createClient();
+  const { data: invites } = await supabase
+    .from("workspace_invites")
+    .select("*")
+    .eq("workspace_id", workspaceId)
+    .eq("invite_type", "link")
+    .is("revoked_at", null)
+    .order("created_at", { ascending: false });
+
+  return (invites ?? []).find((invite) => getInviteStatus(invite) === "pending") ?? null;
+}
+
+export async function createWorkspaceLinkInvite(
+  workspaceId: string,
+): Promise<ActionResponse<ManagedInviteResult>> {
+  const actor = await getInviteActorContext(workspaceId);
+  if ("error" in actor) {
+    return actor;
+  }
+
+  if (!canCreateInvite(actor.role, "link", "member")) {
+    return { error: "You do not have permission to create join links" };
+  }
+
+  const existingLink = await getActiveLinkInvite(workspaceId);
+  if (existingLink) {
+    return {
+      data: {
+        invite: existingLink,
+        url: buildInviteUrl(existingLink.code),
+      },
+    };
+  }
+
+  const admin = createAdminClient();
+  const { data: invite, error } = await admin
+    .from("workspace_invites")
+    .insert({
+      workspace_id: workspaceId,
+      invite_type: "link",
+      role: "member",
+      created_by: actor.user.id,
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error || !invite) {
+    return { error: error?.message ?? "Unable to create join link" };
+  }
+
+  await logInviteActivity({
+    actorId: actor.user.id,
+    invite,
+    action: "created",
+  });
+
+  revalidatePath("/", "layout");
+
+  return {
+    data: {
+      invite,
+      url: buildInviteUrl(invite.code),
+    },
+  };
+}
+
+export async function regenerateWorkspaceLinkInvite(
+  workspaceId: string,
+): Promise<ActionResponse<ManagedInviteResult>> {
+  const actor = await getInviteActorContext(workspaceId);
+  if ("error" in actor) {
+    return actor;
+  }
+
+  if (!canCreateInvite(actor.role, "link", "member")) {
+    return { error: "You do not have permission to regenerate join links" };
+  }
+
+  const activeLink = await getActiveLinkInvite(workspaceId);
+  const admin = createAdminClient();
+
+  if (activeLink) {
+    await admin
+      .from("workspace_invites")
+      .update({
+        revoked_at: new Date().toISOString(),
+        revoked_by: actor.user.id,
+      })
+      .eq("id", activeLink.id);
+
+    await logInviteActivity({
+      actorId: actor.user.id,
+      invite: {
+        ...activeLink,
+        revoked_at: new Date().toISOString(),
+        revoked_by: actor.user.id,
+      },
+      action: "revoked",
+    });
+  }
+
+  return createWorkspaceLinkInvite(workspaceId);
+}
+
+export async function createWorkspaceEmailInvite(input: {
+  workspaceId: string;
+  email: string;
+  role: "admin" | "member";
+}): Promise<ActionResponse<ManagedInviteResult>> {
+  const email = input.email.trim().toLowerCase();
+  if (!email) {
+    return { error: "Email is required" };
+  }
+
+  const actor = await getInviteActorContext(input.workspaceId);
+  if ("error" in actor) {
+    return actor;
+  }
+
+  if (!canCreateInvite(actor.role, "email", input.role)) {
+    return { error: "You do not have permission to create that invite" };
+  }
+
+  const admin = createAdminClient();
+  const { data: invite, error } = await admin
+    .from("workspace_invites")
+    .insert({
+      workspace_id: input.workspaceId,
+      invite_type: "email",
+      email,
+      role: input.role,
+      created_by: actor.user.id,
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error || !invite) {
+    return { error: error?.message ?? "Unable to create email invite" };
+  }
+
+  await logInviteActivity({
+    actorId: actor.user.id,
+    invite,
+    action: "created",
+  });
+
+  revalidatePath("/", "layout");
+
+  return {
+    data: {
+      invite,
+      url: buildInviteUrl(invite.code),
+    },
+  };
+}
+
+export async function revokeWorkspaceInvite(
+  inviteId: string,
+): Promise<ActionResponse<void>> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "Not authenticated" };
+  }
+
+  const { data: invite } = await supabase
+    .from("workspace_invites")
+    .select("*")
+    .eq("id", inviteId)
+    .maybeSingle();
+
+  if (!invite) {
+    return { error: "Invite not found" };
+  }
+
+  const actor = await getInviteActorContext(invite.workspace_id);
+  if ("error" in actor) {
+    return actor;
+  }
+
+  const admin = createAdminClient();
+  const revokedAt = new Date().toISOString();
+  const { error } = await admin
+    .from("workspace_invites")
+    .update({
+      revoked_at: revokedAt,
+      revoked_by: actor.user.id,
+    })
+    .eq("id", inviteId);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  await logInviteActivity({
+    actorId: actor.user.id,
+    invite: {
+      ...invite,
+      revoked_at: revokedAt,
+      revoked_by: actor.user.id,
+    },
+    action: "revoked",
+  });
+
+  revalidatePath("/", "layout");
+  return { data: undefined };
+}
+
+export async function acceptWorkspaceInvite(
+  code: string,
+): Promise<ActionResponse<{ workspaceSlug: string; alreadyMember: boolean }>> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "Please sign in before accepting this invite" };
+  }
+
+  const inviteRecord = await getJoinInviteRecord(code);
+  if (!inviteRecord?.workspace) {
+    return { error: "This invite is invalid or no longer exists" };
+  }
+
+  const status = getInviteStatus(inviteRecord);
+  if (status === "revoked") {
+    return { error: "This invite has been revoked. Ask a workspace admin for a new one." };
+  }
+
+  if (status === "expired") {
+    return { error: "This invite has expired. Ask a workspace admin for a fresh invite." };
+  }
+
+  const currentEmail = user.email?.trim().toLowerCase() ?? "";
+  if (
+    inviteRecord.invite_type === "email" &&
+    inviteRecord.email?.trim().toLowerCase() !== currentEmail
+  ) {
+    return {
+      error: `This invite is for ${inviteRecord.email}. Sign in with that account to continue.`,
+    };
+  }
+
+  if (
+    inviteRecord.invite_type === "email" &&
+    inviteRecord.accepted_at &&
+    inviteRecord.accepted_by !== user.id
+  ) {
+    return { error: "This invite has already been used." };
+  }
+
+  const admin = createAdminClient();
+  const { data: existingMembership } = await admin
+    .from("workspace_members")
+    .select("id")
+    .eq("workspace_id", inviteRecord.workspace_id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!existingMembership) {
+    const { error: membershipError } = await admin.from("workspace_members").upsert(
+      {
+        workspace_id: inviteRecord.workspace_id,
+        user_id: user.id,
+        role: inviteRecord.invite_type === "link" ? "member" : inviteRecord.role,
+      },
+      { onConflict: "workspace_id,user_id" },
+    );
+
+    if (membershipError) {
+      return { error: membershipError.message };
+    }
+  }
+
+  if (inviteRecord.invite_type === "email" && !inviteRecord.accepted_at) {
+    const acceptedAt = new Date().toISOString();
+    const { error: inviteUpdateError } = await admin
+      .from("workspace_invites")
+      .update({
+        accepted_at: acceptedAt,
+        accepted_by: user.id,
+      })
+      .eq("id", inviteRecord.id);
+
+    if (inviteUpdateError) {
+      return { error: inviteUpdateError.message };
+    }
+
+    await logInviteActivity({
+      actorId: user.id,
+      invite: {
+        ...inviteRecord,
+        accepted_at: acceptedAt,
+        accepted_by: user.id,
+      },
+      action: "accepted",
+    });
+  } else if (!existingMembership) {
+    await logInviteActivity({
+      actorId: user.id,
+      invite: inviteRecord,
+      action: "accepted",
+    });
+  }
+
+  revalidatePath("/", "layout");
+
+  return {
+    data: {
+      workspaceSlug: inviteRecord.workspace.slug,
+      alreadyMember: Boolean(existingMembership),
+    },
+  };
+}

--- a/src/lib/actions/workspaces.ts
+++ b/src/lib/actions/workspaces.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import type { ActionResponse, Tables } from "@/lib/types";
 import { createActivity } from "@/lib/actions/activities";
+import { createWorkspaceLinkInvite } from "@/lib/actions/invites";
 
 export async function createWorkspace(
   formData: FormData
@@ -101,6 +102,20 @@ export async function createProject(
     } = await supabase.auth.getUser();
 
     if (user) {
+      const { data: membership } = await supabase
+        .from("workspace_members")
+        .select("id, primary_project_id")
+        .eq("workspace_id", workspaceId)
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      if (membership && !membership.primary_project_id) {
+        await supabase
+          .from("workspace_members")
+          .update({ primary_project_id: data.id })
+          .eq("id", membership.id);
+      }
+
       await createActivity({
         supabase,
         workspaceId,
@@ -122,34 +137,20 @@ export async function createWorkspaceInvite(
   workspaceId: string,
   role: "admin" | "member" = "member"
 ): Promise<ActionResponse<Tables<"workspace_invites">>> {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { error: "Not authenticated" };
+  if (role === "admin") {
+    return { error: "Admin invites must be created as targeted email invites" };
   }
 
-  const { data, error } = await supabase
-    .from("workspace_invites")
-    .insert({
-      workspace_id: workspaceId,
-      role,
-      created_by: user.id,
-      expires_at: new Date(
-        Date.now() + 7 * 24 * 60 * 60 * 1000
-      ).toISOString(),
-    })
-    .select()
-    .single();
-
-  if (error) {
-    return { error: error.message };
+  const result = await createWorkspaceLinkInvite(workspaceId);
+  if (result.error) {
+    return result;
   }
 
-  return { data };
+  if (!result.data) {
+    return { error: "Unable to create invite link" };
+  }
+
+  return { data: result.data.invite };
 }
 
 export async function updateWorkspace(
@@ -338,6 +339,13 @@ export async function removeMember(
   return { data: undefined };
 }
 
-export async function finishOnboarding(workspaceSlug: string): Promise<void> {
+export async function finishOnboarding(
+  workspaceSlug: string,
+  projectId?: string,
+): Promise<void> {
+  if (projectId) {
+    redirect(`/${workspaceSlug}/projects/${projectId}/board`);
+  }
+
   redirect(`/${workspaceSlug}/dashboard`);
 }

--- a/src/lib/invites.ts
+++ b/src/lib/invites.ts
@@ -1,0 +1,90 @@
+import type { Tables, WorkspaceInviteStatus, WorkspaceInviteType, WorkspaceRole } from "@/lib/types";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+type WorkspaceInviteRow = Tables<"workspace_invites">;
+
+export type JoinInviteRecord = WorkspaceInviteRow & {
+  workspace: Pick<Tables<"workspaces">, "id" | "name" | "slug"> | null;
+};
+
+export type WorkspaceInviteListItem = WorkspaceInviteRow & {
+  status: WorkspaceInviteStatus;
+};
+
+export function buildInviteUrl(code: string) {
+  const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000").replace(/\/$/, "");
+  return `${appUrl}/join/${code}`;
+}
+
+export function getInviteStatus(invite: WorkspaceInviteRow): WorkspaceInviteStatus {
+  if (invite.revoked_at) {
+    return "revoked";
+  }
+
+  if (
+    invite.invite_type === "email" &&
+    invite.accepted_at
+  ) {
+    return "accepted";
+  }
+
+  if (invite.expires_at && new Date(invite.expires_at).getTime() <= Date.now()) {
+    return "expired";
+  }
+
+  return "pending";
+}
+
+export function canCreateInvite(
+  actorRole: WorkspaceRole,
+  inviteType: WorkspaceInviteType,
+  role: "admin" | "member",
+) {
+  if (actorRole === "owner") {
+    return inviteType !== "link" || role === "member";
+  }
+
+  if (actorRole === "admin") {
+    return role === "member";
+  }
+
+  return false;
+}
+
+export function getInviteStatusLabel(status: WorkspaceInviteStatus) {
+  switch (status) {
+    case "accepted":
+      return "Accepted";
+    case "expired":
+      return "Expired";
+    case "revoked":
+      return "Revoked";
+    default:
+      return "Pending";
+  }
+}
+
+export async function getJoinInviteRecord(code: string): Promise<JoinInviteRecord | null> {
+  const admin = createAdminClient();
+
+  const { data: invite, error } = await admin
+    .from("workspace_invites")
+    .select("*")
+    .eq("code", code)
+    .maybeSingle();
+
+  if (error || !invite) {
+    return null;
+  }
+
+  const { data: workspace } = await admin
+    .from("workspaces")
+    .select("id, name, slug")
+    .eq("id", invite.workspace_id)
+    .maybeSingle();
+
+  return {
+    ...invite,
+    workspace: workspace ?? null,
+  };
+}

--- a/src/lib/queries/invites.ts
+++ b/src/lib/queries/invites.ts
@@ -1,0 +1,16 @@
+import { createClient } from "@/lib/supabase/server";
+import { getInviteStatus, type WorkspaceInviteListItem } from "@/lib/invites";
+
+export async function getWorkspaceInvites(workspaceId: string): Promise<WorkspaceInviteListItem[]> {
+  const supabase = await createClient();
+  const { data: invites } = await supabase
+    .from("workspace_invites")
+    .select("*")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false });
+
+  return (invites ?? []).map((invite) => ({
+    ...invite,
+    status: getInviteStatus(invite),
+  }));
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -131,33 +131,72 @@ export type Database = {
       };
       workspace_invites: {
         Row: {
+          accepted_at: string | null;
+          accepted_by: string | null;
           id: string;
           workspace_id: string;
           code: string;
+          email: string | null;
+          invite_type: "email" | "link";
           role: "admin" | "member";
           created_by: string;
           expires_at: string | null;
           created_at: string;
+          revoked_at: string | null;
+          revoked_by: string | null;
         };
         Insert: {
+          accepted_at?: string | null;
+          accepted_by?: string | null;
           id?: string;
           workspace_id: string;
           code?: string;
+          email?: string | null;
+          invite_type?: "email" | "link";
           role?: "admin" | "member";
           created_by: string;
           expires_at?: string | null;
           created_at?: string;
+          revoked_at?: string | null;
+          revoked_by?: string | null;
         };
         Update: {
+          accepted_at?: string | null;
+          accepted_by?: string | null;
           id?: string;
           workspace_id?: string;
           code?: string;
+          email?: string | null;
+          invite_type?: "email" | "link";
           role?: "admin" | "member";
           created_by?: string;
           expires_at?: string | null;
           created_at?: string;
+          revoked_at?: string | null;
+          revoked_by?: string | null;
         };
         Relationships: [
+          {
+            foreignKeyName: "workspace_invites_accepted_by_fkey";
+            columns: ["accepted_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "workspace_invites_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "workspace_invites_revoked_by_fkey";
+            columns: ["revoked_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "workspace_invites_workspace_id_fkey";
             columns: ["workspace_id"];

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -4,6 +4,8 @@ export type IssueStatus = "todo" | "in_progress" | "in_review" | "done";
 export type IssuePriority = 0 | 1 | 2 | 3;
 export type WorkspaceRole = "owner" | "admin" | "member";
 export type MemberRole = "admin" | "member";
+export type WorkspaceInviteType = "email" | "link";
+export type WorkspaceInviteStatus = "pending" | "accepted" | "revoked" | "expired";
 export type SprintStatus = "planning" | "active" | "completed";
 export type NotificationType = "mention" | "assigned" | "comment" | "status_change" | "general";
 

--- a/src/lib/utils/activities.ts
+++ b/src/lib/utils/activities.ts
@@ -99,6 +99,33 @@ export function formatActivityAction(activity: ActivityWithActor): string {
       return `${actorName} ${activity.action} project ${name}`;
     }
 
+    case "invite": {
+      const email = meta.email as string | undefined;
+      const inviteType = meta.invite_type as string | undefined;
+      const role = meta.role as string | undefined;
+      const target =
+        inviteType === "link"
+          ? "a join link"
+          : email
+            ? email
+            : "an invite";
+
+      if (activity.action === "created") {
+        const roleLabel = role === "admin" ? "admin" : "member";
+        return `${actorName} invited ${target} as ${roleLabel}`;
+      }
+
+      if (activity.action === "accepted") {
+        return `${actorName} accepted ${target}`;
+      }
+
+      if (activity.action === "revoked") {
+        return `${actorName} revoked ${target}`;
+      }
+
+      return `${actorName} ${activity.action} ${target}`;
+    }
+
     default:
       return `${actorName} ${activity.action}`;
   }

--- a/src/lib/utils/auth-redirect.ts
+++ b/src/lib/utils/auth-redirect.ts
@@ -1,0 +1,37 @@
+import { createClient } from "@/lib/supabase/server";
+import { normalizeRedirectPath } from "@/lib/utils/redirect-path";
+
+export async function getDefaultSignedInPath() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return "/login";
+  }
+
+  const { data: membership } = await supabase
+    .from("workspace_members")
+    .select("workspace:workspaces(slug)")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  const workspace = membership?.workspace as { slug: string } | null | undefined;
+  if (workspace?.slug) {
+    return `/${workspace.slug}/dashboard`;
+  }
+
+  return "/onboarding";
+}
+
+export async function resolvePostAuthRedirect(nextPath: string | null | undefined) {
+  const safeNextPath = normalizeRedirectPath(nextPath);
+  if (safeNextPath) {
+    return safeNextPath;
+  }
+
+  return getDefaultSignedInPath();
+}

--- a/src/lib/utils/redirect-path.ts
+++ b/src/lib/utils/redirect-path.ts
@@ -1,0 +1,17 @@
+export function normalizeRedirectPath(path: string | null | undefined): string | null {
+  if (!path) return null;
+  if (!path.startsWith("/") || path.startsWith("//")) return null;
+  return path;
+}
+
+export function buildAuthRedirectUrl(
+  pathname: "/login" | "/signup",
+  nextPath: string | null | undefined,
+) {
+  const safeNextPath = normalizeRedirectPath(nextPath);
+  if (!safeNextPath) {
+    return pathname;
+  }
+
+  return `${pathname}?next=${encodeURIComponent(safeNextPath)}`;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,10 +1,23 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
+import { normalizeRedirectPath } from "@/lib/utils/redirect-path";
 
-const PUBLIC_PREFIXES = ["/login", "/signup", "/forgot-password", "/reset-password", "/callback"];
+const PUBLIC_PREFIXES = [
+  "/login",
+  "/signup",
+  "/forgot-password",
+  "/reset-password",
+  "/callback",
+  "/join",
+];
 const AUTH_PREFIXES = ["/login", "/signup", "/forgot-password", "/reset-password"];
 
-export async function middleware(request: NextRequest) {
+function getRequestedPath(request: NextRequest) {
+  const search = request.nextUrl.search || "";
+  return `${request.nextUrl.pathname}${search}`;
+}
+
+export async function proxy(request: NextRequest) {
   const { user, supabaseResponse } = await updateSession(request);
   const { pathname } = request.nextUrl;
 
@@ -12,17 +25,19 @@ export async function middleware(request: NextRequest) {
   const isPublicRoute = isLandingPage || PUBLIC_PREFIXES.some((route) => pathname.startsWith(route));
   const isAuthPage = AUTH_PREFIXES.some((route) => pathname.startsWith(route));
 
-  // Unauthenticated users can only access public routes
   if (!user && !isPublicRoute) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
+    url.search = "";
+    url.searchParams.set("next", getRequestedPath(request));
     return NextResponse.redirect(url);
   }
 
-  // Authenticated users on auth pages → redirect to onboarding or workspace
   if (user && isAuthPage) {
+    const nextPath = normalizeRedirectPath(request.nextUrl.searchParams.get("next"));
     const url = request.nextUrl.clone();
-    url.pathname = "/onboarding";
+    url.pathname = nextPath ?? "/";
+    url.search = "";
     return NextResponse.redirect(url);
   }
 

--- a/supabase/migrations/00023_invite_flow_rework.sql
+++ b/supabase/migrations/00023_invite_flow_rework.sql
@@ -1,0 +1,32 @@
+-- 00023_invite_flow_rework.sql
+-- Rework invites around a canonical join flow and auditable lifecycle state.
+
+alter table public.workspace_invites
+  add column invite_type text not null default 'link'
+    check (invite_type in ('email', 'link')),
+  add column email text,
+  add column accepted_at timestamptz,
+  add column accepted_by uuid references public.profiles(id) on delete set null,
+  add column revoked_at timestamptz,
+  add column revoked_by uuid references public.profiles(id) on delete set null;
+
+alter table public.workspace_invites
+  add constraint workspace_invites_email_by_type_check
+    check (
+      (invite_type = 'email' and email is not null)
+      or (invite_type = 'link' and email is null)
+    ),
+  add constraint workspace_invites_link_role_check
+    check (invite_type <> 'link' or role = 'member');
+
+create index idx_workspace_invites_email
+  on public.workspace_invites (email);
+
+create index idx_workspace_invites_lookup
+  on public.workspace_invites (workspace_id, invite_type, created_at desc);
+
+create policy "workspace_invites: owner/admin can update"
+  on public.workspace_invites for update
+  to authenticated
+  using (public.get_user_workspace_role(workspace_id) in ('owner', 'admin'))
+  with check (public.get_user_workspace_role(workspace_id) in ('owner', 'admin'));

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -81,32 +81,13 @@ setup("authenticate", async ({ page }) => {
       await page.getByRole("button", { name: "6 – 20" }).click();
       await page.getByRole("button", { name: "Continue" }).click();
 
-      const reachedDashboardAfterWorkspace = await page
-        .waitForURL(/dashboard/, { timeout: 3000 })
-        .then(() => true)
-        .catch(() => false);
+      await expect(
+        page.getByRole("heading", { name: /create your first project/i })
+      ).toBeVisible({ timeout: 10000 });
 
-      if (!reachedDashboardAfterWorkspace) {
-        // Step 2: skip invites
-        await expect(page.getByText("Invite your team")).toBeVisible({
-          timeout: 10000,
-        });
-        await page.getByRole("button", { name: /skip/i }).click();
-
-        const reachedDashboardAfterInvite = await page
-          .waitForURL(/dashboard/, { timeout: 3000 })
-          .then(() => true)
-          .catch(() => false);
-
-        if (!reachedDashboardAfterInvite) {
-          // Step 3: skip project creation
-          await expect(
-            page.getByRole("heading", { name: /project/i })
-          ).toBeVisible({ timeout: 10000 });
-          await page.getByRole("button", { name: /skip|finish/i }).click();
-          await expect(page).toHaveURL(/dashboard/, { timeout: 15000 });
-        }
-      }
+      await page.getByPlaceholder("My First Project").fill("Playwright Project");
+      await page.getByRole("button", { name: "Create Project" }).click();
+      await expect(page).toHaveURL(/\/projects\/.*\/board/, { timeout: 15000 });
     }
   }
 

--- a/tests/invite-join.spec.ts
+++ b/tests/invite-join.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../src/lib/types";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const OWNER_EMAIL = `owner-${Date.now()}@test.flow.dev`;
+const INVITEE_EMAIL = `invitee-${Date.now()}@test.flow.dev`;
+const TEST_PASSWORD = "testpassword123";
+const OWNER_NAME = "Invite Owner";
+const INVITEE_NAME = "Invitee User";
+const INVITED_WORKSPACE_NAME = `Invite Workspace ${Date.now()}`;
+const INVITED_WORKSPACE_SLUG = `invite-ws-${Date.now()}`;
+const EXISTING_WORKSPACE_NAME = `Existing Workspace ${Date.now()}`;
+const EXISTING_WORKSPACE_SLUG = `existing-ws-${Date.now()}`;
+
+let admin: SupabaseClient<Database>;
+let ownerId: string | null = null;
+let inviteeId: string | null = null;
+let invitedWorkspaceId: string | null = null;
+let existingWorkspaceId: string | null = null;
+let inviteCode: string | null = null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe.serial("invite redemption", () => {
+  test.beforeAll(async () => {
+    admin = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+    const { data: ownerData, error: ownerError } = await admin.auth.admin.createUser({
+      email: OWNER_EMAIL,
+      password: TEST_PASSWORD,
+      email_confirm: true,
+      user_metadata: { full_name: OWNER_NAME },
+    });
+
+    if (ownerError) {
+      throw new Error(`Failed to create owner: ${ownerError.message}`);
+    }
+
+    ownerId = ownerData.user.id;
+
+    const { data: inviteeData, error: inviteeError } = await admin.auth.admin.createUser({
+      email: INVITEE_EMAIL,
+      password: TEST_PASSWORD,
+      email_confirm: true,
+      user_metadata: { full_name: INVITEE_NAME },
+    });
+
+    if (inviteeError) {
+      throw new Error(`Failed to create invitee: ${inviteeError.message}`);
+    }
+
+    inviteeId = inviteeData.user.id;
+
+    const { data: createdInvitedWorkspace, error: invitedWorkspaceError } = await admin
+      .from("workspaces")
+      .insert({
+        name: INVITED_WORKSPACE_NAME,
+        slug: INVITED_WORKSPACE_SLUG,
+      })
+      .select("id")
+      .single();
+
+    if (invitedWorkspaceError) {
+      throw new Error(`Failed to create invited workspace: ${invitedWorkspaceError.message}`);
+    }
+
+    invitedWorkspaceId = createdInvitedWorkspace.id;
+
+    const { data: createdExistingWorkspace, error: existingWorkspaceError } = await admin
+      .from("workspaces")
+      .insert({
+        name: EXISTING_WORKSPACE_NAME,
+        slug: EXISTING_WORKSPACE_SLUG,
+      })
+      .select("id")
+      .single();
+
+    if (existingWorkspaceError) {
+      throw new Error(`Failed to create existing workspace: ${existingWorkspaceError.message}`);
+    }
+
+    existingWorkspaceId = createdExistingWorkspace.id;
+
+    const { error: membershipError } = await admin.from("workspace_members").insert([
+      {
+        workspace_id: invitedWorkspaceId,
+        user_id: ownerId,
+        role: "owner",
+      },
+      {
+        workspace_id: existingWorkspaceId,
+        user_id: inviteeId,
+        role: "owner",
+      },
+    ]);
+
+    if (membershipError) {
+      throw new Error(`Failed to create memberships: ${membershipError.message}`);
+    }
+
+    const { data: invite, error: inviteError } = await admin
+      .from("workspace_invites")
+      .insert({
+        workspace_id: invitedWorkspaceId,
+        invite_type: "email",
+        email: INVITEE_EMAIL,
+        role: "member",
+        created_by: ownerId,
+        expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      })
+      .select("code")
+      .single();
+
+    if (inviteError || !invite) {
+      throw new Error(`Failed to create invite: ${inviteError?.message ?? "missing invite"}`);
+    }
+
+    inviteCode = invite.code;
+  });
+
+  test.afterAll(async () => {
+    if (invitedWorkspaceId) {
+      await admin.from("workspace_invites").delete().eq("workspace_id", invitedWorkspaceId);
+      await admin.from("workspace_members").delete().eq("workspace_id", invitedWorkspaceId);
+      await admin.from("workspaces").delete().eq("id", invitedWorkspaceId);
+    }
+
+    if (existingWorkspaceId) {
+      await admin.from("workspace_members").delete().eq("workspace_id", existingWorkspaceId);
+      await admin.from("workspaces").delete().eq("id", existingWorkspaceId);
+    }
+
+    if (ownerId) {
+      await admin.from("profiles").delete().eq("id", ownerId);
+      await admin.auth.admin.deleteUser(ownerId);
+    }
+
+    if (inviteeId) {
+      await admin.from("profiles").delete().eq("id", inviteeId);
+      await admin.auth.admin.deleteUser(inviteeId);
+    }
+  });
+
+  test("logged-out invitee signs in, returns to the invite, and keeps existing memberships", async ({
+    page,
+  }) => {
+    if (!inviteCode) {
+      throw new Error("Invite code was not created");
+    }
+
+    await page.goto(`/join/${inviteCode}`);
+
+    await expect(
+      page.getByRole("heading", { name: `Join ${INVITED_WORKSPACE_NAME}` })
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole("link", { name: "Sign in" }).click();
+    await expect(page).toHaveURL(/\/login\?next=/, { timeout: 10000 });
+
+    await page.getByLabel(/email/i).fill(INVITEE_EMAIL);
+    await page.getByLabel(/password/i).fill(TEST_PASSWORD);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/join/${inviteCode}`), {
+      timeout: 15000,
+    });
+    await expect(page.getByRole("button", { name: "Join workspace" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Join workspace" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/${INVITED_WORKSPACE_SLUG}/dashboard`), {
+      timeout: 15000,
+    });
+
+    await page.getByRole("button", { name: "Open account menu" }).click();
+    await expect(
+      page.getByRole("menuitem", { name: new RegExp(EXISTING_WORKSPACE_NAME) })
+    ).toBeVisible();
+  });
+});

--- a/tests/phase1-auth-flow.spec.ts
+++ b/tests/phase1-auth-flow.spec.ts
@@ -4,7 +4,7 @@ import type { Database } from "../src/lib/types";
 
 /**
  * Phase 1 Verification #1 (from issue #3):
- * Sign up → log in → see onboarding → create workspace → land on dashboard
+ * Sign up → log in → see onboarding → create workspace → create first project → land on board
  *
  * Uses the Supabase admin API to create a confirmed test user,
  * then drives the full flow through the browser.
@@ -21,7 +21,7 @@ const TEST_WORKSPACE_SLUG = `test-ws-${Date.now()}`;
 let adminClient: SupabaseClient<Database>;
 let testUserId: string | null = null;
 
-test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {
+test.describe.serial("Phase 1: Auth → Onboarding → Board", () => {
   test.beforeAll(async () => {
     adminClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
@@ -110,7 +110,7 @@ test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {
     await expect(page).toHaveURL(/onboarding/, { timeout: 10000 });
   });
 
-  test("4. Onboarding step 1: create workspace", async ({ page }) => {
+  test("4. Onboarding creates the workspace and first project", async ({ page }) => {
     await page.goto("/login");
     await page.getByLabel(/email/i).fill(TEST_EMAIL);
     await page.getByLabel(/password/i).fill(TEST_PASSWORD);
@@ -119,7 +119,7 @@ test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {
 
     // Step 1 UI
     await expect(page.getByText("Set up your workspace")).toBeVisible();
-    await expect(page.getByText("Step 1 of 3", { exact: false })).toBeVisible();
+    await expect(page.getByText("Step 1 of 2", { exact: false })).toBeVisible();
 
     // Fill workspace name
     await page.getByPlaceholder("Acme Inc").fill(TEST_WORKSPACE_NAME);
@@ -139,27 +139,57 @@ test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {
     await page.getByRole("button", { name: "Continue" }).click();
 
     // Should move to step 2
-    await expect(page.getByText("Invite your team")).toBeVisible({
+    await expect(page.getByText("Create your first project")).toBeVisible({
       timeout: 10000,
     });
-    await expect(page.getByText("Step 2 of 3", { exact: false })).toBeVisible();
+    await expect(page.getByText("Step 2 of 2", { exact: false })).toBeVisible();
+
+    await page.getByPlaceholder("My First Project").fill("Onboarding Project");
+    await page.getByRole("button", { name: "Create Project" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`${TEST_WORKSPACE_SLUG}/projects/.*/board`), {
+      timeout: 15000,
+    });
+    await expect(page.getByRole("button", { name: /create first issue/i })).toBeVisible();
   });
 
-  test("5. Onboarding step 2: skip invite → step 3: skip project → land on dashboard", async ({
+  test("5. Board-first setup is visible on the new project", async ({
     page,
   }) => {
     await page.goto("/login");
     await page.getByLabel(/email/i).fill(TEST_EMAIL);
     await page.getByLabel(/password/i).fill(TEST_PASSWORD);
     await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10000 });
 
-    // User already has a workspace from test 4, so should redirect to dashboard
-    await expect(page).toHaveURL(new RegExp(`${TEST_WORKSPACE_SLUG}/dashboard`), {
-      timeout: 10000,
-    });
+    const { data: workspace } = await adminClient
+      .from("workspaces")
+      .select("id")
+      .eq("slug", TEST_WORKSPACE_SLUG)
+      .single();
+
+    const { data: project } = await adminClient
+      .from("projects")
+      .select("id")
+      .eq("workspace_id", workspace.id)
+      .order("created_at", { ascending: true })
+      .single();
+
+    await page.goto(`/${TEST_WORKSPACE_SLUG}/projects/${project.id}/board`);
+
+    await expect(page.getByRole("button", { name: /create first issue/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /create first sprint/i })).toBeVisible();
   });
 
-  test("6. Dashboard shows app shell with sidebar", async ({ page }) => {
+  test("6. Subsequent login redirects to dashboard", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByLabel(/email/i).fill(TEST_EMAIL);
+    await page.getByLabel(/password/i).fill(TEST_PASSWORD);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10000 });
+  });
+
+  test("7. Dashboard shows app shell with sidebar", async ({ page }) => {
     await page.goto("/login");
     await page.getByLabel(/email/i).fill(TEST_EMAIL);
     await page.getByLabel(/password/i).fill(TEST_PASSWORD);
@@ -183,7 +213,7 @@ test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {
     await expect(page.getByText("ET", { exact: true })).toBeVisible();
   });
 
-  test("7. Sidebar navigation works", async ({ page }) => {
+  test("8. Sidebar navigation works", async ({ page }) => {
     await page.goto("/login");
     await page.getByLabel(/email/i).fill(TEST_EMAIL);
     await page.getByLabel(/password/i).fill(TEST_PASSWORD);
@@ -206,7 +236,7 @@ test.describe.serial("Phase 1: Auth → Onboarding → Dashboard", () => {
     await expect(page).toHaveURL(/dashboard/);
   });
 
-  test("8. Unauthenticated user is redirected to login", async ({ page }) => {
+  test("9. Unauthenticated user is redirected to login", async ({ page }) => {
     // Fresh context, no cookies — should redirect to login
     await page.goto(`/${TEST_WORKSPACE_SLUG}/dashboard`);
     await expect(page).toHaveURL(/login/, { timeout: 10000 });


### PR DESCRIPTION
## Summary
- replace the split invite behavior with a unified invite module and canonical `/join/[code]` flow
- preserve explicit auth destinations through login, signup, OAuth, and app redirects so invite redemption survives auth handoff
- rework onboarding to workspace -> first project -> project board, add board-first setup actions, and expose invite state management in Members settings
- add the invite lifecycle migration and Playwright coverage for onboarding and invite redemption

## Testing
- npx playwright test tests/phase1-auth-flow.spec.ts --project=no-auth
- npx playwright test tests/invite-join.spec.ts --project=authenticated

Closes #29