### PR TITLE
Implement guest demo sandbox

### DIFF
--- a/scripts/cleanup-guest-workspaces.ts
+++ b/scripts/cleanup-guest-workspaces.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Deletes expired guest workspaces and anonymous auth users.
+ *
+ * Usage:
+ *   npx tsx scripts/cleanup-guest-workspaces.ts
+ */
+
+import dotenv from "dotenv";
+import path from "node:path";
+import { cleanupExpiredGuestWorkspaces } from "../src/lib/guest/cleanup";
+
+dotenv.config({ path: path.resolve(__dirname, "../.env.local") });
+
+async function main() {
+  const result = await cleanupExpiredGuestWorkspaces();
+
+  console.log(
+    [
+      `Scanned: ${result.scanned}`,
+      `Deleted workspaces: ${result.deletedWorkspaces}`,
+      `Deleted auth users: ${result.deletedAuthUsers}`,
+      `Skipped auth users: ${result.skippedAuthUsers}`,
+      `Errors: ${result.errors.length}`,
+    ].join("\n"),
+  );
+
+  if (result.errors.length > 0) {
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/(auth)/guest-mode-chooser.tsx
+++ b/src/app/(auth)/guest-mode-chooser.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { Plus, Sparkles, UserRound } from "lucide-react";
+import { continueAsGuest } from "@/lib/actions/auth";
+import type { ActionResponse } from "@/lib/types";
+
+type GuestMode = "demo" | "fresh";
+
+type GuestModeChooserProps = {
+  disabled?: boolean;
+};
+
+function getPendingLabel(mode: GuestMode | null) {
+  if (mode === "fresh") return "Creating fresh workspace...";
+  return "Preparing demo workspace...";
+}
+
+export function GuestModeChooser({ disabled = false }: GuestModeChooserProps) {
+  const [open, setOpen] = useState(false);
+  const [selectedMode, setSelectedMode] = useState<GuestMode | null>(null);
+  const [state, formAction, pending] = useActionState<
+    ActionResponse | null,
+    FormData
+  >(async (_prev, formData) => {
+    return await continueAsGuest(formData);
+  }, null);
+
+  return (
+    <div className="mt-3">
+      <button
+        type="button"
+        aria-expanded={open}
+        disabled={disabled || pending}
+        onClick={() => setOpen((current) => !current)}
+        className="flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-surface text-sm font-medium text-text transition-colors hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
+      >
+        <UserRound className="h-4 w-4" />
+        {pending ? getPendingLabel(selectedMode) : "Continue as guest"}
+      </button>
+
+      {state?.error && (
+        <div className="mt-3 rounded-lg border border-danger/20 bg-danger-light px-4 py-3 text-sm text-danger">
+          {state.error}
+        </div>
+      )}
+
+      {open && (
+        <form action={formAction} className="mt-3 grid gap-2 sm:grid-cols-2">
+          <button
+            type="submit"
+            name="mode"
+            value="demo"
+            disabled={disabled || pending}
+            onClick={() => setSelectedMode("demo")}
+            className="flex min-h-20 flex-col items-start justify-center gap-1 rounded-lg border border-border bg-surface px-4 py-3 text-left transition-colors hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
+          >
+            <span className="flex items-center gap-2 text-sm font-medium text-text">
+              <Sparkles className="h-4 w-4" />
+              Explore demo data
+            </span>
+            <span className="text-xs text-text-secondary">Preloaded workspace</span>
+          </button>
+
+          <button
+            type="submit"
+            name="mode"
+            value="fresh"
+            disabled={disabled || pending}
+            onClick={() => setSelectedMode("fresh")}
+            className="flex min-h-20 flex-col items-start justify-center gap-1 rounded-lg border border-border bg-surface px-4 py-3 text-left transition-colors hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
+          >
+            <span className="flex items-center gap-2 text-sm font-medium text-text">
+              <Plus className="h-4 w-4" />
+              Start fresh
+            </span>
+            <span className="text-xs text-text-secondary">Empty workspace</span>
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,9 +3,10 @@
 import { Suspense, useActionState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Github, UserRound } from "lucide-react";
-import { continueAsGuest, signIn, signInWithOAuth } from "@/lib/actions/auth";
+import { Github } from "lucide-react";
+import { signIn, signInWithOAuth } from "@/lib/actions/auth";
 import type { ActionResponse } from "@/lib/types";
+import { GuestModeChooser } from "../guest-mode-chooser";
 
 function LoginPageContent() {
   const searchParams = useSearchParams();
@@ -16,13 +17,6 @@ function LoginPageContent() {
   >(async (_prev, formData) => {
     return await signIn(formData);
   }, null);
-  const [guestState, guestFormAction, guestPending] = useActionState<
-    ActionResponse | null,
-    FormData
-  >(async () => {
-    return await continueAsGuest();
-  }, null);
-  const error = state?.error ?? guestState?.error;
 
   return (
     <div className="w-full max-w-md">
@@ -39,9 +33,9 @@ function LoginPageContent() {
       <p className="text-text-secondary mb-8">Sign in to your workspace</p>
 
       {/* Error message */}
-      {error && (
+      {state?.error && (
         <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm mb-6">
-          {error}
+          {state.error}
         </div>
       )}
 
@@ -92,23 +86,14 @@ function LoginPageContent() {
 
         <button
           type="submit"
-          disabled={pending || guestPending}
+          disabled={pending}
           className="bg-primary text-background w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {pending ? "Signing In..." : "Sign In"}
         </button>
       </form>
 
-      <form action={guestFormAction} className="mt-3">
-        <button
-          type="submit"
-          disabled={pending || guestPending}
-          className="flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-surface text-sm font-medium text-text transition-colors hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
-        >
-          <UserRound className="h-4 w-4" />
-          {guestPending ? "Preparing guest workspace..." : "Continue as guest"}
-        </button>
-      </form>
+      <GuestModeChooser disabled={pending} />
 
       {/* Divider */}
       <div className="flex items-center gap-4 my-6">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,8 +3,8 @@
 import { Suspense, useActionState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Github } from "lucide-react";
-import { signIn, signInWithOAuth } from "@/lib/actions/auth";
+import { Github, UserRound } from "lucide-react";
+import { continueAsGuest, signIn, signInWithOAuth } from "@/lib/actions/auth";
 import type { ActionResponse } from "@/lib/types";
 
 function LoginPageContent() {
@@ -16,6 +16,13 @@ function LoginPageContent() {
   >(async (_prev, formData) => {
     return await signIn(formData);
   }, null);
+  const [guestState, guestFormAction, guestPending] = useActionState<
+    ActionResponse | null,
+    FormData
+  >(async () => {
+    return await continueAsGuest();
+  }, null);
+  const error = state?.error ?? guestState?.error;
 
   return (
     <div className="w-full max-w-md">
@@ -32,9 +39,9 @@ function LoginPageContent() {
       <p className="text-text-secondary mb-8">Sign in to your workspace</p>
 
       {/* Error message */}
-      {state?.error && (
+      {error && (
         <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm mb-6">
-          {state.error}
+          {error}
         </div>
       )}
 
@@ -85,10 +92,21 @@ function LoginPageContent() {
 
         <button
           type="submit"
-          disabled={pending}
+          disabled={pending || guestPending}
           className="bg-primary text-background w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {pending ? "Signing In..." : "Sign In"}
+        </button>
+      </form>
+
+      <form action={guestFormAction} className="mt-3">
+        <button
+          type="submit"
+          disabled={pending || guestPending}
+          className="flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-surface text-sm font-medium text-text transition-colors hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
+        >
+          <UserRound className="h-4 w-4" />
+          {guestPending ? "Preparing guest workspace..." : "Continue as guest"}
         </button>
       </form>
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,9 +3,10 @@
 import { Suspense, useActionState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Github, UserRound } from "lucide-react";
-import { continueAsGuest, signUp, signInWithOAuth } from "@/lib/actions/auth";
+import { Github } from "lucide-react";
+import { signUp, signInWithOAuth } from "@/lib/actions/auth";
 import type { ActionResponse } from "@/lib/types";
+import { GuestModeChooser } from "../guest-mode-chooser";
 
 function SignUpPageContent() {
   const searchParams = useSearchParams();
@@ -16,13 +17,6 @@ function SignUpPageContent() {
   >(async (_prev, formData) => {
     return await signUp(formData);
   }, null);
-  const [guestState, guestFormAction, guestPending] = useActionState<
-    ActionResponse | null,
-    FormData
-  >(async () => {
-    return await continueAsGuest();
-  }, null);
-  const error = state?.error ?? guestState?.error;
 
   return (
     <div className="w-full max-w-md">
@@ -43,9 +37,9 @@ function SignUpPageContent() {
       </p>
 
       {/* Error message */}
-      {error && (
+      {state?.error && (
         <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm mb-6">
-          {error}
+          {state.error}
         </div>
       )}
 
@@ -106,23 +100,14 @@ function SignUpPageContent() {
 
         <button
           type="submit"
-          disabled={pending || guestPending}
+          disabled={pending}
           className="bg-primary text-background w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {pending ? "Creating Account..." : "Create Account"}
         </button>
       </form>
 
-      <form action={guestFormAction} className="mt-3">
-        <button
-          type="submit"
-          disabled={pending || guestPending}
-          className="flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-surface text-sm font-medium text-text transition-colors hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
-        >
-          <UserRound className="h-4 w-4" />
-          {guestPending ? "Preparing guest workspace..." : "Continue as guest"}
-        </button>
-      </form>
+      <GuestModeChooser disabled={pending} />
 
       {/* Divider */}
       <div className="flex items-center gap-4 my-6">

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,8 +3,8 @@
 import { Suspense, useActionState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Github } from "lucide-react";
-import { signUp, signInWithOAuth } from "@/lib/actions/auth";
+import { Github, UserRound } from "lucide-react";
+import { continueAsGuest, signUp, signInWithOAuth } from "@/lib/actions/auth";
 import type { ActionResponse } from "@/lib/types";
 
 function SignUpPageContent() {
@@ -16,6 +16,13 @@ function SignUpPageContent() {
   >(async (_prev, formData) => {
     return await signUp(formData);
   }, null);
+  const [guestState, guestFormAction, guestPending] = useActionState<
+    ActionResponse | null,
+    FormData
+  >(async () => {
+    return await continueAsGuest();
+  }, null);
+  const error = state?.error ?? guestState?.error;
 
   return (
     <div className="w-full max-w-md">
@@ -36,9 +43,9 @@ function SignUpPageContent() {
       </p>
 
       {/* Error message */}
-      {state?.error && (
+      {error && (
         <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm mb-6">
-          {state.error}
+          {error}
         </div>
       )}
 
@@ -99,10 +106,21 @@ function SignUpPageContent() {
 
         <button
           type="submit"
-          disabled={pending}
+          disabled={pending || guestPending}
           className="bg-primary text-background w-full h-12 rounded-lg font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {pending ? "Creating Account..." : "Create Account"}
+        </button>
+      </form>
+
+      <form action={guestFormAction} className="mt-3">
+        <button
+          type="submit"
+          disabled={pending || guestPending}
+          className="flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-surface text-sm font-medium text-text transition-colors hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
+        >
+          <UserRound className="h-4 w-4" />
+          {guestPending ? "Preparing guest workspace..." : "Continue as guest"}
         </button>
       </form>
 

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -4,7 +4,10 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { ActionResponse } from "@/lib/types";
-import { cloneGuestWorkspace } from "@/lib/guest/workspace-clone";
+import {
+  cloneGuestWorkspace,
+  createFreshGuestWorkspace,
+} from "@/lib/guest/workspace-clone";
 import { buildAuthRedirectUrl, normalizeRedirectPath } from "@/lib/utils/redirect-path";
 import {
   resolvePostAuthRedirect,
@@ -64,8 +67,15 @@ export async function signIn(formData: FormData): Promise<ActionResponse> {
   redirect(await resolvePostAuthRedirect(nextPath));
 }
 
-export async function continueAsGuest(): Promise<ActionResponse> {
+type GuestMode = "demo" | "fresh";
+
+function getGuestMode(formData?: FormData): GuestMode {
+  return formData?.get("mode") === "fresh" ? "fresh" : "demo";
+}
+
+export async function continueAsGuest(formData?: FormData): Promise<ActionResponse> {
   const supabase = await createClient();
+  const mode = getGuestMode(formData);
 
   const { data, error } = await supabase.auth.signInAnonymously({
     options: {
@@ -81,13 +91,20 @@ export async function continueAsGuest(): Promise<ActionResponse> {
     };
   }
 
-  let workspaceSlug: string;
+  let redirectPath: string;
 
   try {
-    const { workspace } = await cloneGuestWorkspace({
-      guestUserId: data.user.id,
-    });
-    workspaceSlug = workspace.slug;
+    if (mode === "fresh") {
+      const { workspace } = await createFreshGuestWorkspace({
+        guestUserId: data.user.id,
+      });
+      redirectPath = `/${workspace.slug}/projects`;
+    } else {
+      const { workspace } = await cloneGuestWorkspace({
+        guestUserId: data.user.id,
+      });
+      redirectPath = `/${workspace.slug}/dashboard`;
+    }
   } catch {
     await supabase.auth.signOut();
 
@@ -102,7 +119,7 @@ export async function continueAsGuest(): Promise<ActionResponse> {
     };
   }
 
-  redirect(`/${workspaceSlug}/dashboard`);
+  redirect(redirectPath);
 }
 
 export async function signOut(): Promise<void> {

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -2,7 +2,9 @@
 
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import type { ActionResponse } from "@/lib/types";
+import { cloneGuestWorkspace } from "@/lib/guest/workspace-clone";
 import { buildAuthRedirectUrl, normalizeRedirectPath } from "@/lib/utils/redirect-path";
 import {
   resolvePostAuthRedirect,
@@ -60,6 +62,47 @@ export async function signIn(formData: FormData): Promise<ActionResponse> {
   }
 
   redirect(await resolvePostAuthRedirect(nextPath));
+}
+
+export async function continueAsGuest(): Promise<ActionResponse> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.auth.signInAnonymously({
+    options: {
+      data: { full_name: "Guest User" },
+    },
+  });
+
+  if (error || !data.user) {
+    return {
+      error:
+        error?.message ??
+        "Unable to start guest mode. Please try again in a moment.",
+    };
+  }
+
+  let workspaceSlug: string;
+
+  try {
+    const { workspace } = await cloneGuestWorkspace({
+      guestUserId: data.user.id,
+    });
+    workspaceSlug = workspace.slug;
+  } catch {
+    await supabase.auth.signOut();
+
+    try {
+      await createAdminClient().auth.admin.deleteUser(data.user.id);
+    } catch {
+      // Best-effort cleanup; the lifecycle cleanup job handles abandoned users.
+    }
+
+    return {
+      error: "Unable to prepare guest workspace. Please try again.",
+    };
+  }
+
+  redirect(`/${workspaceSlug}/dashboard`);
 }
 
 export async function signOut(): Promise<void> {

--- a/src/lib/guest/cleanup.ts
+++ b/src/lib/guest/cleanup.ts
@@ -3,6 +3,7 @@ import { createAdminClient } from "../supabase/admin";
 import type { Database } from "../types";
 
 type AdminClient = SupabaseClient<Database>;
+const GUEST_PERSONA_EMAIL_DOMAIN = "guest.flow.local";
 
 export type DeleteGuestAuthUserResult = {
   deleted: boolean;
@@ -34,6 +35,30 @@ function isMissingUserError(error: { message?: string; status?: number } | null)
   return error?.status === 404 || message.includes("not found");
 }
 
+function isGuestPersonaEmail(email: string | null | undefined) {
+  const normalizedEmail = email?.toLowerCase();
+  return (
+    normalizedEmail?.startsWith("persona-") &&
+    normalizedEmail.endsWith(`@${GUEST_PERSONA_EMAIL_DOMAIN}`)
+  ) ?? false;
+}
+
+async function loadGuestPersonaUserIds(
+  admin: AdminClient,
+  workspaceSlug: string,
+) {
+  const { data, error } = await admin
+    .from("profiles")
+    .select("id")
+    .like("email", `persona-${workspaceSlug}-%@${GUEST_PERSONA_EMAIL_DOMAIN}`);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []).map((profile) => profile.id);
+}
+
 export async function deleteAnonymousGuestAuthUser(
   guestUserId: string,
   admin: AdminClient,
@@ -53,6 +78,40 @@ export async function deleteAnonymousGuestAuthUser(
   }
 
   const { error: deleteError } = await admin.auth.admin.deleteUser(guestUserId);
+  if (deleteError) {
+    if (isMissingUserError(deleteError)) {
+      return { deleted: false, skipped: true, reason: "missing" };
+    }
+
+    throw new Error(deleteError.message);
+  }
+
+  return { deleted: true, skipped: false };
+}
+
+export async function deleteGuestPersonaAuthUser(
+  userId: string,
+  admin: AdminClient,
+): Promise<DeleteGuestAuthUserResult> {
+  const { data: profile, error: profileError } = await admin
+    .from("profiles")
+    .select("email")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (profileError) {
+    throw new Error(profileError.message);
+  }
+
+  if (!profile) {
+    return { deleted: false, skipped: true, reason: "missing_profile" };
+  }
+
+  if (!isGuestPersonaEmail(profile.email)) {
+    return { deleted: false, skipped: true, reason: "not_guest_persona" };
+  }
+
+  const { error: deleteError } = await admin.auth.admin.deleteUser(userId);
   if (deleteError) {
     if (isMissingUserError(deleteError)) {
       return { deleted: false, skipped: true, reason: "missing" };
@@ -92,6 +151,7 @@ export async function cleanupExpiredGuestWorkspaces({
   for (const guestWorkspace of guestWorkspaces ?? []) {
     result.scanned += 1;
     const cleanupErrors: string[] = [];
+    let workspaceRemoved = !guestWorkspace.workspace_id;
 
     if (guestWorkspace.workspace_id) {
       const { error: deleteWorkspaceError } = await admin
@@ -103,32 +163,69 @@ export async function cleanupExpiredGuestWorkspaces({
         cleanupErrors.push(deleteWorkspaceError.message);
       } else {
         result.deletedWorkspaces += 1;
+        workspaceRemoved = true;
       }
     }
 
-    try {
-      const authResult = await deleteGuestAuthUser(
-        guestWorkspace.guest_user_id,
-        admin,
-      );
+    if (workspaceRemoved) {
+      try {
+        const authResult = await deleteGuestAuthUser(
+          guestWorkspace.guest_user_id,
+          admin,
+        );
 
-      if (authResult.deleted) {
-        result.deletedAuthUsers += 1;
+        if (authResult.deleted) {
+          result.deletedAuthUsers += 1;
+        }
+
+        if (authResult.skipped) {
+          result.skippedAuthUsers += 1;
+        }
+      } catch (authError) {
+        cleanupErrors.push(
+          authError instanceof Error ? authError.message : String(authError),
+        );
       }
 
-      if (authResult.skipped) {
-        result.skippedAuthUsers += 1;
+      let personaUserIds: string[] = [];
+      try {
+        personaUserIds = await loadGuestPersonaUserIds(
+          admin,
+          guestWorkspace.workspace_slug,
+        );
+      } catch (authError) {
+        cleanupErrors.push(
+          authError instanceof Error ? authError.message : String(authError),
+        );
       }
-    } catch (authError) {
-      cleanupErrors.push(
-        authError instanceof Error ? authError.message : String(authError),
-      );
+
+      for (const personaUserId of personaUserIds) {
+        try {
+          const personaResult = await deleteGuestPersonaAuthUser(
+            personaUserId,
+            admin,
+          );
+
+          if (personaResult.deleted) {
+            result.deletedAuthUsers += 1;
+          }
+
+          if (personaResult.skipped) {
+            result.skippedAuthUsers += 1;
+          }
+        } catch (authError) {
+          cleanupErrors.push(
+            authError instanceof Error ? authError.message : String(authError),
+          );
+        }
+      }
     }
 
+    const cleanupSucceeded = cleanupErrors.length === 0;
     const { error: metadataError } = await admin
       .from("guest_workspaces")
       .update({
-        deleted_at: nowIso,
+        deleted_at: cleanupSucceeded ? nowIso : null,
         cleanup_error: cleanupErrors.length > 0 ? cleanupErrors.join("; ") : null,
       })
       .eq("id", guestWorkspace.id);

--- a/src/lib/guest/cleanup.ts
+++ b/src/lib/guest/cleanup.ts
@@ -1,0 +1,144 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAdminClient } from "../supabase/admin";
+import type { Database } from "../types";
+
+type AdminClient = SupabaseClient<Database>;
+
+export type DeleteGuestAuthUserResult = {
+  deleted: boolean;
+  skipped: boolean;
+  reason?: string;
+};
+
+export type DeleteGuestAuthUser = (
+  guestUserId: string,
+  admin: AdminClient,
+) => Promise<DeleteGuestAuthUserResult>;
+
+export type CleanupExpiredGuestWorkspacesInput = {
+  admin?: AdminClient;
+  now?: Date;
+  deleteGuestAuthUser?: DeleteGuestAuthUser;
+};
+
+export type CleanupExpiredGuestWorkspacesResult = {
+  scanned: number;
+  deletedWorkspaces: number;
+  deletedAuthUsers: number;
+  skippedAuthUsers: number;
+  errors: string[];
+};
+
+function isMissingUserError(error: { message?: string; status?: number } | null) {
+  const message = error?.message?.toLowerCase() ?? "";
+  return error?.status === 404 || message.includes("not found");
+}
+
+export async function deleteAnonymousGuestAuthUser(
+  guestUserId: string,
+  admin: AdminClient,
+): Promise<DeleteGuestAuthUserResult> {
+  const { data, error } = await admin.auth.admin.getUserById(guestUserId);
+
+  if (error) {
+    if (isMissingUserError(error)) {
+      return { deleted: false, skipped: true, reason: "missing" };
+    }
+
+    throw new Error(error.message);
+  }
+
+  if (!data.user?.is_anonymous) {
+    return { deleted: false, skipped: true, reason: "not_anonymous" };
+  }
+
+  const { error: deleteError } = await admin.auth.admin.deleteUser(guestUserId);
+  if (deleteError) {
+    if (isMissingUserError(deleteError)) {
+      return { deleted: false, skipped: true, reason: "missing" };
+    }
+
+    throw new Error(deleteError.message);
+  }
+
+  return { deleted: true, skipped: false };
+}
+
+export async function cleanupExpiredGuestWorkspaces({
+  admin = createAdminClient(),
+  now = new Date(),
+  deleteGuestAuthUser = deleteAnonymousGuestAuthUser,
+}: CleanupExpiredGuestWorkspacesInput = {}): Promise<CleanupExpiredGuestWorkspacesResult> {
+  const nowIso = now.toISOString();
+  const result: CleanupExpiredGuestWorkspacesResult = {
+    scanned: 0,
+    deletedWorkspaces: 0,
+    deletedAuthUsers: 0,
+    skippedAuthUsers: 0,
+    errors: [],
+  };
+
+  const { data: guestWorkspaces, error } = await admin
+    .from("guest_workspaces")
+    .select("*")
+    .lte("expires_at", nowIso)
+    .is("deleted_at", null)
+    .order("expires_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Unable to load expired guest workspaces: ${error.message}`);
+  }
+
+  for (const guestWorkspace of guestWorkspaces ?? []) {
+    result.scanned += 1;
+    const cleanupErrors: string[] = [];
+
+    if (guestWorkspace.workspace_id) {
+      const { error: deleteWorkspaceError } = await admin
+        .from("workspaces")
+        .delete()
+        .eq("id", guestWorkspace.workspace_id);
+
+      if (deleteWorkspaceError) {
+        cleanupErrors.push(deleteWorkspaceError.message);
+      } else {
+        result.deletedWorkspaces += 1;
+      }
+    }
+
+    try {
+      const authResult = await deleteGuestAuthUser(
+        guestWorkspace.guest_user_id,
+        admin,
+      );
+
+      if (authResult.deleted) {
+        result.deletedAuthUsers += 1;
+      }
+
+      if (authResult.skipped) {
+        result.skippedAuthUsers += 1;
+      }
+    } catch (authError) {
+      cleanupErrors.push(
+        authError instanceof Error ? authError.message : String(authError),
+      );
+    }
+
+    const { error: metadataError } = await admin
+      .from("guest_workspaces")
+      .update({
+        deleted_at: nowIso,
+        cleanup_error: cleanupErrors.length > 0 ? cleanupErrors.join("; ") : null,
+      })
+      .eq("id", guestWorkspace.id);
+
+    if (metadataError) {
+      cleanupErrors.push(metadataError.message);
+    }
+
+    result.errors.push(...cleanupErrors);
+  }
+
+  return result;
+}

--- a/src/lib/guest/workspace-clone.ts
+++ b/src/lib/guest/workspace-clone.ts
@@ -7,8 +7,10 @@ export const DEFAULT_GUEST_SOURCE_WORKSPACE_SLUG =
   process.env.GUEST_WORKSPACE_SOURCE_SLUG ?? "pw-workspace";
 
 const GUEST_WORKSPACE_SLUG_PREFIX = "guest-workspace";
+const GUEST_PERSONA_EMAIL_DOMAIN = "guest.flow.local";
 const GUEST_WORKSPACE_LIFETIME_HOURS = 24;
 const MAX_SLUG_ATTEMPTS = 8;
+const FRESH_GUEST_SOURCE_SLUG = "fresh-start";
 
 type AdminClient = SupabaseClient<Database>;
 
@@ -35,6 +37,17 @@ export type CloneGuestWorkspaceResult = {
   lifecycle: Tables<"guest_workspaces">;
   sourceWorkspace: Tables<"workspaces">;
   maps: CloneMaps;
+};
+
+export type CreateFreshGuestWorkspaceInput = {
+  guestUserId: string;
+  now?: Date;
+  admin?: AdminClient;
+};
+
+export type CreateFreshGuestWorkspaceResult = {
+  workspace: Tables<"workspaces">;
+  lifecycle: Tables<"guest_workspaces">;
 };
 
 function addHours(date: Date, hours: number) {
@@ -74,6 +87,27 @@ function mapNullableId(id: string | null, idMap: Map<string, string>) {
   return idMap.get(id) ?? null;
 }
 
+function createGuestPersonaEmail(workspaceSlug: string, index: number) {
+  return `persona-${workspaceSlug}-${index + 1}@${GUEST_PERSONA_EMAIL_DOMAIN}`;
+}
+
+function createGeneratedPassword() {
+  return randomBytes(24).toString("base64url");
+}
+
+function getPersonaDisplayName(
+  profile: Pick<Tables<"profiles">, "full_name" | "email"> | undefined,
+  index: number,
+) {
+  const fullName = profile?.full_name?.trim();
+  if (fullName) return fullName;
+
+  const emailName = profile?.email?.split("@")[0]?.trim();
+  if (emailName) return emailName;
+
+  return `Guest Member ${index + 1}`;
+}
+
 async function loadSourceWorkspace({
   admin,
   sourceWorkspaceId,
@@ -97,11 +131,17 @@ async function loadSourceWorkspace({
 
 async function createUniqueGuestWorkspace({
   admin,
-  sourceWorkspace,
+  template,
   now,
 }: {
   admin: AdminClient;
-  sourceWorkspace: Tables<"workspaces">;
+  template: {
+    name: (suffix: string) => string;
+    issuePrefix: string;
+    issueCounter: number;
+    defaultSprintLength: number;
+    timezone: string;
+  };
   now: Date;
 }) {
   const nowIso = now.toISOString();
@@ -113,12 +153,12 @@ async function createUniqueGuestWorkspace({
     const { data, error } = await admin
       .from("workspaces")
       .insert({
-        name: `Guest Workspace ${suffix.toUpperCase()}`,
+        name: template.name(suffix),
         slug,
-        issue_prefix: sourceWorkspace.issue_prefix,
-        issue_counter: sourceWorkspace.issue_counter,
-        default_sprint_length: sourceWorkspace.default_sprint_length,
-        timezone: sourceWorkspace.timezone,
+        issue_prefix: template.issuePrefix,
+        issue_counter: template.issueCounter,
+        default_sprint_length: template.defaultSprintLength,
+        timezone: template.timezone,
         created_at: nowIso,
         updated_at: nowIso,
       })
@@ -138,6 +178,61 @@ async function createUniqueGuestWorkspace({
   throw new Error(
     `Unable to create a unique guest workspace: ${lastError?.message ?? "unknown error"}`,
   );
+}
+
+async function prepareGuestProfile({
+  admin,
+  guestUserId,
+  workspaceSlug,
+}: {
+  admin: AdminClient;
+  guestUserId: string;
+  workspaceSlug: string;
+}) {
+  const { error } = await admin.from("profiles").upsert(
+    {
+      id: guestUserId,
+      full_name: "Guest User",
+      email: `${workspaceSlug}@${GUEST_PERSONA_EMAIL_DOMAIN}`,
+    },
+    { onConflict: "id" },
+  );
+
+  if (error) {
+    throw new Error(`Unable to prepare guest profile: ${error.message}`);
+  }
+}
+
+async function createGuestLifecycle({
+  admin,
+  clonedWorkspace,
+  sourceWorkspace,
+  sourceWorkspaceSlug,
+  guestUserId,
+  now,
+}: {
+  admin: AdminClient;
+  clonedWorkspace: Tables<"workspaces">;
+  sourceWorkspace?: Tables<"workspaces"> | null;
+  sourceWorkspaceSlug: string;
+  guestUserId: string;
+  now: Date;
+}) {
+  const { data, error } = await admin
+    .from("guest_workspaces")
+    .insert({
+      workspace_id: clonedWorkspace.id,
+      workspace_slug: clonedWorkspace.slug,
+      source_workspace_id: sourceWorkspace?.id ?? null,
+      source_workspace_slug: sourceWorkspace?.slug ?? sourceWorkspaceSlug,
+      guest_user_id: guestUserId,
+      created_at: now.toISOString(),
+      expires_at: addHours(now, GUEST_WORKSPACE_LIFETIME_HOURS).toISOString(),
+    })
+    .select()
+    .single();
+
+  return requireData(data, error, "Unable to create guest lifecycle metadata");
 }
 
 async function insertRows<T extends keyof Database["public"]["Tables"]>(
@@ -164,6 +259,151 @@ function uniqueByUserId(rows: InsertTables<"workspace_members">[]) {
   return [...byUser.values()];
 }
 
+async function loadProfilesById(admin: AdminClient, userIds: string[]) {
+  if (userIds.length === 0) {
+    return new Map<string, Tables<"profiles">>();
+  }
+
+  const { data, error } = await admin
+    .from("profiles")
+    .select("*")
+    .in("id", [...new Set(userIds)]);
+  const profiles = requireData(data, error, "Unable to load source profiles");
+
+  return new Map(profiles.map((profile) => [profile.id, profile]));
+}
+
+async function createGuestPersonaUsers({
+  admin,
+  clonedWorkspace,
+  sourceMemberships,
+  sourceOwnerId,
+  profilesById,
+  userIdMap,
+}: {
+  admin: AdminClient;
+  clonedWorkspace: Tables<"workspaces">;
+  sourceMemberships: Tables<"workspace_members">[];
+  sourceOwnerId: string;
+  profilesById: Map<string, Tables<"profiles">>;
+  userIdMap: Map<string, string>;
+}) {
+  const createdUserIds: string[] = [];
+
+  for (const membership of sourceMemberships) {
+    if (membership.user_id === sourceOwnerId || userIdMap.has(membership.user_id)) {
+      continue;
+    }
+
+    const sourceProfile = profilesById.get(membership.user_id);
+    const email = createGuestPersonaEmail(
+      clonedWorkspace.slug,
+      createdUserIds.length,
+    );
+    const fullName = getPersonaDisplayName(sourceProfile, createdUserIds.length);
+    const { data, error } = await admin.auth.admin.createUser({
+      email,
+      password: createGeneratedPassword(),
+      email_confirm: true,
+      user_metadata: {
+        full_name: fullName,
+        guest_persona: true,
+        guest_workspace_id: clonedWorkspace.id,
+        source_user_id: membership.user_id,
+      },
+    });
+
+    if (error || !data.user) {
+      throw new Error(
+        `Unable to create guest persona for source user ${membership.user_id}: ${
+          error?.message ?? "missing user"
+        }`,
+      );
+    }
+
+    createdUserIds.push(data.user.id);
+    userIdMap.set(membership.user_id, data.user.id);
+
+    const { error: profileError } = await admin
+      .from("profiles")
+      .update({
+        full_name: fullName,
+        email,
+        avatar_url: sourceProfile?.avatar_url ?? null,
+      })
+      .eq("id", data.user.id);
+
+    if (profileError) {
+      throw new Error(
+        `Unable to prepare guest persona profile: ${profileError.message}`,
+      );
+    }
+  }
+
+  return createdUserIds;
+}
+
+export async function createFreshGuestWorkspace({
+  guestUserId,
+  now = new Date(),
+  admin = createAdminClient(),
+}: CreateFreshGuestWorkspaceInput): Promise<CreateFreshGuestWorkspaceResult> {
+  const workspace = await createUniqueGuestWorkspace({
+    admin,
+    template: {
+      name: () => "Fresh Workspace",
+      issuePrefix: "FLO",
+      issueCounter: 0,
+      defaultSprintLength: 14,
+      timezone: "UTC",
+    },
+    now,
+  });
+
+  let lifecycle: Tables<"guest_workspaces"> | null = null;
+
+  try {
+    await prepareGuestProfile({
+      admin,
+      guestUserId,
+      workspaceSlug: workspace.slug,
+    });
+
+    lifecycle = await createGuestLifecycle({
+      admin,
+      clonedWorkspace: workspace,
+      sourceWorkspace: null,
+      sourceWorkspaceSlug: FRESH_GUEST_SOURCE_SLUG,
+      guestUserId,
+      now,
+    });
+
+    const { error: membershipError } = await admin
+      .from("workspace_members")
+      .insert({
+        id: randomUUID(),
+        workspace_id: workspace.id,
+        user_id: guestUserId,
+        role: "owner",
+        created_at: now.toISOString(),
+        updated_at: now.toISOString(),
+      });
+
+    if (membershipError) {
+      throw new Error(`Unable to create guest workspace owner: ${membershipError.message}`);
+    }
+
+    return { workspace, lifecycle };
+  } catch (error) {
+    if (lifecycle) {
+      await admin.from("guest_workspaces").delete().eq("id", lifecycle.id);
+    }
+
+    await admin.from("workspaces").delete().eq("id", workspace.id);
+    throw error;
+  }
+}
+
 export async function cloneGuestWorkspace({
   guestUserId,
   sourceWorkspaceSlug = DEFAULT_GUEST_SOURCE_WORKSPACE_SLUG,
@@ -179,47 +419,33 @@ export async function cloneGuestWorkspace({
 
   const clonedWorkspace = await createUniqueGuestWorkspace({
     admin,
-    sourceWorkspace,
+    template: {
+      name: (suffix) => `Guest Workspace ${suffix.toUpperCase()}`,
+      issuePrefix: sourceWorkspace.issue_prefix,
+      issueCounter: sourceWorkspace.issue_counter,
+      defaultSprintLength: sourceWorkspace.default_sprint_length,
+      timezone: sourceWorkspace.timezone,
+    },
     now,
   });
 
   let lifecycle: Tables<"guest_workspaces"> | null = null;
+  let createdPersonaUserIds: string[] = [];
 
   try {
-    const expiresAt = addHours(now, GUEST_WORKSPACE_LIFETIME_HOURS).toISOString();
-
-    const { error: profileError } = await admin.from("profiles").upsert(
-      {
-        id: guestUserId,
-        full_name: "Guest User",
-        email: `${clonedWorkspace.slug}@guest.flow.local`,
-      },
-      { onConflict: "id" },
-    );
-
-    if (profileError) {
-      throw new Error(`Unable to prepare guest profile: ${profileError.message}`);
-    }
-
-    const { data: lifecycleData, error: lifecycleError } = await admin
-      .from("guest_workspaces")
-      .insert({
-        workspace_id: clonedWorkspace.id,
-        workspace_slug: clonedWorkspace.slug,
-        source_workspace_id: sourceWorkspace.id,
-        source_workspace_slug: sourceWorkspace.slug,
-        guest_user_id: guestUserId,
-        created_at: now.toISOString(),
-        expires_at: expiresAt,
-      })
-      .select()
-      .single();
-
-    lifecycle = requireData(
-      lifecycleData,
-      lifecycleError,
-      "Unable to create guest lifecycle metadata",
-    );
+    await prepareGuestProfile({
+      admin,
+      guestUserId,
+      workspaceSlug: clonedWorkspace.slug,
+    });
+    lifecycle = await createGuestLifecycle({
+      admin,
+      clonedWorkspace,
+      sourceWorkspace,
+      sourceWorkspaceSlug: sourceWorkspace.slug,
+      guestUserId,
+      now,
+    });
 
     const [
       sourceMembershipsResult,
@@ -290,6 +516,19 @@ export async function cloneGuestWorkspace({
     }
 
     const userIdMap = new Map<string, string>([[sourceOwner.user_id, guestUserId]]);
+    const profilesById = await loadProfilesById(
+      admin,
+      sourceMemberships.map((membership) => membership.user_id),
+    );
+    createdPersonaUserIds = await createGuestPersonaUsers({
+      admin,
+      clonedWorkspace,
+      sourceMemberships,
+      sourceOwnerId: sourceOwner.user_id,
+      profilesById,
+      userIdMap,
+    });
+
     const mapUserId = (userId: string | null) => {
       if (!userId) return null;
       return userIdMap.get(userId) ?? userId;
@@ -545,6 +784,11 @@ export async function cloneGuestWorkspace({
     }
 
     await admin.from("workspaces").delete().eq("id", clonedWorkspace.id);
+    await Promise.all(
+      createdPersonaUserIds.map((userId) =>
+        admin.auth.admin.deleteUser(userId).catch(() => undefined),
+      ),
+    );
     throw error;
   }
 }

--- a/src/lib/guest/workspace-clone.ts
+++ b/src/lib/guest/workspace-clone.ts
@@ -1,0 +1,550 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAdminClient } from "../supabase/admin";
+import type { Database, InsertTables, Tables } from "../types";
+
+export const DEFAULT_GUEST_SOURCE_WORKSPACE_SLUG =
+  process.env.GUEST_WORKSPACE_SOURCE_SLUG ?? "pw-workspace";
+
+const GUEST_WORKSPACE_SLUG_PREFIX = "guest-workspace";
+const GUEST_WORKSPACE_LIFETIME_HOURS = 24;
+const MAX_SLUG_ATTEMPTS = 8;
+
+type AdminClient = SupabaseClient<Database>;
+
+type CloneMaps = {
+  workspaceId: string;
+  users: Map<string, string>;
+  teams: Map<string, string>;
+  projects: Map<string, string>;
+  labels: Map<string, string>;
+  sprints: Map<string, string>;
+  issues: Map<string, string>;
+};
+
+export type CloneGuestWorkspaceInput = {
+  guestUserId: string;
+  sourceWorkspaceSlug?: string;
+  sourceWorkspaceId?: string;
+  now?: Date;
+  admin?: AdminClient;
+};
+
+export type CloneGuestWorkspaceResult = {
+  workspace: Tables<"workspaces">;
+  lifecycle: Tables<"guest_workspaces">;
+  sourceWorkspace: Tables<"workspaces">;
+  maps: CloneMaps;
+};
+
+function addHours(date: Date, hours: number) {
+  return new Date(date.getTime() + hours * 60 * 60 * 1000);
+}
+
+function createSlugSuffix() {
+  return randomBytes(4).toString("hex");
+}
+
+function isUniqueViolation(error: { code?: string; message?: string } | null) {
+  return (
+    error?.code === "23505" ||
+    error?.message?.toLowerCase().includes("duplicate") ||
+    error?.message?.toLowerCase().includes("unique")
+  );
+}
+
+function requireData<T>(
+  data: T | null,
+  error: { message: string } | null,
+  message: string,
+): T {
+  if (error) {
+    throw new Error(`${message}: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(message);
+  }
+
+  return data;
+}
+
+function mapNullableId(id: string | null, idMap: Map<string, string>) {
+  if (!id) return null;
+  return idMap.get(id) ?? null;
+}
+
+async function loadSourceWorkspace({
+  admin,
+  sourceWorkspaceId,
+  sourceWorkspaceSlug,
+}: {
+  admin: AdminClient;
+  sourceWorkspaceId?: string;
+  sourceWorkspaceSlug: string;
+}) {
+  const query = admin.from("workspaces").select("*");
+  const { data, error } = sourceWorkspaceId
+    ? await query.eq("id", sourceWorkspaceId).maybeSingle()
+    : await query.eq("slug", sourceWorkspaceSlug).maybeSingle();
+
+  return requireData(
+    data,
+    error,
+    `Unable to load guest source workspace '${sourceWorkspaceId ?? sourceWorkspaceSlug}'`,
+  );
+}
+
+async function createUniqueGuestWorkspace({
+  admin,
+  sourceWorkspace,
+  now,
+}: {
+  admin: AdminClient;
+  sourceWorkspace: Tables<"workspaces">;
+  now: Date;
+}) {
+  const nowIso = now.toISOString();
+  let lastError: { message: string } | null = null;
+
+  for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt++) {
+    const suffix = createSlugSuffix();
+    const slug = `${GUEST_WORKSPACE_SLUG_PREFIX}-${suffix}`;
+    const { data, error } = await admin
+      .from("workspaces")
+      .insert({
+        name: `Guest Workspace ${suffix.toUpperCase()}`,
+        slug,
+        issue_prefix: sourceWorkspace.issue_prefix,
+        issue_counter: sourceWorkspace.issue_counter,
+        default_sprint_length: sourceWorkspace.default_sprint_length,
+        timezone: sourceWorkspace.timezone,
+        created_at: nowIso,
+        updated_at: nowIso,
+      })
+      .select()
+      .single();
+
+    if (!error && data) {
+      return data;
+    }
+
+    lastError = error;
+    if (!isUniqueViolation(error)) {
+      break;
+    }
+  }
+
+  throw new Error(
+    `Unable to create a unique guest workspace: ${lastError?.message ?? "unknown error"}`,
+  );
+}
+
+async function insertRows<T extends keyof Database["public"]["Tables"]>(
+  admin: AdminClient,
+  table: T,
+  rows: InsertTables<T>[],
+  message: string,
+) {
+  if (rows.length === 0) return [];
+
+  const { data, error } = await admin.from(table).insert(rows as never[]).select();
+  return requireData(data, error, message);
+}
+
+function uniqueByUserId(rows: InsertTables<"workspace_members">[]) {
+  const byUser = new Map<string, InsertTables<"workspace_members">>();
+
+  for (const row of rows) {
+    if (!byUser.has(row.user_id) || row.role === "owner") {
+      byUser.set(row.user_id, row);
+    }
+  }
+
+  return [...byUser.values()];
+}
+
+export async function cloneGuestWorkspace({
+  guestUserId,
+  sourceWorkspaceSlug = DEFAULT_GUEST_SOURCE_WORKSPACE_SLUG,
+  sourceWorkspaceId,
+  now = new Date(),
+  admin = createAdminClient(),
+}: CloneGuestWorkspaceInput): Promise<CloneGuestWorkspaceResult> {
+  const sourceWorkspace = await loadSourceWorkspace({
+    admin,
+    sourceWorkspaceId,
+    sourceWorkspaceSlug,
+  });
+
+  const clonedWorkspace = await createUniqueGuestWorkspace({
+    admin,
+    sourceWorkspace,
+    now,
+  });
+
+  let lifecycle: Tables<"guest_workspaces"> | null = null;
+
+  try {
+    const expiresAt = addHours(now, GUEST_WORKSPACE_LIFETIME_HOURS).toISOString();
+
+    const { error: profileError } = await admin.from("profiles").upsert(
+      {
+        id: guestUserId,
+        full_name: "Guest User",
+        email: `${clonedWorkspace.slug}@guest.flow.local`,
+      },
+      { onConflict: "id" },
+    );
+
+    if (profileError) {
+      throw new Error(`Unable to prepare guest profile: ${profileError.message}`);
+    }
+
+    const { data: lifecycleData, error: lifecycleError } = await admin
+      .from("guest_workspaces")
+      .insert({
+        workspace_id: clonedWorkspace.id,
+        workspace_slug: clonedWorkspace.slug,
+        source_workspace_id: sourceWorkspace.id,
+        source_workspace_slug: sourceWorkspace.slug,
+        guest_user_id: guestUserId,
+        created_at: now.toISOString(),
+        expires_at: expiresAt,
+      })
+      .select()
+      .single();
+
+    lifecycle = requireData(
+      lifecycleData,
+      lifecycleError,
+      "Unable to create guest lifecycle metadata",
+    );
+
+    const [
+      sourceMembershipsResult,
+      sourceTeamsResult,
+      sourceProjectsResult,
+      sourceSprintsResult,
+      sourceIssuesResult,
+    ] = await Promise.all([
+      admin
+        .from("workspace_members")
+        .select("*")
+        .eq("workspace_id", sourceWorkspace.id)
+        .order("created_at", { ascending: true }),
+      admin
+        .from("teams")
+        .select("*")
+        .eq("workspace_id", sourceWorkspace.id)
+        .order("created_at", { ascending: true }),
+      admin
+        .from("projects")
+        .select("*")
+        .eq("workspace_id", sourceWorkspace.id)
+        .order("created_at", { ascending: true }),
+      admin
+        .from("sprints")
+        .select("*")
+        .eq("workspace_id", sourceWorkspace.id)
+        .order("created_at", { ascending: true }),
+      admin
+        .from("issues")
+        .select("*")
+        .eq("workspace_id", sourceWorkspace.id)
+        .order("issue_number", { ascending: true }),
+    ]);
+
+    const sourceMemberships = requireData(
+      sourceMembershipsResult.data,
+      sourceMembershipsResult.error,
+      "Unable to load source workspace members",
+    );
+    const sourceTeams = requireData(
+      sourceTeamsResult.data,
+      sourceTeamsResult.error,
+      "Unable to load source teams",
+    );
+    const sourceProjects = requireData(
+      sourceProjectsResult.data,
+      sourceProjectsResult.error,
+      "Unable to load source projects",
+    );
+    const sourceSprints = requireData(
+      sourceSprintsResult.data,
+      sourceSprintsResult.error,
+      "Unable to load source sprints",
+    );
+    const sourceIssues = requireData(
+      sourceIssuesResult.data,
+      sourceIssuesResult.error,
+      "Unable to load source issues",
+    );
+
+    const sourceOwner =
+      sourceMemberships.find((membership) => membership.role === "owner") ??
+      sourceMemberships[0];
+
+    if (!sourceOwner) {
+      throw new Error("Guest source workspace must have at least one member");
+    }
+
+    const userIdMap = new Map<string, string>([[sourceOwner.user_id, guestUserId]]);
+    const mapUserId = (userId: string | null) => {
+      if (!userId) return null;
+      return userIdMap.get(userId) ?? userId;
+    };
+
+    const teamIdMap = new Map<string, string>();
+    const projectIdMap = new Map<string, string>();
+    const labelIdMap = new Map<string, string>();
+    const sprintIdMap = new Map<string, string>();
+    const issueIdMap = new Map<string, string>();
+
+    const membershipRows = uniqueByUserId(
+      sourceMemberships.map((membership) => {
+        const mappedUserId = mapUserId(membership.user_id)!;
+
+        return {
+          id: randomUUID(),
+          workspace_id: clonedWorkspace.id,
+          user_id: mappedUserId,
+          role: mappedUserId === guestUserId ? "owner" : membership.role,
+          created_at: now.toISOString(),
+          updated_at: now.toISOString(),
+        };
+      }),
+    );
+
+    await insertRows(
+      admin,
+      "workspace_members",
+      membershipRows,
+      "Unable to clone workspace members",
+    );
+
+    const teamRows: InsertTables<"teams">[] = sourceTeams.map((team) => {
+      const id = randomUUID();
+      teamIdMap.set(team.id, id);
+
+      return {
+        id,
+        workspace_id: clonedWorkspace.id,
+        name: team.name,
+        created_at: team.created_at,
+        updated_at: team.updated_at,
+      };
+    });
+
+    await insertRows(admin, "teams", teamRows, "Unable to clone teams");
+
+    const teamMemberRows: InsertTables<"team_members">[] = [];
+    if (sourceTeams.length > 0) {
+      const { data: sourceTeamMembers, error: sourceTeamMembersError } = await admin
+        .from("team_members")
+        .select("*")
+        .in(
+          "team_id",
+          sourceTeams.map((team) => team.id),
+        );
+
+      const teamMembers = requireData(
+        sourceTeamMembers,
+        sourceTeamMembersError,
+        "Unable to load source team members",
+      );
+
+      for (const teamMember of teamMembers) {
+        const teamId = teamIdMap.get(teamMember.team_id);
+        if (!teamId) continue;
+
+        teamMemberRows.push({
+          id: randomUUID(),
+          team_id: teamId,
+          user_id: mapUserId(teamMember.user_id)!,
+        });
+      }
+    }
+
+    await insertRows(
+      admin,
+      "team_members",
+      teamMemberRows,
+      "Unable to clone team members",
+    );
+
+    const projectRows: InsertTables<"projects">[] = sourceProjects.map((project) => {
+      const id = randomUUID();
+      projectIdMap.set(project.id, id);
+
+      return {
+        id,
+        workspace_id: clonedWorkspace.id,
+        name: project.name,
+        description: project.description,
+        color: project.color,
+        lead_id: mapUserId(project.lead_id),
+        team_id: mapNullableId(project.team_id, teamIdMap),
+        is_private: project.is_private,
+        is_archived: project.is_archived,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+      };
+    });
+
+    await insertRows(admin, "projects", projectRows, "Unable to clone projects");
+
+    for (const membership of sourceMemberships) {
+      if (!membership.primary_project_id) continue;
+
+      const mappedProjectId = projectIdMap.get(membership.primary_project_id);
+      if (!mappedProjectId) continue;
+
+      const mappedUserId = mapUserId(membership.user_id)!;
+      const { error } = await admin
+        .from("workspace_members")
+        .update({ primary_project_id: mappedProjectId })
+        .eq("workspace_id", clonedWorkspace.id)
+        .eq("user_id", mappedUserId);
+
+      if (error) {
+        throw new Error(`Unable to remap member primary project: ${error.message}`);
+      }
+    }
+
+    const sourceProjectIds = sourceProjects.map((project) => project.id);
+    const { data: labelData, error: labelError } =
+      sourceProjectIds.length > 0
+        ? await admin.from("labels").select("*").in("project_id", sourceProjectIds)
+        : { data: [], error: null };
+
+    const labels = requireData(labelData, labelError, "Unable to load source labels");
+    const labelRows: InsertTables<"labels">[] = labels.map((label) => {
+      const id = randomUUID();
+      labelIdMap.set(label.id, id);
+
+      return {
+        id,
+        project_id: projectIdMap.get(label.project_id)!,
+        name: label.name,
+        color: label.color,
+      };
+    });
+
+    await insertRows(admin, "labels", labelRows, "Unable to clone labels");
+
+    const sprintRows: InsertTables<"sprints">[] = sourceSprints.map((sprint) => {
+      const id = randomUUID();
+      sprintIdMap.set(sprint.id, id);
+
+      return {
+        id,
+        workspace_id: clonedWorkspace.id,
+        project_id: projectIdMap.get(sprint.project_id)!,
+        name: sprint.name,
+        goal: sprint.goal,
+        status: sprint.status,
+        start_date: sprint.start_date,
+        end_date: sprint.end_date,
+        capacity: sprint.capacity,
+        created_at: sprint.created_at,
+        updated_at: sprint.updated_at,
+      };
+    });
+
+    await insertRows(admin, "sprints", sprintRows, "Unable to clone sprints");
+
+    const issueRows: InsertTables<"issues">[] = sourceIssues.map((issue) => {
+      const id = randomUUID();
+      issueIdMap.set(issue.id, id);
+
+      return {
+        id,
+        workspace_id: clonedWorkspace.id,
+        project_id: projectIdMap.get(issue.project_id)!,
+        issue_number: issue.issue_number,
+        issue_key: issue.issue_key,
+        title: issue.title,
+        description: issue.description,
+        status: issue.status,
+        priority: issue.priority,
+        assignee_id: mapUserId(issue.assignee_id),
+        parent_id: null,
+        sprint_id: mapNullableId(issue.sprint_id, sprintIdMap),
+        due_date: issue.due_date,
+        story_points: issue.story_points,
+        sort_order: issue.sort_order,
+        created_by: mapUserId(issue.created_by)!,
+        completed_at: issue.completed_at,
+        checklist: issue.checklist,
+        created_at: issue.created_at,
+        updated_at: issue.updated_at,
+      };
+    });
+
+    await insertRows(admin, "issues", issueRows, "Unable to clone issues");
+
+    for (const issue of sourceIssues) {
+      const mappedParentId = mapNullableId(issue.parent_id, issueIdMap);
+      if (!mappedParentId) continue;
+
+      const { error } = await admin
+        .from("issues")
+        .update({ parent_id: mappedParentId })
+        .eq("id", issueIdMap.get(issue.id)!);
+
+      if (error) {
+        throw new Error(`Unable to remap parent issue: ${error.message}`);
+      }
+    }
+
+    const sourceIssueIds = sourceIssues.map((issue) => issue.id);
+    const { data: issueLabelData, error: issueLabelError } =
+      sourceIssueIds.length > 0
+        ? await admin.from("issue_labels").select("*").in("issue_id", sourceIssueIds)
+        : { data: [], error: null };
+
+    const issueLabels = requireData(
+      issueLabelData,
+      issueLabelError,
+      "Unable to load source issue labels",
+    );
+    const issueLabelRows: InsertTables<"issue_labels">[] = issueLabels.flatMap(
+      (issueLabel) => {
+        const issueId = issueIdMap.get(issueLabel.issue_id);
+        const labelId = labelIdMap.get(issueLabel.label_id);
+
+        return issueId && labelId ? [{ issue_id: issueId, label_id: labelId }] : [];
+      },
+    );
+
+    await insertRows(
+      admin,
+      "issue_labels",
+      issueLabelRows,
+      "Unable to clone issue labels",
+    );
+
+    return {
+      workspace: clonedWorkspace,
+      lifecycle,
+      sourceWorkspace,
+      maps: {
+        workspaceId: clonedWorkspace.id,
+        users: userIdMap,
+        teams: teamIdMap,
+        projects: projectIdMap,
+        labels: labelIdMap,
+        sprints: sprintIdMap,
+        issues: issueIdMap,
+      },
+    };
+  } catch (error) {
+    if (lifecycle) {
+      await admin.from("guest_workspaces").delete().eq("id", lifecycle.id);
+    }
+
+    await admin.from("workspaces").delete().eq("id", clonedWorkspace.id);
+    throw error;
+  }
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -84,6 +84,60 @@ export type Database = {
         };
         Relationships: [];
       };
+      guest_workspaces: {
+        Row: {
+          id: string;
+          workspace_id: string | null;
+          workspace_slug: string;
+          source_workspace_id: string | null;
+          source_workspace_slug: string;
+          guest_user_id: string;
+          created_at: string;
+          expires_at: string;
+          deleted_at: string | null;
+          cleanup_error: string | null;
+        };
+        Insert: {
+          id?: string;
+          workspace_id?: string | null;
+          workspace_slug: string;
+          source_workspace_id?: string | null;
+          source_workspace_slug: string;
+          guest_user_id: string;
+          created_at?: string;
+          expires_at: string;
+          deleted_at?: string | null;
+          cleanup_error?: string | null;
+        };
+        Update: {
+          id?: string;
+          workspace_id?: string | null;
+          workspace_slug?: string;
+          source_workspace_id?: string | null;
+          source_workspace_slug?: string;
+          guest_user_id?: string;
+          created_at?: string;
+          expires_at?: string;
+          deleted_at?: string | null;
+          cleanup_error?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "guest_workspaces_workspace_id_fkey";
+            columns: ["workspace_id"];
+            isOneToOne: true;
+            referencedRelation: "workspaces";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "guest_workspaces_source_workspace_id_fkey";
+            columns: ["source_workspace_id"];
+            isOneToOne: false;
+            referencedRelation: "workspaces";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       workspace_members: {
         Row: {
           id: string;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,8 +17,34 @@ function getRequestedPath(request: NextRequest) {
   return `${request.nextUrl.pathname}${search}`;
 }
 
+function applyRedirectPath(url: URL, path: string) {
+  const [pathname, search = ""] = path.split("?");
+  url.pathname = pathname;
+  url.search = search ? `?${search}` : "";
+}
+
+async function getDefaultSignedInPath(
+  supabase: Awaited<ReturnType<typeof updateSession>>["supabase"],
+  userId: string,
+) {
+  const { data: membership } = await supabase
+    .from("workspace_members")
+    .select("workspace:workspaces(slug)")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  const workspace = membership?.workspace as { slug: string } | null | undefined;
+  if (workspace?.slug) {
+    return `/${workspace.slug}/dashboard`;
+  }
+
+  return "/onboarding";
+}
+
 export async function proxy(request: NextRequest) {
-  const { user, supabaseResponse } = await updateSession(request);
+  const { user, supabase, supabaseResponse } = await updateSession(request);
   const { pathname } = request.nextUrl;
 
   const isLandingPage = pathname === "/";
@@ -36,8 +62,7 @@ export async function proxy(request: NextRequest) {
   if (user && isAuthPage) {
     const nextPath = normalizeRedirectPath(request.nextUrl.searchParams.get("next"));
     const url = request.nextUrl.clone();
-    url.pathname = nextPath ?? "/";
-    url.search = "";
+    applyRedirectPath(url, nextPath ?? (await getDefaultSignedInPath(supabase, user.id)));
     return NextResponse.redirect(url);
   }
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -168,7 +168,7 @@ refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
 # Allow/disallow anonymous sign-ins to your project.
-enable_anonymous_sign_ins = false
+enable_anonymous_sign_ins = true
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.

--- a/supabase/migrations/00024_guest_workspaces.sql
+++ b/supabase/migrations/00024_guest_workspaces.sql
@@ -1,0 +1,24 @@
+-- 00024_guest_workspaces.sql
+-- Lifecycle metadata for isolated anonymous guest demo workspaces.
+
+create table public.guest_workspaces (
+  id                    uuid primary key default gen_random_uuid(),
+  workspace_id          uuid unique references public.workspaces(id) on delete set null,
+  workspace_slug        text not null,
+  source_workspace_id   uuid references public.workspaces(id) on delete set null,
+  source_workspace_slug text not null,
+  guest_user_id         uuid not null,
+  created_at            timestamptz not null default now(),
+  expires_at            timestamptz not null,
+  deleted_at            timestamptz,
+  cleanup_error         text
+);
+
+create index idx_guest_workspaces_expires_at
+  on public.guest_workspaces (expires_at)
+  where deleted_at is null;
+
+create index idx_guest_workspaces_guest_user_id
+  on public.guest_workspaces (guest_user_id);
+
+alter table public.guest_workspaces enable row level security;

--- a/tests/guest-workspaces.spec.ts
+++ b/tests/guest-workspaces.spec.ts
@@ -2,7 +2,11 @@ import { expect, test } from "@playwright/test";
 import { randomUUID } from "node:crypto";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database, Tables } from "../src/lib/types";
-import { cloneGuestWorkspace } from "../src/lib/guest/workspace-clone";
+import {
+  cloneGuestWorkspace,
+  createFreshGuestWorkspace,
+  type CloneGuestWorkspaceResult,
+} from "../src/lib/guest/workspace-clone";
 import { cleanupExpiredGuestWorkspaces } from "../src/lib/guest/cleanup";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -15,6 +19,7 @@ type SourceFixture = {
   workspace: Tables<"workspaces">;
   ownerId: string;
   memberId: string;
+  memberEmail: string;
   teamId: string;
   projectId: string;
   sprintId: string;
@@ -49,7 +54,8 @@ async function createUser(email: string, fullName: string) {
 
 async function createSourceFixture(): Promise<SourceFixture> {
   const ownerId = await createUser(`guest-owner-${RUN_ID}@test.flow.dev`, "Guest Source Owner");
-  const memberId = await createUser(`guest-member-${RUN_ID}@test.flow.dev`, "Guest Source Member");
+  const memberEmail = `guest-member-${RUN_ID}@test.flow.dev`;
+  const memberId = await createUser(memberEmail, "Guest Source Member");
 
   const { data: workspace, error: workspaceError } = await admin
     .from("workspaces")
@@ -210,6 +216,7 @@ async function createSourceFixture(): Promise<SourceFixture> {
     workspace: { ...workspace, issue_counter: 2 },
     ownerId,
     memberId,
+    memberEmail,
     teamId: team.id,
     projectId: project.id,
     sprintId: sprint.id,
@@ -229,6 +236,15 @@ async function getWorkspaceShape(workspaceId: string) {
     ]);
 
   return { projects, teams, sprints, issues };
+}
+
+function getClonedPersonaUserIds(
+  clone: CloneGuestWorkspaceResult,
+  fixture: SourceFixture,
+) {
+  return [...clone.maps.users.entries()]
+    .filter(([sourceUserId]) => sourceUserId !== fixture.ownerId)
+    .map(([, clonedUserId]) => clonedUserId);
 }
 
 test.describe.serial("guest workspace cloning and cleanup", () => {
@@ -263,6 +279,10 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
     });
     workspaceIds.push(clone.workspace.id);
     lifecycleIds.push(clone.lifecycle.id);
+    const clonedMemberId = clone.maps.users.get(source.memberId);
+    expect(clonedMemberId).toBeTruthy();
+    expect(clonedMemberId).not.toBe(source.memberId);
+    userIds.push(...getClonedPersonaUserIds(clone, source));
 
     expect(clone.workspace.slug).toMatch(/^guest-workspace-[a-f0-9]{8}$/);
     expect(clone.workspace.issue_prefix).toBe(source.workspace.issue_prefix);
@@ -277,7 +297,8 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
       .select("*")
       .eq("workspace_id", clone.workspace.id);
     expect(memberships?.find((member) => member.user_id === guestId)?.role).toBe("owner");
-    expect(memberships?.some((member) => member.user_id === source.memberId)).toBe(true);
+    expect(memberships?.some((member) => member.user_id === clonedMemberId)).toBe(true);
+    expect(memberships?.some((member) => member.user_id === source.memberId)).toBe(false);
     expect(memberships?.some((member) => member.user_id === source.ownerId)).toBe(false);
 
     const { data: teams } = await admin
@@ -292,7 +313,7 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
       .select("*")
       .eq("team_id", teams![0].id);
     expect(teamMembers?.map((member) => member.user_id).sort()).toEqual(
-      [guestId, source.memberId].sort(),
+      [guestId, clonedMemberId].sort(),
     );
 
     const { data: projects } = await admin
@@ -331,14 +352,14 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
     expect(parentIssue.id).not.toBe(source.parentIssueId);
     expect(parentIssue.project_id).toBe(clonedProject.id);
     expect(parentIssue.assignee_id).toBe(guestId);
-    expect(parentIssue.created_by).toBe(source.memberId);
+    expect(parentIssue.created_by).toBe(clonedMemberId);
     expect(parentIssue.checklist).toEqual([
       { id: expect.any(String), text: "Confirm guest clone", completed: true },
       { id: expect.any(String), text: "Verify issue counter", completed: false },
     ]);
     expect(childIssue.parent_id).toBe(parentIssue.id);
     expect(childIssue.created_by).toBe(guestId);
-    expect(childIssue.assignee_id).toBe(source.memberId);
+    expect(childIssue.assignee_id).toBe(clonedMemberId);
 
     const { data: issueLabels } = await admin
       .from("issue_labels")
@@ -371,7 +392,78 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
     expect(newIssue?.issue_key).toBe("GST-3");
     await guestClient.auth.signOut();
 
+    const sourceMemberClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
+    const { error: sourceMemberSignInError } = await sourceMemberClient.auth.signInWithPassword({
+      email: source.memberEmail,
+      password: TEST_PASSWORD,
+    });
+    expect(sourceMemberSignInError).toBeNull();
+
+    const { data: sourceMemberWorkspace, error: sourceMemberWorkspaceError } =
+      await sourceMemberClient
+        .from("workspaces")
+        .select("id")
+        .eq("id", clone.workspace.id)
+        .maybeSingle();
+    expect(sourceMemberWorkspaceError).toBeNull();
+    expect(sourceMemberWorkspace).toBeNull();
+    await sourceMemberClient.auth.signOut();
+
     expect(await getWorkspaceShape(source.workspace.id)).toEqual(sourceShapeBefore);
+  });
+
+  test("creates a fresh guest workspace without demo data", async () => {
+    const guestId = await createUser(`fresh-start-guest-${RUN_ID}@test.flow.dev`, "Fresh Start Guest");
+
+    const fresh = await createFreshGuestWorkspace({
+      admin,
+      guestUserId: guestId,
+      now: new Date("2030-01-01T00:00:00.000Z"),
+    });
+    workspaceIds.push(fresh.workspace.id);
+    lifecycleIds.push(fresh.lifecycle.id);
+
+    expect(fresh.workspace.name).toBe("Fresh Workspace");
+    expect(fresh.workspace.slug).toMatch(/^guest-workspace-[a-f0-9]{8}$/);
+    expect(fresh.workspace.issue_counter).toBe(0);
+    expect(fresh.lifecycle.guest_user_id).toBe(guestId);
+    expect(fresh.lifecycle.source_workspace_id).toBeNull();
+    expect(fresh.lifecycle.source_workspace_slug).toBe("fresh-start");
+    expect(new Date(fresh.lifecycle.expires_at).getTime()).toBe(
+      new Date("2030-01-02T00:00:00.000Z").getTime(),
+    );
+
+    const { data: memberships } = await admin
+      .from("workspace_members")
+      .select("*")
+      .eq("workspace_id", fresh.workspace.id);
+    expect(memberships).toHaveLength(1);
+    expect(memberships?.[0].user_id).toBe(guestId);
+    expect(memberships?.[0].role).toBe("owner");
+
+    expect(await getWorkspaceShape(fresh.workspace.id)).toEqual({
+      projects: 0,
+      teams: 0,
+      sprints: 0,
+      issues: 0,
+    });
+
+    const guestClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
+    const { error: signInError } = await guestClient.auth.signInWithPassword({
+      email: `fresh-start-guest-${RUN_ID}@test.flow.dev`,
+      password: TEST_PASSWORD,
+    });
+    expect(signInError).toBeNull();
+
+    const { data: visibleWorkspace, error: visibleWorkspaceError } =
+      await guestClient
+        .from("workspaces")
+        .select("id")
+        .eq("id", fresh.workspace.id)
+        .single();
+    expect(visibleWorkspaceError).toBeNull();
+    expect(visibleWorkspace?.id).toBe(fresh.workspace.id);
+    await guestClient.auth.signOut();
   });
 
   test("removes expired guest workspaces and preserves active ones idempotently", async () => {
@@ -387,6 +479,8 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
     });
     workspaceIds.push(expired.workspace.id);
     lifecycleIds.push(expired.lifecycle.id);
+    const expiredPersonaUserIds = getClonedPersonaUserIds(expired, source);
+    userIds.push(...expiredPersonaUserIds);
 
     const fresh = await cloneGuestWorkspace({
       admin,
@@ -396,6 +490,7 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
     });
     workspaceIds.push(fresh.workspace.id);
     lifecycleIds.push(fresh.lifecycle.id);
+    userIds.push(...getClonedPersonaUserIds(fresh, source));
 
     const { data: missingLifecycle, error: missingLifecycleError } = await admin
       .from("guest_workspaces")
@@ -425,7 +520,7 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
 
     expect(firstCleanup.scanned).toBe(2);
     expect(firstCleanup.deletedWorkspaces).toBe(1);
-    expect(firstCleanup.deletedAuthUsers).toBe(2);
+    expect(firstCleanup.deletedAuthUsers).toBe(3);
     expect(firstCleanup.errors).toEqual([]);
     expect(authDeletes.sort()).toEqual([expiredGuestId, missingGuestId].sort());
 
@@ -451,11 +546,73 @@ test.describe.serial("guest workspace cloning and cleanup", () => {
     expect(lifecycles?.find((row) => row.id === missingLifecycle!.id)?.deleted_at).toBeTruthy();
     expect(lifecycles?.find((row) => row.id === fresh.lifecycle.id)?.deleted_at).toBeNull();
 
+    const { data: expiredPersonaProfile } = await admin
+      .from("profiles")
+      .select("id")
+      .eq("id", expiredPersonaUserIds[0]!)
+      .maybeSingle();
+    expect(expiredPersonaProfile).toBeNull();
+
     const secondCleanup = await cleanupExpiredGuestWorkspaces({
       admin,
       now: new Date("2026-01-02T01:00:00.000Z"),
       deleteGuestAuthUser: async () => ({ deleted: true, skipped: false }),
     });
     expect(secondCleanup.scanned).toBe(0);
+  });
+
+  test("keeps failed cleanup records retryable", async () => {
+    const retryGuestId = await createUser(`retry-guest-${RUN_ID}@test.flow.dev`, "Retry Guest");
+    const { data: retryLifecycle, error: retryLifecycleError } = await admin
+      .from("guest_workspaces")
+      .insert({
+        workspace_id: null,
+        workspace_slug: `retry-deleted-${RUN_ID}`,
+        source_workspace_id: source.workspace.id,
+        source_workspace_slug: source.workspace.slug,
+        guest_user_id: retryGuestId,
+        created_at: "2026-01-01T00:00:00.000Z",
+        expires_at: "2026-01-01T01:00:00.000Z",
+      })
+      .select()
+      .single();
+    expect(retryLifecycleError).toBeNull();
+    lifecycleIds.push(retryLifecycle!.id);
+
+    const failedCleanup = await cleanupExpiredGuestWorkspaces({
+      admin,
+      now: new Date("2026-01-02T01:00:00.000Z"),
+      deleteGuestAuthUser: async () => {
+        throw new Error("temporary auth outage");
+      },
+    });
+
+    expect(failedCleanup.scanned).toBe(1);
+    expect(failedCleanup.errors).toEqual(["temporary auth outage"]);
+
+    const { data: failedLifecycle } = await admin
+      .from("guest_workspaces")
+      .select("deleted_at, cleanup_error")
+      .eq("id", retryLifecycle!.id)
+      .single();
+    expect(failedLifecycle?.deleted_at).toBeNull();
+    expect(failedLifecycle?.cleanup_error).toContain("temporary auth outage");
+
+    const retriedCleanup = await cleanupExpiredGuestWorkspaces({
+      admin,
+      now: new Date("2026-01-02T02:00:00.000Z"),
+      deleteGuestAuthUser: async () => ({ deleted: true, skipped: false }),
+    });
+
+    expect(retriedCleanup.scanned).toBe(1);
+    expect(retriedCleanup.errors).toEqual([]);
+
+    const { data: retriedLifecycle } = await admin
+      .from("guest_workspaces")
+      .select("deleted_at, cleanup_error")
+      .eq("id", retryLifecycle!.id)
+      .single();
+    expect(retriedLifecycle?.deleted_at).toBeTruthy();
+    expect(retriedLifecycle?.cleanup_error).toBeNull();
   });
 });

--- a/tests/guest-workspaces.spec.ts
+++ b/tests/guest-workspaces.spec.ts
@@ -1,0 +1,461 @@
+import { expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Tables } from "../src/lib/types";
+import { cloneGuestWorkspace } from "../src/lib/guest/workspace-clone";
+import { cleanupExpiredGuestWorkspaces } from "../src/lib/guest/cleanup";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const TEST_PASSWORD = "guestTest!2026";
+const RUN_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+type SourceFixture = {
+  workspace: Tables<"workspaces">;
+  ownerId: string;
+  memberId: string;
+  teamId: string;
+  projectId: string;
+  sprintId: string;
+  labelIds: string[];
+  parentIssueId: string;
+  childIssueId: string;
+};
+
+let admin: SupabaseClient<Database>;
+let source: SourceFixture;
+const workspaceIds: string[] = [];
+const lifecycleIds: string[] = [];
+const userIds: string[] = [];
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+async function createUser(email: string, fullName: string) {
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password: TEST_PASSWORD,
+    email_confirm: true,
+    user_metadata: { full_name: fullName },
+  });
+
+  if (error) {
+    throw new Error(`Failed to create user ${email}: ${error.message}`);
+  }
+
+  userIds.push(data.user.id);
+  return data.user.id;
+}
+
+async function createSourceFixture(): Promise<SourceFixture> {
+  const ownerId = await createUser(`guest-owner-${RUN_ID}@test.flow.dev`, "Guest Source Owner");
+  const memberId = await createUser(`guest-member-${RUN_ID}@test.flow.dev`, "Guest Source Member");
+
+  const { data: workspace, error: workspaceError } = await admin
+    .from("workspaces")
+    .insert({
+      name: `Guest Source ${RUN_ID}`,
+      slug: `guest-source-${RUN_ID}`.replace(/[^a-z0-9-]/g, "-"),
+      issue_prefix: "GST",
+      issue_counter: 0,
+      default_sprint_length: 10,
+      timezone: "Asia/Kuwait",
+    })
+    .select()
+    .single();
+
+  if (workspaceError || !workspace) {
+    throw new Error(`Failed to create source workspace: ${workspaceError?.message}`);
+  }
+  workspaceIds.push(workspace.id);
+
+  const { error: membershipError } = await admin.from("workspace_members").insert([
+    { workspace_id: workspace.id, user_id: ownerId, role: "owner" },
+    { workspace_id: workspace.id, user_id: memberId, role: "member" },
+  ]);
+  if (membershipError) {
+    throw new Error(`Failed to create source memberships: ${membershipError.message}`);
+  }
+
+  const { data: team, error: teamError } = await admin
+    .from("teams")
+    .insert({ workspace_id: workspace.id, name: "Demo Engineering" })
+    .select()
+    .single();
+  if (teamError || !team) {
+    throw new Error(`Failed to create source team: ${teamError?.message}`);
+  }
+
+  const { error: teamMemberError } = await admin.from("team_members").insert([
+    { team_id: team.id, user_id: ownerId },
+    { team_id: team.id, user_id: memberId },
+  ]);
+  if (teamMemberError) {
+    throw new Error(`Failed to create source team members: ${teamMemberError.message}`);
+  }
+
+  const { data: project, error: projectError } = await admin
+    .from("projects")
+    .insert({
+      workspace_id: workspace.id,
+      name: "Guest Demo Project",
+      description: "Project used to verify guest cloning",
+      color: "#3B82F6",
+      lead_id: ownerId,
+      team_id: team.id,
+    })
+    .select()
+    .single();
+  if (projectError || !project) {
+    throw new Error(`Failed to create source project: ${projectError?.message}`);
+  }
+
+  await admin
+    .from("workspace_members")
+    .update({ primary_project_id: project.id })
+    .eq("workspace_id", workspace.id);
+
+  const { data: labels, error: labelsError } = await admin
+    .from("labels")
+    .insert([
+      { project_id: project.id, name: "Bug", color: "#EF4444" },
+      { project_id: project.id, name: "Feature", color: "#3B82F6" },
+    ])
+    .select();
+  if (labelsError || !labels) {
+    throw new Error(`Failed to create source labels: ${labelsError?.message}`);
+  }
+
+  const { data: sprint, error: sprintError } = await admin
+    .from("sprints")
+    .insert({
+      workspace_id: workspace.id,
+      project_id: project.id,
+      name: "Guest Sprint",
+      goal: "Validate guest clone data",
+      status: "active",
+      start_date: "2026-04-01",
+      end_date: "2026-04-14",
+      capacity: 20,
+    })
+    .select()
+    .single();
+  if (sprintError || !sprint) {
+    throw new Error(`Failed to create source sprint: ${sprintError?.message}`);
+  }
+
+  const checklist = [
+    { id: randomUUID(), text: "Confirm guest clone", completed: true },
+    { id: randomUUID(), text: "Verify issue counter", completed: false },
+  ];
+  const { data: parentIssue, error: parentIssueError } = await admin
+    .from("issues")
+    .insert({
+      workspace_id: workspace.id,
+      project_id: project.id,
+      issue_number: 1,
+      issue_key: "GST-1",
+      title: "Parent demo issue",
+      description: "Parent issue copied into guest workspaces",
+      status: "in_progress",
+      priority: 1,
+      assignee_id: ownerId,
+      sprint_id: sprint.id,
+      story_points: 5,
+      sort_order: 1000,
+      created_by: memberId,
+      checklist,
+    })
+    .select()
+    .single();
+  if (parentIssueError || !parentIssue) {
+    throw new Error(`Failed to create parent issue: ${parentIssueError?.message}`);
+  }
+
+  const { data: childIssue, error: childIssueError } = await admin
+    .from("issues")
+    .insert({
+      workspace_id: workspace.id,
+      project_id: project.id,
+      issue_number: 2,
+      issue_key: "GST-2",
+      title: "Child demo issue",
+      description: "Child issue copied with remapped parent",
+      status: "todo",
+      priority: 2,
+      assignee_id: memberId,
+      sprint_id: sprint.id,
+      story_points: 3,
+      sort_order: 2000,
+      created_by: ownerId,
+      parent_id: parentIssue.id,
+    })
+    .select()
+    .single();
+  if (childIssueError || !childIssue) {
+    throw new Error(`Failed to create child issue: ${childIssueError?.message}`);
+  }
+
+  const { error: issueLabelsError } = await admin.from("issue_labels").insert([
+    { issue_id: parentIssue.id, label_id: labels[0].id },
+    { issue_id: childIssue.id, label_id: labels[1].id },
+  ]);
+  if (issueLabelsError) {
+    throw new Error(`Failed to create source issue labels: ${issueLabelsError.message}`);
+  }
+
+  await admin.from("workspaces").update({ issue_counter: 2 }).eq("id", workspace.id);
+
+  return {
+    workspace: { ...workspace, issue_counter: 2 },
+    ownerId,
+    memberId,
+    teamId: team.id,
+    projectId: project.id,
+    sprintId: sprint.id,
+    labelIds: labels.map((label) => label.id),
+    parentIssueId: parentIssue.id,
+    childIssueId: childIssue.id,
+  };
+}
+
+async function getWorkspaceShape(workspaceId: string) {
+  const [{ count: projects }, { count: teams }, { count: sprints }, { count: issues }] =
+    await Promise.all([
+      admin.from("projects").select("id", { count: "exact", head: true }).eq("workspace_id", workspaceId),
+      admin.from("teams").select("id", { count: "exact", head: true }).eq("workspace_id", workspaceId),
+      admin.from("sprints").select("id", { count: "exact", head: true }).eq("workspace_id", workspaceId),
+      admin.from("issues").select("id", { count: "exact", head: true }).eq("workspace_id", workspaceId),
+    ]);
+
+  return { projects, teams, sprints, issues };
+}
+
+test.describe.serial("guest workspace cloning and cleanup", () => {
+  test.beforeAll(async () => {
+    admin = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+    source = await createSourceFixture();
+  });
+
+  test.afterAll(async () => {
+    if (lifecycleIds.length > 0) {
+      await admin.from("guest_workspaces").delete().in("id", lifecycleIds);
+    }
+
+    if (workspaceIds.length > 0) {
+      await admin.from("workspaces").delete().in("id", workspaceIds);
+    }
+
+    for (const userId of userIds) {
+      await admin.auth.admin.deleteUser(userId).catch(() => undefined);
+    }
+  });
+
+  test("clones a guest workspace with remapped core data and a usable issue counter", async () => {
+    const guestId = await createUser(`guest-user-${RUN_ID}@test.flow.dev`, "Guest User");
+    const sourceShapeBefore = await getWorkspaceShape(source.workspace.id);
+
+    const clone = await cloneGuestWorkspace({
+      admin,
+      guestUserId: guestId,
+      sourceWorkspaceSlug: source.workspace.slug,
+      now: new Date("2030-01-01T00:00:00.000Z"),
+    });
+    workspaceIds.push(clone.workspace.id);
+    lifecycleIds.push(clone.lifecycle.id);
+
+    expect(clone.workspace.slug).toMatch(/^guest-workspace-[a-f0-9]{8}$/);
+    expect(clone.workspace.issue_prefix).toBe(source.workspace.issue_prefix);
+    expect(clone.workspace.issue_counter).toBe(2);
+    expect(clone.lifecycle.guest_user_id).toBe(guestId);
+    expect(new Date(clone.lifecycle.expires_at).getTime()).toBe(
+      new Date("2030-01-02T00:00:00.000Z").getTime(),
+    );
+
+    const { data: memberships } = await admin
+      .from("workspace_members")
+      .select("*")
+      .eq("workspace_id", clone.workspace.id);
+    expect(memberships?.find((member) => member.user_id === guestId)?.role).toBe("owner");
+    expect(memberships?.some((member) => member.user_id === source.memberId)).toBe(true);
+    expect(memberships?.some((member) => member.user_id === source.ownerId)).toBe(false);
+
+    const { data: teams } = await admin
+      .from("teams")
+      .select("*")
+      .eq("workspace_id", clone.workspace.id);
+    expect(teams).toHaveLength(1);
+    expect(teams?.[0].id).not.toBe(source.teamId);
+
+    const { data: teamMembers } = await admin
+      .from("team_members")
+      .select("*")
+      .eq("team_id", teams![0].id);
+    expect(teamMembers?.map((member) => member.user_id).sort()).toEqual(
+      [guestId, source.memberId].sort(),
+    );
+
+    const { data: projects } = await admin
+      .from("projects")
+      .select("*")
+      .eq("workspace_id", clone.workspace.id);
+    expect(projects).toHaveLength(1);
+    const clonedProject = projects![0];
+    expect(clonedProject.id).not.toBe(source.projectId);
+    expect(clonedProject.lead_id).toBe(guestId);
+    expect(clonedProject.team_id).toBe(teams![0].id);
+
+    const { data: labels } = await admin
+      .from("labels")
+      .select("*")
+      .eq("project_id", clonedProject.id);
+    expect(labels).toHaveLength(2);
+    expect(labels?.some((label) => source.labelIds.includes(label.id))).toBe(false);
+
+    const { data: sprints } = await admin
+      .from("sprints")
+      .select("*")
+      .eq("workspace_id", clone.workspace.id);
+    expect(sprints).toHaveLength(1);
+    expect(sprints![0].project_id).toBe(clonedProject.id);
+    expect(sprints![0].id).not.toBe(source.sprintId);
+
+    const { data: issues } = await admin
+      .from("issues")
+      .select("*")
+      .eq("workspace_id", clone.workspace.id)
+      .order("issue_number", { ascending: true });
+    expect(issues).toHaveLength(2);
+
+    const [parentIssue, childIssue] = issues!;
+    expect(parentIssue.id).not.toBe(source.parentIssueId);
+    expect(parentIssue.project_id).toBe(clonedProject.id);
+    expect(parentIssue.assignee_id).toBe(guestId);
+    expect(parentIssue.created_by).toBe(source.memberId);
+    expect(parentIssue.checklist).toEqual([
+      { id: expect.any(String), text: "Confirm guest clone", completed: true },
+      { id: expect.any(String), text: "Verify issue counter", completed: false },
+    ]);
+    expect(childIssue.parent_id).toBe(parentIssue.id);
+    expect(childIssue.created_by).toBe(guestId);
+    expect(childIssue.assignee_id).toBe(source.memberId);
+
+    const { data: issueLabels } = await admin
+      .from("issue_labels")
+      .select("*")
+      .in("issue_id", issues!.map((issue) => issue.id));
+    expect(issueLabels).toHaveLength(2);
+    expect(issueLabels?.every((row) => labels!.some((label) => label.id === row.label_id))).toBe(true);
+
+    const guestClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
+    const { error: signInError } = await guestClient.auth.signInWithPassword({
+      email: `guest-user-${RUN_ID}@test.flow.dev`,
+      password: TEST_PASSWORD,
+    });
+    expect(signInError).toBeNull();
+
+    const { data: newIssue, error: newIssueError } = await guestClient.rpc(
+      "create_issue",
+      {
+        p_workspace_id: clone.workspace.id,
+        p_project_id: clonedProject.id,
+        p_title: "Guest-created issue",
+        p_description: "Created after cloning to verify the counter",
+        p_status: "todo",
+        p_priority: 3,
+        p_label_ids: [] as string[],
+      },
+    );
+    expect(newIssueError).toBeNull();
+    expect(newIssue?.issue_number).toBe(3);
+    expect(newIssue?.issue_key).toBe("GST-3");
+    await guestClient.auth.signOut();
+
+    expect(await getWorkspaceShape(source.workspace.id)).toEqual(sourceShapeBefore);
+  });
+
+  test("removes expired guest workspaces and preserves active ones idempotently", async () => {
+    const expiredGuestId = await createUser(`expired-guest-${RUN_ID}@test.flow.dev`, "Expired Guest");
+    const freshGuestId = await createUser(`fresh-guest-${RUN_ID}@test.flow.dev`, "Fresh Guest");
+    const missingGuestId = await createUser(`missing-guest-${RUN_ID}@test.flow.dev`, "Missing Guest");
+
+    const expired = await cloneGuestWorkspace({
+      admin,
+      guestUserId: expiredGuestId,
+      sourceWorkspaceSlug: source.workspace.slug,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    workspaceIds.push(expired.workspace.id);
+    lifecycleIds.push(expired.lifecycle.id);
+
+    const fresh = await cloneGuestWorkspace({
+      admin,
+      guestUserId: freshGuestId,
+      sourceWorkspaceSlug: source.workspace.slug,
+      now: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    workspaceIds.push(fresh.workspace.id);
+    lifecycleIds.push(fresh.lifecycle.id);
+
+    const { data: missingLifecycle, error: missingLifecycleError } = await admin
+      .from("guest_workspaces")
+      .insert({
+        workspace_id: null,
+        workspace_slug: `already-deleted-${RUN_ID}`,
+        source_workspace_id: source.workspace.id,
+        source_workspace_slug: source.workspace.slug,
+        guest_user_id: missingGuestId,
+        created_at: "2026-01-01T00:00:00.000Z",
+        expires_at: "2026-01-01T01:00:00.000Z",
+      })
+      .select()
+      .single();
+    expect(missingLifecycleError).toBeNull();
+    lifecycleIds.push(missingLifecycle!.id);
+
+    const authDeletes: string[] = [];
+    const firstCleanup = await cleanupExpiredGuestWorkspaces({
+      admin,
+      now: new Date("2026-01-02T01:00:00.000Z"),
+      deleteGuestAuthUser: async (guestUserId) => {
+        authDeletes.push(guestUserId);
+        return { deleted: true, skipped: false };
+      },
+    });
+
+    expect(firstCleanup.scanned).toBe(2);
+    expect(firstCleanup.deletedWorkspaces).toBe(1);
+    expect(firstCleanup.deletedAuthUsers).toBe(2);
+    expect(firstCleanup.errors).toEqual([]);
+    expect(authDeletes.sort()).toEqual([expiredGuestId, missingGuestId].sort());
+
+    const { data: expiredWorkspace } = await admin
+      .from("workspaces")
+      .select("id")
+      .eq("id", expired.workspace.id)
+      .maybeSingle();
+    expect(expiredWorkspace).toBeNull();
+
+    const { data: freshWorkspace } = await admin
+      .from("workspaces")
+      .select("id")
+      .eq("id", fresh.workspace.id)
+      .maybeSingle();
+    expect(freshWorkspace?.id).toBe(fresh.workspace.id);
+
+    const { data: lifecycles } = await admin
+      .from("guest_workspaces")
+      .select("id, deleted_at")
+      .in("id", [expired.lifecycle.id, fresh.lifecycle.id, missingLifecycle!.id]);
+    expect(lifecycles?.find((row) => row.id === expired.lifecycle.id)?.deleted_at).toBeTruthy();
+    expect(lifecycles?.find((row) => row.id === missingLifecycle!.id)?.deleted_at).toBeTruthy();
+    expect(lifecycles?.find((row) => row.id === fresh.lifecycle.id)?.deleted_at).toBeNull();
+
+    const secondCleanup = await cleanupExpiredGuestWorkspaces({
+      admin,
+      now: new Date("2026-01-02T01:00:00.000Z"),
+      deleteGuestAuthUser: async () => ({ deleted: true, skipped: false }),
+    });
+    expect(secondCleanup.scanned).toBe(0);
+  });
+});

--- a/tests/phase1-auth-flow.spec.ts
+++ b/tests/phase1-auth-flow.spec.ts
@@ -162,18 +162,30 @@ test.describe.serial("Phase 1: Auth → Onboarding → Board", () => {
     await page.getByRole("button", { name: "Sign In" }).click();
     await expect(page).toHaveURL(/dashboard/, { timeout: 10000 });
 
-    const { data: workspace } = await adminClient
+    const { data: workspace, error: workspaceError } = await adminClient
       .from("workspaces")
       .select("id")
       .eq("slug", TEST_WORKSPACE_SLUG)
       .single();
 
-    const { data: project } = await adminClient
+    if (workspaceError || !workspace) {
+      throw new Error(
+        `Failed to load onboarding workspace: ${workspaceError?.message ?? "missing"}`
+      );
+    }
+
+    const { data: project, error: projectError } = await adminClient
       .from("projects")
       .select("id")
       .eq("workspace_id", workspace.id)
       .order("created_at", { ascending: true })
       .single();
+
+    if (projectError || !project) {
+      throw new Error(
+        `Failed to load onboarding project: ${projectError?.message ?? "missing"}`
+      );
+    }
 
     await page.goto(`/${TEST_WORKSPACE_SLUG}/projects/${project.id}/board`);
 


### PR DESCRIPTION
## Summary
- add Continue as guest login action backed by Supabase anonymous auth
- clone isolated guest workspaces from the seeded demo workspace with lifecycle metadata
- add cleanup script and direct clone/lifecycle tests

## Verification
- npx tsc --noEmit
- npx eslint src/lib/guest/workspace-clone.ts src/lib/guest/cleanup.ts src/lib/actions/auth.ts 'src/app/(auth)/login/page.tsx' src/proxy.ts tests/guest-workspaces.spec.ts tests/phase1-auth-flow.spec.ts scripts/cleanup-guest-workspaces.ts
- npx playwright test tests/guest-workspaces.spec.ts --project=authenticated
- playwright-cli guest smoke: /login -> Continue as guest -> cloned guest dashboard

Closes #35