### PR TITLE
Implement guest demo sandbox

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,3 +2,4 @@ NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+GUEST_DEMO_SOURCE_WORKSPACE_SLUG=pw-workspace

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.0",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "typescript": "^5"
       }
     },
@@ -395,6 +396,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -722,9 +1165,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -740,9 +1180,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -760,9 +1197,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -778,9 +1212,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -798,9 +1229,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -816,9 +1244,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -836,9 +1261,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -855,9 +1277,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -873,9 +1292,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -899,9 +1315,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -923,9 +1336,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -949,9 +1359,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -973,9 +1380,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -999,9 +1403,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1024,9 +1425,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1048,9 +1446,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1261,9 +1656,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,9 +1671,6 @@
       "integrity": "sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1299,9 +1688,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1703,6 @@
       "integrity": "sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3505,9 +3888,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3525,9 +3905,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3545,9 +3922,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3565,9 +3939,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4668,9 +5039,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4685,9 +5053,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4702,9 +5067,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4719,9 +5081,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4736,9 +5095,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4753,9 +5109,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4770,9 +5123,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4787,9 +5137,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5975,6 +6322,48 @@
         "benchmarks"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6224,6 +6613,32 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -6587,6 +7002,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7750,9 +8166,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7774,9 +8187,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7798,9 +8208,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7822,9 +8229,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9688,37 +10092,46 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "cleanup:guests": "tsx scripts/cleanup-guest-workspaces.ts",
+    "test:guest": "tsx --test tests/guest-workspace.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -54,6 +56,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.0",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5"
   }
 }

--- a/scripts/cleanup-guest-workspaces.ts
+++ b/scripts/cleanup-guest-workspaces.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env npx tsx
+
+import dotenv from "dotenv";
+import path from "node:path";
+import { cleanupExpiredGuestWorkspaces } from "../src/lib/guest/cleanup";
+
+dotenv.config({ path: path.resolve(__dirname, "../.env.local") });
+
+async function main() {
+  const result = await cleanupExpiredGuestWorkspaces();
+
+  console.log(
+    [
+      `scanned=${result.scanned}`,
+      `deletedWorkspaces=${result.deletedWorkspaces}`,
+      `deletedUsers=${result.deletedUsers}`,
+      `skippedUsers=${result.skippedUsers}`,
+      `markedCleaned=${result.markedCleaned}`,
+    ].join(" "),
+  );
+
+  if (result.errors.length > 0) {
+    console.error(result.errors.join("\n"));
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,8 +3,8 @@
 import { Suspense, useActionState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Github } from "lucide-react";
-import { signIn, signInWithOAuth } from "@/lib/actions/auth";
+import { DoorOpen, Github } from "lucide-react";
+import { continueAsGuest, signIn, signInWithOAuth } from "@/lib/actions/auth";
 import type { ActionResponse } from "@/lib/types";
 
 function LoginPageContent() {
@@ -15,6 +15,12 @@ function LoginPageContent() {
     FormData
   >(async (_prev, formData) => {
     return await signIn(formData);
+  }, null);
+  const [guestState, guestAction, guestPending] = useActionState<
+    ActionResponse | null,
+    FormData
+  >(async () => {
+    return await continueAsGuest();
   }, null);
 
   return (
@@ -35,6 +41,12 @@ function LoginPageContent() {
       {state?.error && (
         <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm mb-6">
           {state.error}
+        </div>
+      )}
+
+      {guestState?.error && (
+        <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm mb-6">
+          {guestState.error}
         </div>
       )}
 
@@ -138,6 +150,17 @@ function LoginPageContent() {
           GitHub
         </button>
       </div>
+
+      <form action={guestAction} className="mt-3">
+        <button
+          type="submit"
+          disabled={guestPending}
+          className="flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-surface text-sm font-medium text-text transition-colors hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
+        >
+          <DoorOpen className="h-5 w-5" />
+          {guestPending ? "Preparing guest workspace..." : "Continue as guest"}
+        </button>
+      </form>
 
       {/* Footer link */}
       <p className="text-center text-sm text-text-secondary mt-8">

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -2,11 +2,13 @@
 
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import type { ActionResponse } from "@/lib/types";
 import { buildAuthRedirectUrl, normalizeRedirectPath } from "@/lib/utils/redirect-path";
 import {
   resolvePostAuthRedirect,
 } from "@/lib/utils/auth-redirect";
+import { cloneGuestWorkspace } from "@/lib/guest/workspace-clone";
 
 export async function signUp(formData: FormData): Promise<ActionResponse> {
   const supabase = await createClient();
@@ -72,6 +74,51 @@ export async function signOutTo(nextPath: string | null | undefined): Promise<vo
   const supabase = await createClient();
   await supabase.auth.signOut();
   redirect(buildAuthRedirectUrl("/login", nextPath));
+}
+
+export async function continueAsGuest(): Promise<ActionResponse<void>> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.auth.signInAnonymously({
+    options: {
+      data: { full_name: "Guest Visitor" },
+    },
+  });
+
+  const guestUserId = data.user?.id;
+  if (error || !guestUserId) {
+    return {
+      error:
+        error?.message ??
+        "Guest mode is unavailable. Please try again in a moment.",
+    };
+  }
+
+  let workspaceSlug: string;
+  try {
+    const clone = await cloneGuestWorkspace({
+      guestUserId,
+      guestDisplayName: "Guest Visitor",
+    });
+    workspaceSlug = clone.workspace.slug;
+  } catch (cloneError) {
+    await supabase.auth.signOut();
+
+    try {
+      await createAdminClient().auth.admin.deleteUser(guestUserId);
+    } catch {
+      // Best-effort cleanup; the clone module removes partial workspace data.
+    }
+
+    return {
+      error:
+        cloneError instanceof Error
+          ? cloneError.message
+          : "Unable to prepare guest workspace. Please try again.",
+    };
+  }
+
+  redirect(`/${workspaceSlug}/dashboard`);
 }
 
 export async function forgotPassword(

--- a/src/lib/guest/cleanup.ts
+++ b/src/lib/guest/cleanup.ts
@@ -1,0 +1,141 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAdminClient } from "../supabase/admin";
+import type { Database, Tables } from "../types";
+
+type AdminClient = SupabaseClient<Database>;
+
+export type CleanupExpiredGuestWorkspacesOptions = {
+  now?: Date;
+  batchSize?: number;
+  supabase?: AdminClient;
+};
+
+export type CleanupExpiredGuestWorkspacesResult = {
+  scanned: number;
+  deletedWorkspaces: number;
+  deletedUsers: number;
+  skippedUsers: number;
+  markedCleaned: number;
+  errors: string[];
+};
+
+function isMissingAuthUserError(error: { message?: string; status?: number } | null) {
+  return (
+    error?.status === 404 ||
+    error?.message?.toLowerCase().includes("not found") ||
+    error?.message?.toLowerCase().includes("user not found")
+  );
+}
+
+async function cleanupGuestWorkspace(
+  supabase: AdminClient,
+  record: Tables<"guest_workspaces">,
+  cleanedAt: string,
+) {
+  let workspaceDeleted = false;
+  let userDeleted = false;
+  let userSkipped = false;
+  const errors: string[] = [];
+
+  if (record.workspace_id) {
+    const { error } = await supabase
+      .from("workspaces")
+      .delete()
+      .eq("id", record.workspace_id);
+
+    if (error) {
+      errors.push(`Workspace ${record.workspace_id}: ${error.message}`);
+    } else {
+      workspaceDeleted = true;
+    }
+  }
+
+  if (record.guest_user_id) {
+    const { data: userData, error: getUserError } =
+      await supabase.auth.admin.getUserById(record.guest_user_id);
+
+    if (getUserError) {
+      if (!isMissingAuthUserError(getUserError)) {
+        errors.push(`Guest user ${record.guest_user_id}: ${getUserError.message}`);
+      }
+    } else if (userData.user?.is_anonymous === true) {
+      const { error: deleteUserError } = await supabase.auth.admin.deleteUser(
+        record.guest_user_id,
+      );
+
+      if (deleteUserError && !isMissingAuthUserError(deleteUserError)) {
+        errors.push(`Guest user ${record.guest_user_id}: ${deleteUserError.message}`);
+      } else {
+        userDeleted = true;
+      }
+    } else {
+      userSkipped = true;
+    }
+  }
+
+  const shouldMarkCleaned = errors.length === 0;
+  if (shouldMarkCleaned) {
+    const { error } = await supabase
+      .from("guest_workspaces")
+      .update({ cleaned_at: cleanedAt, cleanup_error: null })
+      .eq("id", record.id);
+
+    if (error) {
+      errors.push(`Guest record ${record.id}: ${error.message}`);
+    }
+  } else {
+    await supabase
+      .from("guest_workspaces")
+      .update({ cleanup_error: errors.join("; ") })
+      .eq("id", record.id);
+  }
+
+  return {
+    workspaceDeleted,
+    userDeleted,
+    userSkipped,
+    markedCleaned: shouldMarkCleaned && errors.length === 0,
+    errors,
+  };
+}
+
+export async function cleanupExpiredGuestWorkspaces(
+  options: CleanupExpiredGuestWorkspacesOptions = {},
+): Promise<CleanupExpiredGuestWorkspacesResult> {
+  const supabase = options.supabase ?? createAdminClient();
+  const now = options.now ?? new Date();
+  const batchSize = options.batchSize ?? 100;
+  const cleanedAt = now.toISOString();
+
+  const { data: records, error } = await supabase
+    .from("guest_workspaces")
+    .select("*")
+    .is("cleaned_at", null)
+    .lte("expires_at", cleanedAt)
+    .order("expires_at", { ascending: true })
+    .limit(batchSize);
+
+  if (error) {
+    throw new Error(`Unable to load expired guest workspaces: ${error.message}`);
+  }
+
+  const result: CleanupExpiredGuestWorkspacesResult = {
+    scanned: records?.length ?? 0,
+    deletedWorkspaces: 0,
+    deletedUsers: 0,
+    skippedUsers: 0,
+    markedCleaned: 0,
+    errors: [],
+  };
+
+  for (const record of records ?? []) {
+    const item = await cleanupGuestWorkspace(supabase, record, cleanedAt);
+    if (item.workspaceDeleted) result.deletedWorkspaces++;
+    if (item.userDeleted) result.deletedUsers++;
+    if (item.userSkipped) result.skippedUsers++;
+    if (item.markedCleaned) result.markedCleaned++;
+    result.errors.push(...item.errors);
+  }
+
+  return result;
+}

--- a/src/lib/guest/workspace-clone.ts
+++ b/src/lib/guest/workspace-clone.ts
@@ -1,0 +1,749 @@
+import { randomBytes } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAdminClient } from "../supabase/admin";
+import type { Database, InsertTables, Tables } from "../types";
+
+type AdminClient = SupabaseClient<Database>;
+
+export const DEFAULT_GUEST_SOURCE_WORKSPACE_SLUG =
+  process.env.GUEST_DEMO_SOURCE_WORKSPACE_SLUG ?? "pw-workspace";
+export const GUEST_WORKSPACE_TTL_HOURS = 24;
+
+type CloneMaps = {
+  projects: Map<string, string>;
+  teams: Map<string, string>;
+  labels: Map<string, string>;
+  sprints: Map<string, string>;
+  issues: Map<string, string>;
+};
+
+export type GuestWorkspaceCloneResult = {
+  workspace: Tables<"workspaces">;
+  guestWorkspace: Tables<"guest_workspaces">;
+  sourceWorkspace: Tables<"workspaces">;
+  maps: CloneMaps;
+};
+
+export type CloneGuestWorkspaceOptions = {
+  guestUserId: string;
+  guestDisplayName?: string | null;
+  sourceWorkspaceSlug?: string;
+  now?: Date;
+  slugSuffix?: string;
+  supabase?: AdminClient;
+};
+
+function randomSuffix() {
+  return randomBytes(3).toString("hex");
+}
+
+export function buildGuestWorkspaceSlug(suffix = randomSuffix()) {
+  const cleanSuffix = suffix
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .slice(0, 10);
+
+  return `guest-workspace-${cleanSuffix || randomSuffix()}`;
+}
+
+function isDuplicateError(error: { code?: string; message?: string } | null) {
+  return (
+    error?.code === "23505" ||
+    error?.message?.toLowerCase().includes("duplicate") ||
+    error?.message?.toLowerCase().includes("unique")
+  );
+}
+
+function fail(context: string, error?: { message?: string } | null): never {
+  throw new Error(error?.message ? `${context}: ${error.message}` : context);
+}
+
+function addHours(date: Date, hours: number) {
+  return new Date(date.getTime() + hours * 60 * 60 * 1000);
+}
+
+function mapNullableId(id: string | null, map: Map<string, string>) {
+  if (!id) return null;
+  return map.get(id) ?? id;
+}
+
+function mapProfileId(id: string, sourceOwnerId: string | null, guestUserId: string) {
+  return id === sourceOwnerId ? guestUserId : id;
+}
+
+function roleRank(role: Tables<"workspace_members">["role"]) {
+  if (role === "owner") return 3;
+  if (role === "admin") return 2;
+  return 1;
+}
+
+async function ensureGuestProfile(
+  supabase: AdminClient,
+  guestUserId: string,
+  guestDisplayName: string,
+) {
+  const syntheticEmail = `guest-${guestUserId.slice(0, 8)}@guest.flow.local`;
+  const { error } = await supabase.from("profiles").upsert(
+    {
+      id: guestUserId,
+      full_name: guestDisplayName,
+      email: syntheticEmail,
+    },
+    { onConflict: "id" },
+  );
+
+  if (error) fail("Unable to prepare guest profile", error);
+}
+
+async function fetchSourceWorkspace(
+  supabase: AdminClient,
+  sourceWorkspaceSlug: string,
+) {
+  const { data, error } = await supabase
+    .from("workspaces")
+    .select("*")
+    .eq("slug", sourceWorkspaceSlug)
+    .single();
+
+  if (error || !data) fail(`Source workspace '${sourceWorkspaceSlug}' not found`, error);
+  return data;
+}
+
+async function createWorkspaceCopy(
+  supabase: AdminClient,
+  sourceWorkspace: Tables<"workspaces">,
+  slugSuffix?: string,
+) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const suffix = attempt === 0 && slugSuffix ? slugSuffix : randomSuffix();
+    const slug = buildGuestWorkspaceSlug(suffix);
+    const { data, error } = await supabase
+      .from("workspaces")
+      .insert({
+        name: "Guest Workspace",
+        slug,
+        issue_prefix: sourceWorkspace.issue_prefix,
+        issue_counter: sourceWorkspace.issue_counter,
+        default_sprint_length: sourceWorkspace.default_sprint_length,
+        timezone: sourceWorkspace.timezone,
+      })
+      .select()
+      .single();
+
+    if (data) return data;
+    if (!isDuplicateError(error)) fail("Unable to create guest workspace", error);
+  }
+
+  fail("Unable to create a unique guest workspace URL");
+}
+
+async function cloneWorkspaceMembers({
+  supabase,
+  sourceWorkspaceId,
+  clonedWorkspaceId,
+  sourceOwnerId,
+  guestUserId,
+}: {
+  supabase: AdminClient;
+  sourceWorkspaceId: string;
+  clonedWorkspaceId: string;
+  sourceOwnerId: string | null;
+  guestUserId: string;
+}) {
+  const { data: sourceMembers, error } = await supabase
+    .from("workspace_members")
+    .select("*")
+    .eq("workspace_id", sourceWorkspaceId)
+    .order("created_at", { ascending: true });
+
+  if (error) fail("Unable to read source workspace members", error);
+
+  const byUser = new Map<string, InsertTables<"workspace_members">>();
+  for (const member of sourceMembers ?? []) {
+    const mappedUserId = mapProfileId(member.user_id, sourceOwnerId, guestUserId);
+    const role =
+      member.user_id === sourceOwnerId
+        ? "owner"
+        : member.role === "owner"
+          ? "admin"
+          : member.role;
+    const row: InsertTables<"workspace_members"> = {
+      workspace_id: clonedWorkspaceId,
+      user_id: mappedUserId,
+      role,
+      primary_project_id: null,
+      created_at: member.created_at,
+      updated_at: member.updated_at,
+    };
+    const existing = byUser.get(mappedUserId);
+
+    if (!existing || roleRank(row.role ?? "member") > roleRank(existing.role ?? "member")) {
+      byUser.set(mappedUserId, row);
+    }
+  }
+
+  const existingGuest = byUser.get(guestUserId);
+  if (!existingGuest || existingGuest.role !== "owner") {
+    byUser.set(guestUserId, {
+      workspace_id: clonedWorkspaceId,
+      user_id: guestUserId,
+      role: "owner",
+      primary_project_id: null,
+    });
+  }
+
+  const rows = [...byUser.values()];
+  if (rows.length === 0) return [];
+
+  const { data: clonedMembers, error: insertError } = await supabase
+    .from("workspace_members")
+    .insert(rows)
+    .select();
+
+  if (insertError) fail("Unable to clone workspace members", insertError);
+  return clonedMembers ?? [];
+}
+
+async function cloneTeams(
+  supabase: AdminClient,
+  sourceWorkspaceId: string,
+  clonedWorkspaceId: string,
+) {
+  const { data: sourceTeams, error } = await supabase
+    .from("teams")
+    .select("*")
+    .eq("workspace_id", sourceWorkspaceId)
+    .order("created_at", { ascending: true });
+
+  if (error) fail("Unable to read source teams", error);
+  if (!sourceTeams?.length) return { sourceTeams: [], map: new Map<string, string>() };
+
+  const { data: clonedTeams, error: insertError } = await supabase
+    .from("teams")
+    .insert(
+      sourceTeams.map((team) => ({
+        workspace_id: clonedWorkspaceId,
+        name: team.name,
+        created_at: team.created_at,
+        updated_at: team.updated_at,
+      })),
+    )
+    .select();
+
+  if (insertError) fail("Unable to clone teams", insertError);
+
+  const map = new Map<string, string>();
+  sourceTeams.forEach((team, index) => {
+    const cloned = clonedTeams?.[index];
+    if (cloned) map.set(team.id, cloned.id);
+  });
+
+  return { sourceTeams, map };
+}
+
+async function cloneTeamMembers({
+  supabase,
+  sourceTeamIds,
+  teamMap,
+  sourceOwnerId,
+  guestUserId,
+}: {
+  supabase: AdminClient;
+  sourceTeamIds: string[];
+  teamMap: Map<string, string>;
+  sourceOwnerId: string | null;
+  guestUserId: string;
+}) {
+  if (sourceTeamIds.length === 0) return;
+
+  const { data: sourceTeamMembers, error } = await supabase
+    .from("team_members")
+    .select("*")
+    .in("team_id", sourceTeamIds);
+
+  if (error) fail("Unable to read source team members", error);
+
+  const seen = new Set<string>();
+  const rows = (sourceTeamMembers ?? []).flatMap((member) => {
+    const teamId = teamMap.get(member.team_id);
+    if (!teamId) return [];
+
+    const userId = mapProfileId(member.user_id, sourceOwnerId, guestUserId);
+    const key = `${teamId}:${userId}`;
+    if (seen.has(key)) return [];
+    seen.add(key);
+
+    return [{ team_id: teamId, user_id: userId }];
+  });
+
+  if (rows.length === 0) return;
+
+  const { error: insertError } = await supabase.from("team_members").insert(rows);
+  if (insertError) fail("Unable to clone team members", insertError);
+}
+
+async function cloneProjects({
+  supabase,
+  sourceWorkspaceId,
+  clonedWorkspaceId,
+  teamMap,
+  sourceOwnerId,
+  guestUserId,
+}: {
+  supabase: AdminClient;
+  sourceWorkspaceId: string;
+  clonedWorkspaceId: string;
+  teamMap: Map<string, string>;
+  sourceOwnerId: string | null;
+  guestUserId: string;
+}) {
+  const { data: sourceProjects, error } = await supabase
+    .from("projects")
+    .select("*")
+    .eq("workspace_id", sourceWorkspaceId)
+    .order("created_at", { ascending: true });
+
+  if (error) fail("Unable to read source projects", error);
+  if (!sourceProjects?.length) return { sourceProjects: [], map: new Map<string, string>() };
+
+  const rows: InsertTables<"projects">[] = sourceProjects.map((project) => ({
+    workspace_id: clonedWorkspaceId,
+    name: project.name,
+    description: project.description,
+    color: project.color,
+    lead_id: project.lead_id
+      ? mapProfileId(project.lead_id, sourceOwnerId, guestUserId)
+      : null,
+    team_id: mapNullableId(project.team_id, teamMap),
+    is_private: project.is_private,
+    is_archived: project.is_archived,
+    created_at: project.created_at,
+    updated_at: project.updated_at,
+  }));
+
+  const { data: clonedProjects, error: insertError } = await supabase
+    .from("projects")
+    .insert(rows)
+    .select();
+
+  if (insertError) fail("Unable to clone projects", insertError);
+
+  const map = new Map<string, string>();
+  sourceProjects.forEach((project, index) => {
+    const cloned = clonedProjects?.[index];
+    if (cloned) map.set(project.id, cloned.id);
+  });
+
+  return { sourceProjects, map };
+}
+
+async function clonePrimaryProjects({
+  supabase,
+  sourceWorkspaceId,
+  clonedWorkspaceId,
+  projectMap,
+  sourceOwnerId,
+  guestUserId,
+}: {
+  supabase: AdminClient;
+  sourceWorkspaceId: string;
+  clonedWorkspaceId: string;
+  projectMap: Map<string, string>;
+  sourceOwnerId: string | null;
+  guestUserId: string;
+}) {
+  const { data: sourceMembers, error } = await supabase
+    .from("workspace_members")
+    .select("user_id, primary_project_id")
+    .eq("workspace_id", sourceWorkspaceId)
+    .not("primary_project_id", "is", null);
+
+  if (error) fail("Unable to read source primary projects", error);
+
+  for (const member of sourceMembers ?? []) {
+    const primaryProjectId = member.primary_project_id
+      ? projectMap.get(member.primary_project_id)
+      : null;
+    if (!primaryProjectId) continue;
+
+    const userId = mapProfileId(member.user_id, sourceOwnerId, guestUserId);
+    const { error: updateError } = await supabase
+      .from("workspace_members")
+      .update({ primary_project_id: primaryProjectId })
+      .eq("workspace_id", clonedWorkspaceId)
+      .eq("user_id", userId);
+
+    if (updateError) fail("Unable to clone member primary project", updateError);
+  }
+}
+
+async function cloneLabels(
+  supabase: AdminClient,
+  sourceProjectIds: string[],
+  projectMap: Map<string, string>,
+) {
+  if (sourceProjectIds.length === 0) return new Map<string, string>();
+
+  const { data: sourceLabels, error } = await supabase
+    .from("labels")
+    .select("*")
+    .in("project_id", sourceProjectIds)
+    .order("name", { ascending: true });
+
+  if (error) fail("Unable to read source labels", error);
+  if (!sourceLabels?.length) return new Map<string, string>();
+
+  const rows = sourceLabels.flatMap((label) => {
+    const projectId = projectMap.get(label.project_id);
+    if (!projectId) return [];
+    return [{ project_id: projectId, name: label.name, color: label.color }];
+  });
+
+  const { data: clonedLabels, error: insertError } = await supabase
+    .from("labels")
+    .insert(rows)
+    .select();
+
+  if (insertError) fail("Unable to clone labels", insertError);
+
+  const map = new Map<string, string>();
+  sourceLabels.forEach((label, index) => {
+    const cloned = clonedLabels?.[index];
+    if (cloned) map.set(label.id, cloned.id);
+  });
+
+  return map;
+}
+
+async function cloneSprints({
+  supabase,
+  sourceWorkspaceId,
+  clonedWorkspaceId,
+  projectMap,
+}: {
+  supabase: AdminClient;
+  sourceWorkspaceId: string;
+  clonedWorkspaceId: string;
+  projectMap: Map<string, string>;
+}) {
+  const { data: sourceSprints, error } = await supabase
+    .from("sprints")
+    .select("*")
+    .eq("workspace_id", sourceWorkspaceId)
+    .order("created_at", { ascending: true });
+
+  if (error) fail("Unable to read source sprints", error);
+  if (!sourceSprints?.length) return new Map<string, string>();
+
+  const rows = sourceSprints.flatMap((sprint) => {
+    const projectId = projectMap.get(sprint.project_id);
+    if (!projectId) return [];
+
+    return [
+      {
+        workspace_id: clonedWorkspaceId,
+        project_id: projectId,
+        name: sprint.name,
+        goal: sprint.goal,
+        status: sprint.status,
+        start_date: sprint.start_date,
+        end_date: sprint.end_date,
+        capacity: sprint.capacity,
+        created_at: sprint.created_at,
+        updated_at: sprint.updated_at,
+      },
+    ];
+  });
+
+  const { data: clonedSprints, error: insertError } = await supabase
+    .from("sprints")
+    .insert(rows)
+    .select();
+
+  if (insertError) fail("Unable to clone sprints", insertError);
+
+  const map = new Map<string, string>();
+  sourceSprints.forEach((sprint, index) => {
+    const cloned = clonedSprints?.[index];
+    if (cloned) map.set(sprint.id, cloned.id);
+  });
+
+  return map;
+}
+
+async function cloneIssues({
+  supabase,
+  sourceWorkspaceId,
+  clonedWorkspaceId,
+  projectMap,
+  sprintMap,
+  sourceOwnerId,
+  guestUserId,
+}: {
+  supabase: AdminClient;
+  sourceWorkspaceId: string;
+  clonedWorkspaceId: string;
+  projectMap: Map<string, string>;
+  sprintMap: Map<string, string>;
+  sourceOwnerId: string | null;
+  guestUserId: string;
+}) {
+  const { data: sourceIssues, error } = await supabase
+    .from("issues")
+    .select("*")
+    .eq("workspace_id", sourceWorkspaceId)
+    .order("issue_number", { ascending: true });
+
+  if (error) fail("Unable to read source issues", error);
+  if (!sourceIssues?.length) return new Map<string, string>();
+
+  const rows = sourceIssues.flatMap((issue) => {
+    const projectId = projectMap.get(issue.project_id);
+    if (!projectId) return [];
+
+    return [
+      {
+        workspace_id: clonedWorkspaceId,
+        project_id: projectId,
+        issue_number: issue.issue_number,
+        issue_key: issue.issue_key,
+        title: issue.title,
+        description: issue.description,
+        status: issue.status,
+        priority: issue.priority,
+        assignee_id: issue.assignee_id
+          ? mapProfileId(issue.assignee_id, sourceOwnerId, guestUserId)
+          : null,
+        sprint_id: mapNullableId(issue.sprint_id, sprintMap),
+        due_date: issue.due_date,
+        story_points: issue.story_points,
+        sort_order: issue.sort_order,
+        created_by: mapProfileId(issue.created_by, sourceOwnerId, guestUserId),
+        completed_at: issue.completed_at,
+        checklist: issue.checklist,
+        created_at: issue.created_at,
+        updated_at: issue.updated_at,
+      },
+    ];
+  });
+
+  const { data: clonedIssues, error: insertError } = await supabase
+    .from("issues")
+    .insert(rows)
+    .select();
+
+  if (insertError) fail("Unable to clone issues", insertError);
+
+  const map = new Map<string, string>();
+  sourceIssues.forEach((issue, index) => {
+    const cloned = clonedIssues?.[index];
+    if (cloned) map.set(issue.id, cloned.id);
+  });
+
+  for (const issue of sourceIssues) {
+    if (!issue.parent_id) continue;
+
+    const clonedIssueId = map.get(issue.id);
+    const clonedParentId = map.get(issue.parent_id);
+    if (!clonedIssueId || !clonedParentId) continue;
+
+    const { error: updateError } = await supabase
+      .from("issues")
+      .update({ parent_id: clonedParentId })
+      .eq("id", clonedIssueId);
+
+    if (updateError) fail("Unable to clone issue hierarchy", updateError);
+  }
+
+  return map;
+}
+
+async function cloneIssueLabels({
+  supabase,
+  sourceIssueIds,
+  issueMap,
+  labelMap,
+}: {
+  supabase: AdminClient;
+  sourceIssueIds: string[];
+  issueMap: Map<string, string>;
+  labelMap: Map<string, string>;
+}) {
+  if (sourceIssueIds.length === 0) return;
+
+  const { data: sourceIssueLabels, error } = await supabase
+    .from("issue_labels")
+    .select("*")
+    .in("issue_id", sourceIssueIds);
+
+  if (error) fail("Unable to read source issue labels", error);
+
+  const rows = (sourceIssueLabels ?? []).flatMap((issueLabel) => {
+    const issueId = issueMap.get(issueLabel.issue_id);
+    const labelId = labelMap.get(issueLabel.label_id);
+    if (!issueId || !labelId) return [];
+    return [{ issue_id: issueId, label_id: labelId }];
+  });
+
+  if (rows.length === 0) return;
+
+  const { error: insertError } = await supabase.from("issue_labels").insert(rows);
+  if (insertError) fail("Unable to clone issue labels", insertError);
+}
+
+async function createGuestWorkspaceRecord({
+  supabase,
+  workspace,
+  sourceWorkspace,
+  guestUserId,
+  now,
+}: {
+  supabase: AdminClient;
+  workspace: Tables<"workspaces">;
+  sourceWorkspace: Tables<"workspaces">;
+  guestUserId: string;
+  now: Date;
+}) {
+  const { data, error } = await supabase
+    .from("guest_workspaces")
+    .insert({
+      workspace_id: workspace.id,
+      workspace_slug: workspace.slug,
+      source_workspace_id: sourceWorkspace.id,
+      source_workspace_slug: sourceWorkspace.slug,
+      guest_user_id: guestUserId,
+      expires_at: addHours(now, GUEST_WORKSPACE_TTL_HOURS).toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error || !data) fail("Unable to create guest lifecycle record", error);
+  return data;
+}
+
+async function deletePartialWorkspace(supabase: AdminClient, workspaceId: string | null) {
+  if (!workspaceId) return;
+  await supabase.from("workspaces").delete().eq("id", workspaceId);
+}
+
+export async function cloneGuestWorkspace(
+  options: CloneGuestWorkspaceOptions,
+): Promise<GuestWorkspaceCloneResult> {
+  const supabase = options.supabase ?? createAdminClient();
+  const now = options.now ?? new Date();
+  const sourceWorkspaceSlug =
+    options.sourceWorkspaceSlug ?? DEFAULT_GUEST_SOURCE_WORKSPACE_SLUG;
+  const guestDisplayName = options.guestDisplayName?.trim() || "Guest Visitor";
+  let clonedWorkspaceId: string | null = null;
+
+  try {
+    await ensureGuestProfile(supabase, options.guestUserId, guestDisplayName);
+
+    const sourceWorkspace = await fetchSourceWorkspace(supabase, sourceWorkspaceSlug);
+    const { data: sourceOwner } = await supabase
+      .from("workspace_members")
+      .select("user_id")
+      .eq("workspace_id", sourceWorkspace.id)
+      .eq("role", "owner")
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    const sourceOwnerId = sourceOwner?.user_id ?? null;
+    const workspace = await createWorkspaceCopy(
+      supabase,
+      sourceWorkspace,
+      options.slugSuffix,
+    );
+    clonedWorkspaceId = workspace.id;
+
+    await cloneWorkspaceMembers({
+      supabase,
+      sourceWorkspaceId: sourceWorkspace.id,
+      clonedWorkspaceId: workspace.id,
+      sourceOwnerId,
+      guestUserId: options.guestUserId,
+    });
+
+    const { sourceTeams, map: teamMap } = await cloneTeams(
+      supabase,
+      sourceWorkspace.id,
+      workspace.id,
+    );
+    await cloneTeamMembers({
+      supabase,
+      sourceTeamIds: sourceTeams.map((team) => team.id),
+      teamMap,
+      sourceOwnerId,
+      guestUserId: options.guestUserId,
+    });
+
+    const { sourceProjects, map: projectMap } = await cloneProjects({
+      supabase,
+      sourceWorkspaceId: sourceWorkspace.id,
+      clonedWorkspaceId: workspace.id,
+      teamMap,
+      sourceOwnerId,
+      guestUserId: options.guestUserId,
+    });
+    await clonePrimaryProjects({
+      supabase,
+      sourceWorkspaceId: sourceWorkspace.id,
+      clonedWorkspaceId: workspace.id,
+      projectMap,
+      sourceOwnerId,
+      guestUserId: options.guestUserId,
+    });
+
+    const labelMap = await cloneLabels(
+      supabase,
+      sourceProjects.map((project) => project.id),
+      projectMap,
+    );
+    const sprintMap = await cloneSprints({
+      supabase,
+      sourceWorkspaceId: sourceWorkspace.id,
+      clonedWorkspaceId: workspace.id,
+      projectMap,
+    });
+    const issueMap = await cloneIssues({
+      supabase,
+      sourceWorkspaceId: sourceWorkspace.id,
+      clonedWorkspaceId: workspace.id,
+      projectMap,
+      sprintMap,
+      sourceOwnerId,
+      guestUserId: options.guestUserId,
+    });
+    await cloneIssueLabels({
+      supabase,
+      sourceIssueIds: [...issueMap.keys()],
+      issueMap,
+      labelMap,
+    });
+
+    const guestWorkspace = await createGuestWorkspaceRecord({
+      supabase,
+      workspace,
+      sourceWorkspace,
+      guestUserId: options.guestUserId,
+      now,
+    });
+
+    return {
+      workspace,
+      guestWorkspace,
+      sourceWorkspace,
+      maps: {
+        teams: teamMap,
+        projects: projectMap,
+        labels: labelMap,
+        sprints: sprintMap,
+        issues: issueMap,
+      },
+    };
+  } catch (error) {
+    await deletePartialWorkspace(supabase, clonedWorkspaceId);
+    throw error;
+  }
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
-import type { Database } from "@/lib/types/database";
+import type { Database } from "../types/database";
 
 export function createAdminClient() {
   return createClient<Database>(

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -713,6 +713,60 @@ export type Database = {
           },
         ];
       };
+      guest_workspaces: {
+        Row: {
+          id: string;
+          workspace_id: string | null;
+          workspace_slug: string;
+          source_workspace_id: string | null;
+          source_workspace_slug: string;
+          guest_user_id: string;
+          created_at: string;
+          expires_at: string;
+          cleaned_at: string | null;
+          cleanup_error: string | null;
+        };
+        Insert: {
+          id?: string;
+          workspace_id?: string | null;
+          workspace_slug: string;
+          source_workspace_id?: string | null;
+          source_workspace_slug: string;
+          guest_user_id: string;
+          created_at?: string;
+          expires_at: string;
+          cleaned_at?: string | null;
+          cleanup_error?: string | null;
+        };
+        Update: {
+          id?: string;
+          workspace_id?: string | null;
+          workspace_slug?: string;
+          source_workspace_id?: string | null;
+          source_workspace_slug?: string;
+          guest_user_id?: string;
+          created_at?: string;
+          expires_at?: string;
+          cleaned_at?: string | null;
+          cleanup_error?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "guest_workspaces_workspace_id_fkey";
+            columns: ["workspace_id"];
+            isOneToOne: false;
+            referencedRelation: "workspaces";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "guest_workspaces_source_workspace_id_fkey";
+            columns: ["source_workspace_id"];
+            isOneToOne: false;
+            referencedRelation: "workspaces";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
     };
     Views: Record<string, never>;
     Functions: {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -168,7 +168,7 @@ refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
 # Allow/disallow anonymous sign-ins to your project.
-enable_anonymous_sign_ins = false
+enable_anonymous_sign_ins = true
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.

--- a/supabase/migrations/00024_guest_workspaces.sql
+++ b/supabase/migrations/00024_guest_workspaces.sql
@@ -1,0 +1,28 @@
+-- 00024_guest_workspaces.sql
+-- Lifecycle metadata for isolated anonymous demo workspaces.
+
+create table guest_workspaces (
+  id                    uuid primary key default gen_random_uuid(),
+  workspace_id          uuid references workspaces(id) on delete set null,
+  workspace_slug        text not null,
+  source_workspace_id   uuid references workspaces(id) on delete set null,
+  source_workspace_slug text not null,
+  guest_user_id         uuid not null,
+  created_at            timestamptz not null default now(),
+  expires_at            timestamptz not null,
+  cleaned_at            timestamptz,
+  cleanup_error         text
+);
+
+create unique index guest_workspaces_workspace_unique
+  on guest_workspaces (workspace_id)
+  where workspace_id is not null;
+
+create index idx_guest_workspaces_expired
+  on guest_workspaces (expires_at)
+  where cleaned_at is null;
+
+create index idx_guest_workspaces_guest_user
+  on guest_workspaces (guest_user_id);
+
+alter table guest_workspaces enable row level security;

--- a/tests/guest-workspace.test.ts
+++ b/tests/guest-workspace.test.ts
@@ -1,0 +1,458 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import dotenv from "dotenv";
+import path from "node:path";
+import { cleanupExpiredGuestWorkspaces } from "../src/lib/guest/cleanup";
+import { cloneGuestWorkspace } from "../src/lib/guest/workspace-clone";
+import type { Database } from "../src/lib/types";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const PASSWORD = "guestTest!2026";
+
+const missingEnvReason =
+  !SUPABASE_URL || !SUPABASE_SERVICE_KEY || !SUPABASE_ANON_KEY
+    ? "Supabase environment variables are not configured"
+    : undefined;
+
+function adminClient() {
+  return createClient<Database>(SUPABASE_URL!, SUPABASE_SERVICE_KEY!);
+}
+
+async function createTestUser(
+  admin: SupabaseClient<Database>,
+  email: string,
+  fullName: string,
+) {
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password: PASSWORD,
+    email_confirm: true,
+    user_metadata: { full_name: fullName },
+  });
+
+  if (error || !data.user) {
+    throw new Error(error?.message ?? "Unable to create test user");
+  }
+
+  return data.user.id;
+}
+
+async function deleteUsers(admin: SupabaseClient<Database>, ids: string[]) {
+  for (const id of ids) {
+    await admin.auth.admin.deleteUser(id);
+  }
+}
+
+async function createSourceWorkspace(admin: SupabaseClient<Database>, suffix: string) {
+  const sourceSlug = `guest-source-${suffix}`;
+  const ownerEmail = `guest-owner-${suffix}@test.flow.dev`;
+  const memberEmail = `guest-member-${suffix}@test.flow.dev`;
+  const ownerId = await createTestUser(admin, ownerEmail, "Source Owner");
+  const memberId = await createTestUser(admin, memberEmail, "Demo Member");
+  const checklist = [{ id: randomUUID(), text: "Verify clone mapping", completed: false }];
+
+  const { data: workspace, error: workspaceError } = await admin
+    .from("workspaces")
+    .insert({
+      name: "Guest Source",
+      slug: sourceSlug,
+      issue_prefix: "GST",
+      issue_counter: 2,
+      default_sprint_length: 10,
+      timezone: "UTC",
+    })
+    .select()
+    .single();
+  if (workspaceError || !workspace) throw workspaceError;
+
+  await admin.from("workspace_members").insert([
+    { workspace_id: workspace.id, user_id: ownerId, role: "owner" },
+    { workspace_id: workspace.id, user_id: memberId, role: "member" },
+  ]);
+
+  const { data: team, error: teamError } = await admin
+    .from("teams")
+    .insert({ workspace_id: workspace.id, name: "Engineering" })
+    .select()
+    .single();
+  if (teamError || !team) throw teamError;
+
+  await admin.from("team_members").insert([
+    { team_id: team.id, user_id: ownerId },
+    { team_id: team.id, user_id: memberId },
+  ]);
+
+  const { data: project, error: projectError } = await admin
+    .from("projects")
+    .insert({
+      workspace_id: workspace.id,
+      name: "Demo Project",
+      description: "Source project for guest clone tests",
+      color: "#3B82F6",
+      lead_id: ownerId,
+      team_id: team.id,
+    })
+    .select()
+    .single();
+  if (projectError || !project) throw projectError;
+
+  await admin
+    .from("workspace_members")
+    .update({ primary_project_id: project.id })
+    .eq("workspace_id", workspace.id);
+
+  const { data: labels, error: labelError } = await admin
+    .from("labels")
+    .insert([
+      { project_id: project.id, name: "Bug", color: "#EF4444" },
+      { project_id: project.id, name: "Feature", color: "#3B82F6" },
+    ])
+    .select();
+  if (labelError || !labels) throw labelError;
+
+  const { data: sprint, error: sprintError } = await admin
+    .from("sprints")
+    .insert({
+      workspace_id: workspace.id,
+      project_id: project.id,
+      name: "Sprint 1",
+      goal: "Clone the useful demo data",
+      status: "active",
+      start_date: "2026-04-20",
+      end_date: "2026-05-04",
+      capacity: 20,
+    })
+    .select()
+    .single();
+  if (sprintError || !sprint) throw sprintError;
+
+  const { data: parentIssue, error: parentError } = await admin
+    .from("issues")
+    .insert({
+      workspace_id: workspace.id,
+      project_id: project.id,
+      issue_number: 1,
+      issue_key: "GST-1",
+      title: "Parent issue",
+      description: "Parent issue description",
+      status: "in_progress",
+      priority: 1,
+      assignee_id: ownerId,
+      sprint_id: sprint.id,
+      story_points: 5,
+      sort_order: 1000,
+      created_by: ownerId,
+      checklist,
+    })
+    .select()
+    .single();
+  if (parentError || !parentIssue) throw parentError;
+
+  const { data: childIssue, error: childError } = await admin
+    .from("issues")
+    .insert({
+      workspace_id: workspace.id,
+      project_id: project.id,
+      issue_number: 2,
+      issue_key: "GST-2",
+      title: "Child issue",
+      status: "todo",
+      priority: 2,
+      assignee_id: memberId,
+      sprint_id: sprint.id,
+      story_points: 2,
+      sort_order: 2000,
+      created_by: ownerId,
+      parent_id: parentIssue.id,
+    })
+    .select()
+    .single();
+  if (childError || !childIssue) throw childError;
+
+  await admin.from("issue_labels").insert([
+    { issue_id: parentIssue.id, label_id: labels[0].id },
+    { issue_id: childIssue.id, label_id: labels[1].id },
+  ]);
+
+  return {
+    workspace,
+    ownerId,
+    ownerEmail,
+    memberId,
+    project,
+    team,
+    sprint,
+    labels,
+    parentIssue,
+    childIssue,
+    checklist,
+  };
+}
+
+test(
+  "cloneGuestWorkspace creates an isolated demo workspace with remapped IDs",
+  { skip: missingEnvReason },
+  async () => {
+    const admin = adminClient();
+    const suffix = randomUUID().slice(0, 8);
+    const guestEmail = `guest-clone-${suffix}@test.flow.dev`;
+    const guestUserId = await createTestUser(admin, guestEmail, "Guest Tester");
+    const source = await createSourceWorkspace(admin, suffix);
+    let clonedWorkspaceId: string | null = null;
+
+    try {
+      const clone = await cloneGuestWorkspace({
+        supabase: admin,
+        guestUserId,
+        guestDisplayName: "Guest Tester",
+        sourceWorkspaceSlug: source.workspace.slug,
+        slugSuffix: suffix,
+        now: new Date("2026-04-27T00:00:00.000Z"),
+      });
+      clonedWorkspaceId = clone.workspace.id;
+
+      assert.match(clone.workspace.slug, /^guest-workspace-[a-z0-9]+$/);
+      assert.notEqual(clone.workspace.id, source.workspace.id);
+      assert.equal(clone.workspace.issue_counter, 2);
+
+      const { data: clonedMembers } = await admin
+        .from("workspace_members")
+        .select("user_id, role, primary_project_id")
+        .eq("workspace_id", clone.workspace.id);
+      assert.equal(clonedMembers?.some((m) => m.user_id === guestUserId && m.role === "owner"), true);
+      assert.equal(clonedMembers?.some((m) => m.user_id === source.memberId && m.role === "member"), true);
+      assert.equal(clonedMembers?.some((m) => m.user_id === source.ownerId), false);
+
+      const { data: clonedTeams } = await admin
+        .from("teams")
+        .select("*")
+        .eq("workspace_id", clone.workspace.id);
+      assert.equal(clonedTeams?.length, 1);
+      assert.notEqual(clonedTeams?.[0].id, source.team.id);
+
+      const { data: clonedTeamMembers } = await admin
+        .from("team_members")
+        .select("*")
+        .eq("team_id", clonedTeams![0].id);
+      assert.equal(clonedTeamMembers?.some((m) => m.user_id === guestUserId), true);
+      assert.equal(clonedTeamMembers?.some((m) => m.user_id === source.memberId), true);
+
+      const { data: clonedProjects } = await admin
+        .from("projects")
+        .select("*")
+        .eq("workspace_id", clone.workspace.id);
+      assert.equal(clonedProjects?.length, 1);
+      const clonedProject = clonedProjects![0];
+      assert.notEqual(clonedProject.id, source.project.id);
+      assert.equal(clonedProject.team_id, clonedTeams![0].id);
+      assert.equal(clonedProject.lead_id, guestUserId);
+
+      const { data: clonedLabels } = await admin
+        .from("labels")
+        .select("*")
+        .eq("project_id", clonedProject.id);
+      assert.equal(clonedLabels?.length, 2);
+
+      const { data: clonedSprints } = await admin
+        .from("sprints")
+        .select("*")
+        .eq("workspace_id", clone.workspace.id);
+      assert.equal(clonedSprints?.length, 1);
+      assert.equal(clonedSprints?.[0].project_id, clonedProject.id);
+
+      const { data: clonedIssues } = await admin
+        .from("issues")
+        .select("*")
+        .eq("workspace_id", clone.workspace.id)
+        .order("issue_number", { ascending: true });
+      assert.equal(clonedIssues?.length, 2);
+      const clonedParent = clonedIssues![0];
+      const clonedChild = clonedIssues![1];
+      assert.notEqual(clonedParent.id, source.parentIssue.id);
+      assert.equal(clonedParent.project_id, clonedProject.id);
+      assert.equal(clonedParent.sprint_id, clonedSprints![0].id);
+      assert.equal(clonedParent.assignee_id, guestUserId);
+      assert.equal(clonedParent.created_by, guestUserId);
+      assert.deepEqual(clonedParent.checklist, source.checklist);
+      assert.equal(clonedChild.parent_id, clonedParent.id);
+      assert.notEqual(clonedChild.parent_id, source.parentIssue.id);
+      assert.equal(clonedChild.assignee_id, source.memberId);
+
+      const { data: clonedIssueLabels } = await admin
+        .from("issue_labels")
+        .select("*")
+        .in("issue_id", clonedIssues!.map((issue) => issue.id));
+      assert.equal(clonedIssueLabels?.length, 2);
+
+      const { data: sourceWorkspaceAfter } = await admin
+        .from("workspaces")
+        .select("issue_counter")
+        .eq("id", source.workspace.id)
+        .single();
+      assert.equal(sourceWorkspaceAfter?.issue_counter, 2);
+
+      const guestClient = createClient<Database>(SUPABASE_URL!, SUPABASE_ANON_KEY!);
+      const { error: signInError } = await guestClient.auth.signInWithPassword({
+        email: guestEmail,
+        password: PASSWORD,
+      });
+      assert.equal(signInError, null);
+
+      const { data: newIssue, error: createIssueError } = await guestClient.rpc(
+        "create_issue",
+        {
+          p_workspace_id: clone.workspace.id,
+          p_project_id: clonedProject.id,
+          p_title: "Guest-created issue",
+        },
+      );
+      assert.equal(createIssueError, null);
+      assert.equal(newIssue?.issue_number, 3);
+      assert.equal(newIssue?.issue_key, "GST-3");
+    } finally {
+      if (clonedWorkspaceId) {
+        await admin.from("workspaces").delete().eq("id", clonedWorkspaceId);
+      }
+      await admin
+        .from("guest_workspaces")
+        .delete()
+        .eq("source_workspace_slug", source.workspace.slug);
+      await admin.from("workspaces").delete().eq("id", source.workspace.id);
+      await deleteUsers(admin, [guestUserId, source.ownerId, source.memberId]);
+    }
+  },
+);
+
+test(
+  "cleanupExpiredGuestWorkspaces removes expired workspaces and is idempotent",
+  { skip: missingEnvReason },
+  async () => {
+    const admin = adminClient();
+    const suffix = randomUUID().slice(0, 8);
+    const expiredUserId = await createTestUser(
+      admin,
+      `guest-expired-${suffix}@test.flow.dev`,
+      "Expired Guest",
+    );
+    const freshUserId = await createTestUser(
+      admin,
+      `guest-fresh-${suffix}@test.flow.dev`,
+      "Fresh Guest",
+    );
+    const missingUserId = randomUUID();
+    const now = new Date("2026-04-27T00:00:00.000Z");
+
+    const { data: expiredWorkspace, error: expiredWorkspaceError } = await admin
+      .from("workspaces")
+      .insert({ name: "Expired Guest", slug: `expired-guest-${suffix}` })
+      .select()
+      .single();
+    if (expiredWorkspaceError || !expiredWorkspace) throw expiredWorkspaceError;
+
+    const { data: freshWorkspace, error: freshWorkspaceError } = await admin
+      .from("workspaces")
+      .insert({ name: "Fresh Guest", slug: `fresh-guest-${suffix}` })
+      .select()
+      .single();
+    if (freshWorkspaceError || !freshWorkspace) throw freshWorkspaceError;
+
+    try {
+      const { data: expiredRecord, error: expiredRecordError } = await admin
+        .from("guest_workspaces")
+        .insert({
+          workspace_id: expiredWorkspace.id,
+          workspace_slug: expiredWorkspace.slug,
+          source_workspace_slug: "source",
+          guest_user_id: expiredUserId,
+          expires_at: "2026-04-26T23:00:00.000Z",
+        })
+        .select()
+        .single();
+      if (expiredRecordError || !expiredRecord) throw expiredRecordError;
+
+      const { data: freshRecord, error: freshRecordError } = await admin
+        .from("guest_workspaces")
+        .insert({
+          workspace_id: freshWorkspace.id,
+          workspace_slug: freshWorkspace.slug,
+          source_workspace_slug: "source",
+          guest_user_id: freshUserId,
+          expires_at: "2026-04-28T00:00:00.000Z",
+        })
+        .select()
+        .single();
+      if (freshRecordError || !freshRecord) throw freshRecordError;
+
+      const { data: alreadyDeletedRecord, error: alreadyDeletedError } = await admin
+        .from("guest_workspaces")
+        .insert({
+          workspace_id: null,
+          workspace_slug: `already-deleted-${suffix}`,
+          source_workspace_slug: "source",
+          guest_user_id: missingUserId,
+          expires_at: "2026-04-26T22:00:00.000Z",
+        })
+        .select()
+        .single();
+      if (alreadyDeletedError || !alreadyDeletedRecord) throw alreadyDeletedError;
+
+      const result = await cleanupExpiredGuestWorkspaces({
+        supabase: admin,
+        now,
+        batchSize: 10,
+      });
+
+      assert.equal(result.scanned, 2);
+      assert.equal(result.deletedWorkspaces, 1);
+      assert.equal(result.markedCleaned, 2);
+      assert.equal(result.errors.length, 0);
+
+      const { data: expiredWorkspaceAfter } = await admin
+        .from("workspaces")
+        .select("id")
+        .eq("id", expiredWorkspace.id)
+        .maybeSingle();
+      assert.equal(expiredWorkspaceAfter, null);
+
+      const { data: freshWorkspaceAfter } = await admin
+        .from("workspaces")
+        .select("id")
+        .eq("id", freshWorkspace.id)
+        .maybeSingle();
+      assert.equal(freshWorkspaceAfter?.id, freshWorkspace.id);
+
+      const { data: recordsAfter } = await admin
+        .from("guest_workspaces")
+        .select("id, cleaned_at")
+        .in("id", [expiredRecord.id, freshRecord.id, alreadyDeletedRecord.id]);
+      const byId = new Map(recordsAfter?.map((record) => [record.id, record]));
+      assert.notEqual(byId.get(expiredRecord.id)?.cleaned_at, null);
+      assert.notEqual(byId.get(alreadyDeletedRecord.id)?.cleaned_at, null);
+      assert.equal(byId.get(freshRecord.id)?.cleaned_at, null);
+
+      const secondPass = await cleanupExpiredGuestWorkspaces({
+        supabase: admin,
+        now,
+        batchSize: 10,
+      });
+      assert.equal(secondPass.scanned, 0);
+    } finally {
+      await admin
+        .from("guest_workspaces")
+        .delete()
+        .in("workspace_slug", [
+          expiredWorkspace.slug,
+          freshWorkspace.slug,
+          `already-deleted-${suffix}`,
+        ]);
+      await admin.from("workspaces").delete().eq("id", freshWorkspace.id);
+      await deleteUsers(admin, [expiredUserId, freshUserId]);
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- add Continue as guest flow using Supabase anonymous auth
- clone seeded workspace data into isolated 24-hour guest workspaces
- add guest cleanup lifecycle script and direct clone/cleanup tests

## Verification
- npm run build
- npx eslint src/lib/guest/workspace-clone.ts src/lib/guest/cleanup.ts src/lib/actions/auth.ts 'src/app/(auth)/login/page.tsx' tests/guest-workspace.test.ts scripts/cleanup-guest-workspaces.ts
- npm run test:guest (skips without .env.local)