### PR TITLE
Fix duplicate realtime comments

### DIFF
--- a/src/components/issues/comment-thread.tsx
+++ b/src/components/issues/comment-thread.tsx
@@ -66,6 +66,10 @@ export function CommentThread({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const authorById = useMemo(
+    () => new Map(members.map((member) => [member.user_id, member.profile])),
+    [members]
+  );
 
   // Get current user ID client-side
   useEffect(() => {
@@ -155,6 +159,7 @@ export function CommentThread({
   const { comments, setComments } = useRealtimeComments({
     issueId,
     initialComments: fetchedComments,
+    authorById,
   });
 
   // Build interleaved timeline
@@ -200,20 +205,39 @@ export function CommentThread({
       });
 
       const result = await createComment({ issueId, workspaceId, body });
-      if (result.error) {
-        toast.error(result.error);
+      const saved = result.data;
+      if (!saved) {
+        toast.error(result.error ?? "Unable to create comment");
         // Remove optimistic comment on error
         setComments((prev) => prev.filter((c) => c.id !== optimisticId));
-      } else {
-        // Replace optimistic with real comment (realtime may also deliver it)
-        setComments((prev) =>
-          prev.map((c) =>
-            c.id === optimisticId ? { ...optimistic, ...result.data, author: optimistic.author } : c
-          )
-        );
+        return;
       }
+
+      // Replace optimistic with real comment and collapse any realtime copy.
+      const savedComment: CommentWithAuthor = {
+        ...optimistic,
+        ...saved,
+        author:
+          optimistic.author ??
+          authorById.get(saved.author_id) ??
+          null,
+      };
+
+      setComments((prev) => {
+        let replacedOptimistic = false;
+        const next = prev
+          .filter((c) => c.id !== saved.id)
+          .map((c) => {
+            if (c.id !== optimisticId) return c;
+
+            replacedOptimistic = true;
+            return savedComment;
+          });
+
+        return replacedOptimistic ? next : [...next, savedComment];
+      });
     },
-    [issueId, workspaceId, currentUserId, members, setComments]
+    [issueId, workspaceId, currentUserId, members, authorById, setComments]
   );
 
   const handleUpdateComment = useCallback(

--- a/src/lib/hooks/use-realtime-comments.ts
+++ b/src/lib/hooks/use-realtime-comments.ts
@@ -8,11 +8,13 @@ import type { Tables } from "@/lib/types";
 interface UseRealtimeCommentsOptions {
   issueId: string | null;
   initialComments: CommentWithAuthor[];
+  authorById?: ReadonlyMap<string, CommentWithAuthor["author"]>;
 }
 
 export function useRealtimeComments({
   issueId,
   initialComments,
+  authorById,
 }: UseRealtimeCommentsOptions) {
   const [comments, setComments] =
     useState<CommentWithAuthor[]>(initialComments);
@@ -22,6 +24,26 @@ export function useRealtimeComments({
     setComments(initialComments);
   }, [initialComments]);
 
+  // Backfill authors for realtime rows that arrived without joined profile data.
+  useEffect(() => {
+    if (!authorById) return;
+
+    setComments((prev) => {
+      let changed = false;
+      const next = prev.map((comment) => {
+        if (comment.author) return comment;
+
+        const author = authorById.get(comment.author_id);
+        if (!author) return comment;
+
+        changed = true;
+        return { ...comment, author };
+      });
+
+      return changed ? next : prev;
+    });
+  }, [authorById]);
+
   const handleInsert = useCallback(
     (payload: { new: Tables<"comments"> }) => {
       const row = payload.new;
@@ -29,12 +51,12 @@ export function useRealtimeComments({
         if (prev.some((c) => c.id === row.id)) return prev;
         const stub: CommentWithAuthor = {
           ...row,
-          author: null,
+          author: authorById?.get(row.author_id) ?? null,
         };
         return [...prev, stub];
       });
     },
-    []
+    [authorById]
   );
 
   const handleUpdate = useCallback(

--- a/tests/comment-thread.spec.ts
+++ b/tests/comment-thread.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../src/lib/types";
+
+const WS = "/pw-workspace";
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+let admin: SupabaseClient<Database>;
+let workspaceId: string;
+let projectId: string;
+let issueKey: string;
+
+async function cleanupComment(body: string) {
+  const { data: comments } = await admin
+    .from("comments")
+    .select("id")
+    .eq("body", body);
+
+  const commentIds = comments?.map((comment) => comment.id) ?? [];
+  if (commentIds.length === 0) return;
+
+  const { data: activities } = await admin
+    .from("activities")
+    .select("id")
+    .eq("workspace_id", workspaceId)
+    .eq("action", "commented")
+    .filter("metadata->>comment_preview", "eq", body.slice(0, 100));
+
+  const activityIds = activities?.map((activity) => activity.id) ?? [];
+  if (activityIds.length > 0) {
+    await admin.from("notifications").delete().in("activity_id", activityIds);
+    await admin.from("activities").delete().in("id", activityIds);
+  }
+
+  await admin.from("comments").delete().in("id", commentIds);
+}
+
+test.describe.serial("comment thread", () => {
+  test.beforeAll(async () => {
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+      throw new Error("Missing Supabase env for comment thread test");
+    }
+
+    admin = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+    const { data: workspace, error: workspaceError } = await admin
+      .from("workspaces")
+      .select("id")
+      .eq("slug", WS.slice(1))
+      .single();
+
+    if (workspaceError || !workspace) {
+      throw new Error(
+        `Failed to load comment test workspace: ${workspaceError?.message ?? "missing"}`
+      );
+    }
+
+    workspaceId = workspace.id;
+
+    const { data: issue, error: issueError } = await admin
+      .from("issues")
+      .select("issue_key, project_id")
+      .eq("workspace_id", workspace.id)
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .single();
+
+    if (issueError || !issue) {
+      throw new Error(
+        `Failed to load comment test issue: ${issueError?.message ?? "missing"}`
+      );
+    }
+
+    projectId = issue.project_id;
+    issueKey = issue.issue_key;
+  });
+
+  test("does not duplicate a newly submitted comment as Unknown", async ({
+    page,
+  }) => {
+    const body = `PW duplicate comment guard ${Date.now()}`;
+
+    try {
+      await page.goto(`${WS}/projects/${projectId}/list?issue=${issueKey}`);
+
+      const panel = page.getByRole("dialog", {
+        name: new RegExp(`^${issueKey}:`),
+      });
+      await expect(panel).toBeVisible({ timeout: 10000 });
+
+      await panel
+        .getByPlaceholder("Leave a comment... (@ to mention)")
+        .fill(body);
+      await panel
+        .getByPlaceholder("Leave a comment... (@ to mention)")
+        .press("Enter");
+
+      await expect(panel.getByText(body)).toHaveCount(1, { timeout: 10000 });
+
+      await page.waitForTimeout(1500);
+
+      await expect(panel.getByText(body)).toHaveCount(1);
+      const commentRow = panel.locator(".group", { hasText: body });
+      await expect(commentRow).toHaveCount(1);
+      await expect(commentRow).not.toContainText("Unknown");
+    } finally {
+      await cleanupComment(body);
+    }
+  });
+});


### PR DESCRIPTION
Summary
- Collapse optimistic and realtime copies of a newly created comment into one saved row
- Hydrate realtime comment authors from workspace member profiles to avoid Unknown rows
- Add an authenticated Playwright regression for the duplicate comment path

Tests
- npx eslint src/components/issues/comment-thread.tsx src/lib/hooks/use-realtime-comments.ts tests/comment-thread.spec.ts
- npx playwright test tests/comment-thread.spec.ts --project=authenticated

Note
- Full tsc is currently blocked by existing nullability errors in tests/phase1-auth-flow.spec.ts.