### PR TITLE
Add realtime collaboration awareness to Board and List views

### DIFF
--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/board-with-detail.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/board/board-with-detail.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState, useCallback, Suspense } from "react";
+import { useState, useCallback, useEffect, Suspense } from "react";
 import { BoardView } from "@/components/board/board-view";
 import { IssueDetailPanel } from "@/components/issues/issue-detail-panel";
 import { useIssueFromUrl } from "@/lib/hooks/use-issue-from-url";
 import { FilterBar } from "@/components/filters/filter-bar";
 import { useIssueFilters } from "@/lib/hooks/use-issue-filters";
+import { PresenceProvider, usePresence } from "@/providers/presence-provider";
+import { PresenceStack } from "@/components/presence/presence-stack";
 import type { IssueWithDetails } from "@/lib/queries/issues";
 import { getIssueClient } from "@/lib/queries/issues-client";
 
@@ -24,6 +26,7 @@ function BoardWithDetailInner({
   sprints = [],
   labels = [],
 }: BoardWithDetailProps) {
+  const { peers, setFocusedIssue } = usePresence();
   const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
   const [selectedIssueFallback, setSelectedIssueFallback] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
@@ -68,22 +71,30 @@ function BoardWithDetailInner({
 
   useIssueFromUrl(initialIssues, openIssue);
 
+  // Broadcast which issue (if any) the user is currently focused on.
+  useEffect(() => {
+    setFocusedIssue(detailOpen && selectedIssueId ? selectedIssueId : null);
+  }, [detailOpen, selectedIssueId, setFocusedIssue]);
+
   return (
     <>
-      <div className="px-6 pt-4">
-        <FilterBar
-          filters={filters}
-          searchQuery={searchQuery}
-          searchInputRef={searchInputRef}
-          onSearchChange={setSearchQuery}
-          onToggleFilter={toggleFilter}
-          onClearFilter={clearFilter}
-          onClearAll={clearAll}
-          hasActiveFilters={hasActiveFilters}
-          enabledFilters={["status", "priority", "assignee", "label"]}
-          members={members}
-          labels={labels}
-        />
+      <div className="flex items-center justify-between gap-4 px-6 pt-4">
+        <div className="min-w-0 flex-1">
+          <FilterBar
+            filters={filters}
+            searchQuery={searchQuery}
+            searchInputRef={searchInputRef}
+            onSearchChange={setSearchQuery}
+            onToggleFilter={toggleFilter}
+            onClearFilter={clearFilter}
+            onClearAll={clearAll}
+            hasActiveFilters={hasActiveFilters}
+            enabledFilters={["status", "priority", "assignee", "label"]}
+            members={members}
+            labels={labels}
+          />
+        </div>
+        <PresenceStack peers={peers} />
       </div>
       <BoardView
         initialIssues={initialIssues}
@@ -108,7 +119,13 @@ function BoardWithDetailInner({
 export function BoardWithDetail(props: BoardWithDetailProps) {
   return (
     <Suspense>
-      <BoardWithDetailInner {...props} />
+      <PresenceProvider
+        projectId={props.projectId}
+        view="board"
+        members={props.members ?? []}
+      >
+        <BoardWithDetailInner {...props} />
+      </PresenceProvider>
     </Suspense>
   );
 }

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/list-view-content.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/list-view-content.tsx
@@ -1,25 +1,75 @@
 "use client";
 
-import { useState, useCallback, Suspense } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef, Suspense } from "react";
 import { IssueList } from "@/components/issues/issue-list";
 import { IssueDetailPanel } from "@/components/issues/issue-detail-panel";
 import { useIssueFromUrl } from "@/lib/hooks/use-issue-from-url";
 import { FilterBar } from "@/components/filters/filter-bar";
 import { useIssueFilters } from "@/lib/hooks/use-issue-filters";
+import { useRealtimeIssues } from "@/lib/hooks/use-realtime-issues";
+import { PresenceProvider, usePresence } from "@/providers/presence-provider";
+import { PresenceStack } from "@/components/presence/presence-stack";
 import type { IssueWithDetails } from "@/lib/queries/issues";
 import { getIssueClient } from "@/lib/queries/issues-client";
 
 interface ListViewContentProps {
+  projectId: string;
   issues: IssueWithDetails[];
-  members: { user_id: string; profile: { full_name: string | null; email: string } }[];
+  members: { user_id: string; profile: { id: string; full_name: string | null; email: string; avatar_url: string | null } }[];
   sprints: { id: string; name: string; status: string; project_id?: string }[];
   labels: { id: string; name: string; color: string }[];
 }
 
-function ListViewContentInner({ issues, members, sprints, labels }: ListViewContentProps) {
+function ListViewContentInner({
+  projectId,
+  issues: initialIssues,
+  members,
+  sprints,
+  labels,
+}: ListViewContentProps) {
+  const presence = usePresence();
   const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
   const [selectedIssueFallback, setSelectedIssueFallback] = useState<IssueWithDetails | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
+
+  const [flashingIds, setFlashingIds] = useState<Set<string>>(() => new Set());
+  const flashTimers = useRef<Map<string, number>>(new Map());
+
+  const handleRemoteUpdate = useCallback((issueId: string) => {
+    setFlashingIds((prev) => {
+      if (prev.has(issueId)) return prev;
+      const next = new Set(prev);
+      next.add(issueId);
+      return next;
+    });
+    const existing = flashTimers.current.get(issueId);
+    if (existing) window.clearTimeout(existing);
+    const timer = window.setTimeout(() => {
+      setFlashingIds((prev) => {
+        if (!prev.has(issueId)) return prev;
+        const next = new Set(prev);
+        next.delete(issueId);
+        return next;
+      });
+      flashTimers.current.delete(issueId);
+    }, 700);
+    flashTimers.current.set(issueId, timer);
+  }, []);
+
+  useEffect(() => {
+    const timers = flashTimers.current;
+    return () => {
+      for (const t of timers.values()) window.clearTimeout(t);
+      timers.clear();
+    };
+  }, []);
+
+  const { issues } = useRealtimeIssues({
+    projectId,
+    initialIssues,
+    isSelfUpdate: presence.isSelfUpdate,
+    onRemoteUpdate: handleRemoteUpdate,
+  });
 
   const {
     filters,
@@ -59,28 +109,42 @@ function ListViewContentInner({ issues, members, sprints, labels }: ListViewCont
 
   useIssueFromUrl(issues, openIssue);
 
+  useEffect(() => {
+    presence.setFocusedIssue(detailOpen && selectedIssueId ? selectedIssueId : null);
+  }, [detailOpen, selectedIssueId, presence]);
+
+  const watchersByIssue = useMemo(
+    () => presence.peersByIssue,
+    [presence.peersByIssue],
+  );
+
   return (
     <>
-      <div className="px-6 pb-2">
-        <FilterBar
-          filters={filters}
-          searchQuery={searchQuery}
-          searchInputRef={searchInputRef}
-          onSearchChange={setSearchQuery}
-          onToggleFilter={toggleFilter}
-          onClearFilter={clearFilter}
-          onClearAll={clearAll}
-          hasActiveFilters={hasActiveFilters}
-          enabledFilters={["status", "priority", "assignee", "label"]}
-          members={members}
-          labels={labels}
-        />
+      <div className="flex items-center justify-between gap-4 px-6 pb-2">
+        <div className="min-w-0 flex-1">
+          <FilterBar
+            filters={filters}
+            searchQuery={searchQuery}
+            searchInputRef={searchInputRef}
+            onSearchChange={setSearchQuery}
+            onToggleFilter={toggleFilter}
+            onClearFilter={clearFilter}
+            onClearAll={clearAll}
+            hasActiveFilters={hasActiveFilters}
+            enabledFilters={["status", "priority", "assignee", "label"]}
+            members={members}
+            labels={labels}
+          />
+        </div>
+        <PresenceStack peers={presence.peers} />
       </div>
       <IssueList
         issues={filteredIssues}
         showProject={false}
         onIssueClick={handleIssueClick}
         treeMode
+        watchersByIssue={watchersByIssue}
+        flashingIds={flashingIds}
       />
       <IssueDetailPanel
         key={selectedIssue?.id ?? "issue-detail-empty"}
@@ -99,7 +163,13 @@ function ListViewContentInner({ issues, members, sprints, labels }: ListViewCont
 export function ListViewContent(props: ListViewContentProps) {
   return (
     <Suspense>
-      <ListViewContentInner {...props} />
+      <PresenceProvider
+        projectId={props.projectId}
+        view="list"
+        members={props.members}
+      >
+        <ListViewContentInner {...props} />
+      </PresenceProvider>
     </Suspense>
   );
 }

--- a/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectId]/list/page.tsx
@@ -55,6 +55,7 @@ export default async function ListPage({
 
       {hasIssues && (
         <ListViewContent
+          projectId={projectData.id}
           issues={issues}
           members={members}
           sprints={sprints}

--- a/src/components/board/board-card.tsx
+++ b/src/components/board/board-card.tsx
@@ -7,7 +7,10 @@ import { getInitials } from "@/lib/utils/format";
 import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { formatDate } from "@/lib/utils/dates";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { WatcherDots } from "@/components/presence/watcher-dots";
+import { DraggingPill } from "@/components/presence/dragging-pill";
 import type { IssuePriority } from "@/lib/types";
+import type { Peer } from "@/lib/hooks/use-presence-channel";
 
 export interface BoardCardProps {
   id: string;
@@ -29,6 +32,9 @@ export interface BoardCardProps {
   isDragOverlay?: boolean;
   onClick?: (id: string) => void;
   onParentClick?: (id: string) => void;
+  watchers?: Peer[];
+  draggingPeer?: Peer | null;
+  isRemoteFlashing?: boolean;
 }
 
 export function BoardCard({
@@ -48,8 +54,12 @@ export function BoardCard({
   isDragOverlay = false,
   onClick,
   onParentClick,
+  watchers,
+  draggingPeer,
+  isRemoteFlashing = false,
 }: BoardCardProps) {
-  const sortable = useSortable({ id, disabled: isDragOverlay });
+  const isRemoteDragging = !!draggingPeer && !isDragOverlay;
+  const sortable = useSortable({ id, disabled: isDragOverlay || isRemoteDragging });
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     isDragOverlay
       ? { attributes: {}, listeners: {}, setNodeRef: undefined, transform: null, transition: undefined, isDragging: false }
@@ -73,17 +83,25 @@ export function BoardCard({
     <div
       ref={setNodeRef}
       style={style}
+      data-issue-id={id}
       {...attributes}
       {...listeners}
-      onClick={() => { if (!isDragging && onClick) onClick(id); }}
+      onClick={() => {
+        if (!isDragging && !isRemoteDragging && onClick) onClick(id);
+      }}
       aria-label={`Issue ${issueKey}: ${title}`}
       aria-roledescription="sortable"
       className={cn(
-        "rounded-lg border border-border bg-surface p-3 shadow-sm cursor-grab active:cursor-grabbing transition-shadow hover:shadow-md",
+        "relative rounded-lg border border-border bg-surface p-3 shadow-sm transition-shadow duration-700 hover:shadow-md",
+        isRemoteDragging
+          ? "cursor-not-allowed opacity-60"
+          : "cursor-grab active:cursor-grabbing",
         isDragging && "opacity-30",
         isDragOverlay && "shadow-lg ring-2 ring-primary/10 rotate-[2deg]",
+        isRemoteFlashing && "ring-2 ring-primary/40",
       )}
     >
+      {isRemoteDragging && draggingPeer && <DraggingPill peer={draggingPeer} />}
       {/* Header: issue key + priority dot */}
       <div className="flex items-center justify-between">
         <span className="text-xs font-mono text-text-muted">{issueKey}</span>
@@ -174,8 +192,8 @@ export function BoardCard({
         </div>
       )}
 
-      {/* Footer: due date + assignee */}
-      {(dueDate || assignee) && (
+      {/* Footer: due date + watchers + assignee */}
+      {(dueDate || assignee || (watchers && watchers.length > 0)) && (
         <div className="flex items-center justify-between mt-2.5">
           {dueDate ? (
             <span
@@ -193,14 +211,19 @@ export function BoardCard({
           ) : (
             <span />
           )}
-          {assignee && (
-            <Avatar size="sm" className="h-6 w-6 text-[10px]">
-              {assignee.avatar_url && (
-                <AvatarImage src={assignee.avatar_url} alt={assignee.full_name ?? ""} />
-              )}
-              <AvatarFallback>{getInitials(assignee.full_name)}</AvatarFallback>
-            </Avatar>
-          )}
+          <div className="flex items-center gap-1.5">
+            {watchers && watchers.length > 0 && (
+              <WatcherDots peers={watchers} />
+            )}
+            {assignee && (
+              <Avatar size="sm" className="h-6 w-6 text-[10px]">
+                {assignee.avatar_url && (
+                  <AvatarImage src={assignee.avatar_url} alt={assignee.full_name ?? ""} />
+                )}
+                <AvatarFallback>{getInitials(assignee.full_name)}</AvatarFallback>
+              </Avatar>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/board/board-column.tsx
+++ b/src/components/board/board-column.tsx
@@ -11,6 +11,7 @@ import { BoardCard } from "./board-card";
 import { BoardQuickAdd } from "./board-quick-add";
 import type { IssueStatus } from "@/lib/types";
 import type { IssueWithDetails } from "@/lib/queries/issues";
+import type { Peer } from "@/lib/hooks/use-presence-channel";
 
 interface BoardColumnProps {
   status: IssueStatus;
@@ -24,6 +25,9 @@ interface BoardColumnProps {
   onQuickAddCreated: () => void;
   onIssueClick?: (id: string) => void;
   onParentClick?: (id: string) => void;
+  peersByIssue?: Map<string, Peer[]>;
+  draggingByIssue?: Map<string, Peer>;
+  flashingIds?: Set<string>;
 }
 
 export function BoardColumn({
@@ -38,6 +42,9 @@ export function BoardColumn({
   onQuickAddCreated,
   onIssueClick,
   onParentClick,
+  peersByIssue,
+  draggingByIssue,
+  flashingIds,
 }: BoardColumnProps) {
   const { setNodeRef } = useDroppable({ id: status });
   const config = STATUS_CONFIG[status];
@@ -105,6 +112,9 @@ export function BoardColumn({
               subIssueTotalCount={showHierarchy ? issue.sub_issues_count : 0}
               onClick={onIssueClick}
               onParentClick={onParentClick}
+              watchers={peersByIssue?.get(issue.id) ?? []}
+              draggingPeer={draggingByIssue?.get(issue.id) ?? null}
+              isRemoteFlashing={flashingIds?.has(issue.id) ?? false}
             />
           ))}
 

--- a/src/components/board/board-quick-add.tsx
+++ b/src/components/board/board-quick-add.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useWorkspace } from "@/providers/workspace-provider";
+import { useOptionalPresence } from "@/providers/presence-provider";
 import { createIssue } from "@/lib/actions/issues";
 import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { cn } from "@/lib/utils/cn";
@@ -25,6 +26,7 @@ export function BoardQuickAdd({
   onCreated,
 }: BoardQuickAddProps) {
   const { workspace } = useWorkspace();
+  const presence = useOptionalPresence();
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
@@ -56,6 +58,7 @@ export function BoardQuickAdd({
     setLoading(false);
 
     if (!result.error && "data" in result && result.data) {
+      presence?.markSelfUpdated(result.data.id);
       toast.success(`Issue ${result.data.issue_key} created`);
       onCreated();
       router.refresh();

--- a/src/components/board/board-view.tsx
+++ b/src/components/board/board-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useRef, useCallback } from "react";
+import { useState, useMemo, useRef, useCallback, useEffect } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -19,6 +19,7 @@ import { updateIssue } from "@/lib/actions/issues";
 import { STATUS_ORDER } from "@/lib/utils/statuses";
 import { BoardColumn } from "./board-column";
 import { BoardCard } from "./board-card";
+import { useOptionalPresence } from "@/providers/presence-provider";
 import type { IssueStatus } from "@/lib/types";
 import type { IssueWithDetails } from "@/lib/queries/issues";
 
@@ -88,9 +89,44 @@ export function BoardView({
   onIssueClick,
   issueFilter,
 }: BoardViewProps) {
+  const presence = useOptionalPresence();
+  const [flashingIds, setFlashingIds] = useState<Set<string>>(() => new Set());
+  const flashTimers = useRef<Map<string, number>>(new Map());
+
+  const handleRemoteUpdate = useCallback((issueId: string) => {
+    setFlashingIds((prev) => {
+      if (prev.has(issueId)) return prev;
+      const next = new Set(prev);
+      next.add(issueId);
+      return next;
+    });
+    const existing = flashTimers.current.get(issueId);
+    if (existing) window.clearTimeout(existing);
+    const timer = window.setTimeout(() => {
+      setFlashingIds((prev) => {
+        if (!prev.has(issueId)) return prev;
+        const next = new Set(prev);
+        next.delete(issueId);
+        return next;
+      });
+      flashTimers.current.delete(issueId);
+    }, 700);
+    flashTimers.current.set(issueId, timer);
+  }, []);
+
+  useEffect(() => {
+    const timers = flashTimers.current;
+    return () => {
+      for (const t of timers.values()) window.clearTimeout(t);
+      timers.clear();
+    };
+  }, []);
+
   const { issues, setIssues } = useRealtimeIssues({
     projectId,
     initialIssues,
+    isSelfUpdate: presence?.isSelfUpdate,
+    onRemoteUpdate: handleRemoteUpdate,
   });
   const [activeId, setActiveId] = useState<string | null>(null);
   const [quickAddStatus, setQuickAddStatus] = useState<IssueStatus | null>(null);
@@ -167,10 +203,12 @@ export function BoardView({
 
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
-      setActiveId(event.active.id as string);
+      const id = event.active.id as string;
+      setActiveId(id);
       issuesSnapshot.current = issues.map((i) => ({ ...i }));
+      presence?.broadcastDragStart(id);
     },
-    [issues],
+    [issues, presence],
   );
 
   const handleDragOver = useCallback(
@@ -204,91 +242,104 @@ export function BoardView({
     async (event: DragEndEvent) => {
       const { active, over } = event;
       setActiveId(null);
-
-      if (!over) return;
-
       const activeIssueId = active.id as string;
-      const activeIssue = hierarchyIssues.find((i) => i.id === activeIssueId);
-      if (!activeIssue) return;
 
-      const targetColumn = findColumnOfOver(
-        over.id,
-        hierarchyIssues,
-        over.data?.current as Record<string, unknown> | undefined,
-      );
-      if (!targetColumn) return;
+      try {
+        if (!over) return;
 
-      const newStatus = targetColumn;
-      const columnIssues = hierarchyIssues
-        .filter((i) => i.status === newStatus && i.id !== activeIssueId)
-        .sort((a, b) => a.sort_order - b.sort_order);
+        const activeIssue = hierarchyIssues.find((i) => i.id === activeIssueId);
+        if (!activeIssue) return;
 
-      // Determine target index
-      let targetIndex = columnIssues.length; // default: end of column
-      if (over.id !== newStatus) {
-        // Dropped on a specific card — find its index
-        const overIdx = columnIssues.findIndex((i) => i.id === over.id);
-        if (overIdx !== -1) {
-          targetIndex = overIdx;
-        }
-      }
+        const targetColumn = findColumnOfOver(
+          over.id,
+          hierarchyIssues,
+          over.data?.current as Record<string, unknown> | undefined,
+        );
+        if (!targetColumn) return;
 
-      const newSortOrder = calculateSortOrder(columnIssues, targetIndex);
-
-      // Optimistic local update
-      setIssues((prev) =>
-        prev.map((i) =>
-          i.id === activeIssueId
-            ? { ...i, status: newStatus, sort_order: newSortOrder }
-            : i,
-        ),
-      );
-
-      // Persist
-      const result = await updateIssue(activeIssueId, {
-        status: newStatus,
-        sort_order: newSortOrder,
-      });
-
-      if (result.error) {
-        // Rollback
-        setIssues(issuesSnapshot.current);
-        return;
-      }
-
-      // Rebalance if needed
-      if (needsRebalance(columnIssues, targetIndex)) {
-        const allColumnIssues = hierarchyIssues
-          .filter((i) => i.status === newStatus || i.id === activeIssueId)
-          .filter((i) => i.status === newStatus)
+        const newStatus = targetColumn;
+        const columnIssues = hierarchyIssues
+          .filter((i) => i.status === newStatus && i.id !== activeIssueId)
           .sort((a, b) => a.sort_order - b.sort_order);
 
-        const rebalancePromises = allColumnIssues.map((issue, idx) =>
-          updateIssue(issue.id, { sort_order: (idx + 1) * 1000 }),
-        );
-        await Promise.all(rebalancePromises);
+        // Determine target index
+        let targetIndex = columnIssues.length; // default: end of column
+        if (over.id !== newStatus) {
+          // Dropped on a specific card — find its index
+          const overIdx = columnIssues.findIndex((i) => i.id === over.id);
+          if (overIdx !== -1) {
+            targetIndex = overIdx;
+          }
+        }
 
-        // Update local state with rebalanced orders
+        const newSortOrder = calculateSortOrder(columnIssues, targetIndex);
+
+        // Optimistic local update
         setIssues((prev) =>
-          prev.map((i) => {
-            const rebalancedIdx = allColumnIssues.findIndex(
-              (ri) => ri.id === i.id,
-            );
-            if (rebalancedIdx !== -1) {
-              return { ...i, sort_order: (rebalancedIdx + 1) * 1000 };
-            }
-            return i;
-          }),
+          prev.map((i) =>
+            i.id === activeIssueId
+              ? { ...i, status: newStatus, sort_order: newSortOrder }
+              : i,
+          ),
         );
+
+        // Mark before the network call so the realtime UPDATE round-trip
+        // is treated as self-originated.
+        presence?.markSelfUpdated(activeIssueId);
+
+        // Persist
+        const result = await updateIssue(activeIssueId, {
+          status: newStatus,
+          sort_order: newSortOrder,
+        });
+
+        if (result.error) {
+          // Rollback
+          setIssues(issuesSnapshot.current);
+          return;
+        }
+
+        // Rebalance if needed
+        if (needsRebalance(columnIssues, targetIndex)) {
+          const allColumnIssues = hierarchyIssues
+            .filter((i) => i.status === newStatus || i.id === activeIssueId)
+            .filter((i) => i.status === newStatus)
+            .sort((a, b) => a.sort_order - b.sort_order);
+
+          for (const issue of allColumnIssues) {
+            presence?.markSelfUpdated(issue.id);
+          }
+          const rebalancePromises = allColumnIssues.map((issue, idx) =>
+            updateIssue(issue.id, { sort_order: (idx + 1) * 1000 }),
+          );
+          await Promise.all(rebalancePromises);
+
+          // Update local state with rebalanced orders
+          setIssues((prev) =>
+            prev.map((i) => {
+              const rebalancedIdx = allColumnIssues.findIndex(
+                (ri) => ri.id === i.id,
+              );
+              if (rebalancedIdx !== -1) {
+                return { ...i, sort_order: (rebalancedIdx + 1) * 1000 };
+              }
+              return i;
+            }),
+          );
+        }
+      } finally {
+        presence?.broadcastDragEnd(activeIssueId);
       }
     },
-    [hierarchyIssues, setIssues],
+    [hierarchyIssues, setIssues, presence],
   );
 
   const handleDragCancel = useCallback(() => {
+    const cancelledId = activeId;
     setActiveId(null);
     setIssues(issuesSnapshot.current);
-  }, [setIssues]);
+    if (cancelledId) presence?.broadcastDragEnd(cancelledId);
+  }, [activeId, setIssues, presence]);
 
   const handleQuickAddCreated = useCallback(() => {
     setQuickAddStatus(null);
@@ -318,6 +369,9 @@ export function BoardView({
             onQuickAddCreated={handleQuickAddCreated}
             onIssueClick={onIssueClick}
             onParentClick={onIssueClick}
+            peersByIssue={presence?.peersByIssue}
+            draggingByIssue={presence?.draggingByIssue}
+            flashingIds={flashingIds}
           />
         ))}
       </div>

--- a/src/components/issues/issue-detail-panel.tsx
+++ b/src/components/issues/issue-detail-panel.tsx
@@ -15,6 +15,7 @@ import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { STATUS_CONFIG, STATUS_ORDER } from "@/lib/utils/statuses";
 import { formatDate } from "@/lib/utils/dates";
 import { updateIssue } from "@/lib/actions/issues";
+import { useOptionalPresence } from "@/providers/presence-provider";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { getInitials } from "@/lib/utils/format";
 import { TiptapEditor } from "./tiptap-editor";
@@ -72,6 +73,7 @@ export function IssueDetailPanel({
   syncUrl = true,
 }: IssueDetailPanelProps) {
   const router = useRouter();
+  const presence = useOptionalPresence();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -154,6 +156,7 @@ export function IssueDetailPanel({
       const current = issueRef.current;
       if (!current) return { error: "Issue not found" };
       setSaving(true);
+      presence?.markSelfUpdated(current.id);
       const result = await updateIssue(current.id, updates);
       setSaving(false);
       if (result.error) {
@@ -163,7 +166,7 @@ export function IssueDetailPanel({
       }
       return result;
     },
-    [router]
+    [router, presence]
   );
 
   // ── Copy permalink ─────────────────────────────────────────

--- a/src/components/issues/issue-list.tsx
+++ b/src/components/issues/issue-list.tsx
@@ -6,12 +6,15 @@ import { IssueRow } from "./issue-row";
 import { STATUS_CONFIG, STATUS_ORDER } from "@/lib/utils/statuses";
 import type { IssueStatus } from "@/lib/types";
 import type { IssueWithDetails } from "@/lib/queries/issues";
+import type { Peer } from "@/lib/hooks/use-presence-channel";
 
 interface IssueListProps {
   issues: IssueWithDetails[];
   showProject?: boolean;
   onIssueClick?: (id: string) => void;
   treeMode?: boolean;
+  watchersByIssue?: Map<string, Peer[]>;
+  flashingIds?: Set<string>;
 }
 
 type TreeRow = {
@@ -25,6 +28,8 @@ export function IssueList({
   showProject = true,
   onIssueClick,
   treeMode = false,
+  watchersByIssue,
+  flashingIds,
 }: IssueListProps) {
   const [expandedParents, setExpandedParents] = useState<Record<string, boolean>>({});
 
@@ -79,6 +84,8 @@ export function IssueList({
               hasChildren={hasChildren}
               expanded={expandedParents[issue.id] ?? false}
               onToggleExpand={toggleParent}
+              watchers={watchersByIssue?.get(issue.id) ?? []}
+              isRemoteFlashing={flashingIds?.has(issue.id) ?? false}
             />
           ))}
         </div>
@@ -114,6 +121,8 @@ export function IssueList({
           issues={grouped.get(status) ?? []}
           showProject={showProject}
           onIssueClick={onIssueClick}
+          watchersByIssue={watchersByIssue}
+          flashingIds={flashingIds}
         />
       ))}
     </div>
@@ -138,11 +147,15 @@ function StatusGroup({
   issues,
   showProject,
   onIssueClick,
+  watchersByIssue,
+  flashingIds,
 }: {
   status: IssueStatus;
   issues: IssueWithDetails[];
   showProject: boolean;
   onIssueClick?: (id: string) => void;
+  watchersByIssue?: Map<string, Peer[]>;
+  flashingIds?: Set<string>;
 }) {
   const [expanded, setExpanded] = useState(status !== "done");
   const config = STATUS_CONFIG[status];
@@ -180,6 +193,8 @@ function StatusGroup({
               status={issue.status}
               showProject={showProject}
               onClick={onIssueClick}
+              watchers={watchersByIssue?.get(issue.id) ?? []}
+              isRemoteFlashing={flashingIds?.has(issue.id) ?? false}
             />
           ))}
         </div>

--- a/src/components/issues/issue-row.tsx
+++ b/src/components/issues/issue-row.tsx
@@ -2,7 +2,9 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils/cn";
 import { PRIORITY_CONFIG } from "@/lib/utils/priorities";
 import { formatDate } from "@/lib/utils/dates";
+import { WatcherDots } from "@/components/presence/watcher-dots";
 import type { IssuePriority } from "@/lib/types";
+import type { Peer } from "@/lib/hooks/use-presence-channel";
 import { ChevronDown, ChevronRight } from "lucide-react";
 
 interface IssueRowProps {
@@ -19,6 +21,8 @@ interface IssueRowProps {
   hasChildren?: boolean;
   expanded?: boolean;
   onToggleExpand?: (id: string) => void;
+  watchers?: Peer[];
+  isRemoteFlashing?: boolean;
 }
 
 export function IssueRow({
@@ -35,6 +39,8 @@ export function IssueRow({
   hasChildren = false,
   expanded = false,
   onToggleExpand,
+  watchers,
+  isRemoteFlashing = false,
 }: IssueRowProps) {
   const priorityConfig = PRIORITY_CONFIG[priority as IssuePriority];
   const isDone = status === "done";
@@ -57,7 +63,11 @@ export function IssueRow({
     <>
       <div
         onClick={() => onClick?.(id)}
-        className="cursor-pointer rounded-xl border border-border bg-surface px-4 py-3.5 shadow-sm transition-colors hover:bg-surface-hover/70 sm:hidden"
+        data-issue-id={id}
+        className={cn(
+          "cursor-pointer rounded-xl border border-border bg-surface px-4 py-3.5 shadow-sm transition-colors duration-700 hover:bg-surface-hover/70 sm:hidden",
+          isRemoteFlashing && "bg-primary/5",
+        )}
       >
         <div className="flex items-start gap-3">
           <div className="mt-0.5 flex items-center gap-1.5">
@@ -123,6 +133,9 @@ export function IssueRow({
                   {isDone ? dueDateDisplay : `Due ${dueDateDisplay}`}
                 </span>
               )}
+              {watchers && watchers.length > 0 && (
+                <WatcherDots peers={watchers} className="ml-auto" />
+              )}
             </div>
           </div>
         </div>
@@ -130,7 +143,11 @@ export function IssueRow({
 
       <div
         onClick={() => onClick?.(id)}
-        className="group hidden cursor-pointer items-center gap-3 border-b border-border px-6 py-2.5 transition-colors last:border-b-0 hover:bg-surface-hover/50 sm:flex"
+        data-issue-id={id}
+        className={cn(
+          "group hidden cursor-pointer items-center gap-3 border-b border-border px-6 py-2.5 transition-colors duration-700 last:border-b-0 hover:bg-surface-hover/50 sm:flex",
+          isRemoteFlashing && "bg-primary/5",
+        )}
       >
         <div className="flex items-center gap-2 shrink-0">
           {hasChildren ? (
@@ -160,6 +177,9 @@ export function IssueRow({
         <div className="flex min-w-0 flex-1 items-center gap-2" style={{ paddingLeft: indent }}>
           {depth > 0 && <span className="h-5 w-px shrink-0 bg-border" />}
           <span className="text-sm text-text truncate">{title}</span>
+          {watchers && watchers.length > 0 && (
+            <WatcherDots peers={watchers} className="shrink-0" />
+          )}
         </div>
 
         {/* Project */}

--- a/src/components/presence/dragging-pill.tsx
+++ b/src/components/presence/dragging-pill.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils/format";
+import { peerColor } from "@/lib/utils/peer-color";
+import type { Peer } from "@/lib/hooks/use-presence-channel";
+
+interface DraggingPillProps {
+  peer: Peer;
+}
+
+export function DraggingPill({ peer }: DraggingPillProps) {
+  const name =
+    peer.profile.full_name?.trim() || peer.profile.email || "A teammate";
+  const color = peerColor(peer.userId);
+
+  return (
+    <div
+      data-testid="dragging-pill"
+      aria-live="polite"
+      className="pointer-events-none absolute right-2 top-2 inline-flex items-center gap-1 rounded-full border border-border bg-surface px-1.5 py-0.5 text-[10px] font-medium text-text-secondary shadow-sm"
+      style={{ borderColor: color }}
+    >
+      <Avatar className="h-3.5 w-3.5 text-[7px]">
+        {peer.profile.avatar_url && (
+          <AvatarImage src={peer.profile.avatar_url} alt={name} />
+        )}
+        <AvatarFallback className="text-[7px]">
+          {getInitials(peer.profile.full_name)}
+        </AvatarFallback>
+      </Avatar>
+      <span className="max-w-[120px] truncate">
+        {peer.profile.full_name?.split(" ")[0] || "Teammate"} is moving this
+      </span>
+    </div>
+  );
+}

--- a/src/components/presence/presence-stack.tsx
+++ b/src/components/presence/presence-stack.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils/format";
+import { peerColor } from "@/lib/utils/peer-color";
+import type { Peer } from "@/lib/hooks/use-presence-channel";
+import { cn } from "@/lib/utils/cn";
+
+interface PresenceStackProps {
+  peers: Peer[];
+  max?: number;
+  className?: string;
+}
+
+export function PresenceStack({
+  peers,
+  max = 4,
+  className,
+}: PresenceStackProps) {
+  if (peers.length === 0) return null;
+
+  const visible = peers.slice(0, max);
+  const overflow = peers.length - visible.length;
+
+  return (
+    <div
+      data-testid="presence-stack"
+      className={cn("flex items-center -space-x-2", className)}
+      aria-label={`${peers.length} ${peers.length === 1 ? "person is" : "people are"} viewing this project`}
+    >
+      {visible.map((peer) => {
+        const name = peer.profile.full_name?.trim() || peer.profile.email || "Teammate";
+        const tooltip = peer.focusedIssueId
+          ? `${name} • viewing an issue`
+          : `${name} • on the ${peer.view}`;
+        return (
+          <Avatar
+            key={peer.userId}
+            size="sm"
+            className="ring-2 ring-surface"
+            style={{ boxShadow: `0 0 0 2px ${peerColor(peer.userId)}` }}
+            title={tooltip}
+            aria-label={tooltip}
+          >
+            {peer.profile.avatar_url && (
+              <AvatarImage
+                src={peer.profile.avatar_url}
+                alt={name}
+              />
+            )}
+            <AvatarFallback>{getInitials(peer.profile.full_name)}</AvatarFallback>
+          </Avatar>
+        );
+      })}
+      {overflow > 0 && (
+        <span
+          className="relative inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-surface text-[10px] font-medium text-text-secondary ring-2 ring-surface"
+          title={`+${overflow} more`}
+          aria-label={`${overflow} more viewers`}
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/presence/watcher-dots.tsx
+++ b/src/components/presence/watcher-dots.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils/format";
+import { peerColor } from "@/lib/utils/peer-color";
+import type { Peer } from "@/lib/hooks/use-presence-channel";
+import { cn } from "@/lib/utils/cn";
+
+interface WatcherDotsProps {
+  peers: Peer[];
+  max?: number;
+  className?: string;
+}
+
+export function WatcherDots({ peers, max = 2, className }: WatcherDotsProps) {
+  if (peers.length === 0) return null;
+  const visible = peers.slice(0, max);
+  const overflow = peers.length - visible.length;
+
+  return (
+    <div
+      data-testid="watcher-dots"
+      className={cn("flex items-center -space-x-1", className)}
+      aria-label={`${peers.length} ${peers.length === 1 ? "person" : "people"} viewing`}
+    >
+      {visible.map((peer) => {
+        const name =
+          peer.profile.full_name?.trim() || peer.profile.email || "Teammate";
+        return (
+          <Avatar
+            key={peer.userId}
+            className="h-4 w-4 text-[8px]"
+            style={{ boxShadow: `0 0 0 1.5px ${peerColor(peer.userId)}` }}
+            title={`${name} is viewing this`}
+          >
+            {peer.profile.avatar_url && (
+              <AvatarImage src={peer.profile.avatar_url} alt={name} />
+            )}
+            <AvatarFallback className="text-[8px]">
+              {getInitials(peer.profile.full_name)}
+            </AvatarFallback>
+          </Avatar>
+        );
+      })}
+      {overflow > 0 && (
+        <span
+          className="relative inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-surface-hover px-1 text-[8px] font-medium text-text-secondary ring-1 ring-surface"
+          title={`+${overflow} more`}
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/lib/hooks/use-presence-channel.ts
+++ b/src/lib/hooks/use-presence-channel.ts
@@ -1,0 +1,282 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/client";
+
+export type PresenceView = "board" | "list";
+
+export interface PeerProfile {
+  id: string;
+  full_name: string | null;
+  email: string;
+  avatar_url: string | null;
+}
+
+export interface PresencePayload {
+  userId: string;
+  view: PresenceView;
+  focusedIssueId: string | null;
+  draggingIssueId: string | null;
+  ts: number;
+}
+
+export interface Peer extends PresencePayload {
+  profile: PeerProfile;
+}
+
+interface DragBroadcast {
+  userId: string;
+  issueId: string;
+  ts: number;
+}
+
+interface UsePresenceChannelOptions {
+  projectId: string;
+  view: PresenceView;
+  members: { user_id: string; profile: PeerProfile }[];
+}
+
+const HEARTBEAT_MS = 30_000;
+const DRAG_BROADCAST_TTL = 4_000;
+
+export function usePresenceChannel({
+  projectId,
+  view,
+  members,
+}: UsePresenceChannelOptions) {
+  const [selfUserId, setSelfUserId] = useState<string | null>(null);
+  const [peers, setPeers] = useState<Peer[]>([]);
+  const [draggingFromBroadcast, setDraggingFromBroadcast] = useState<
+    Record<string, DragBroadcast>
+  >({});
+
+  const channelRef = useRef<RealtimeChannel | null>(null);
+  const stateRef = useRef<PresencePayload | null>(null);
+  const subscribedRef = useRef(false);
+
+  const profileById = useMemo(() => {
+    const map = new Map<string, PeerProfile>();
+    for (const member of members) {
+      map.set(member.user_id, member.profile);
+    }
+    return map;
+  }, [members]);
+
+  // Fetch the current user's id once.
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data }) => {
+      if (cancelled) return;
+      if (data.user) setSelfUserId(data.user.id);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Subscribe once we have user + project.
+  useEffect(() => {
+    if (!selfUserId || !projectId) return;
+
+    const supabase = createClient();
+    const channel = supabase.channel(`project:${projectId}:presence`, {
+      config: {
+        presence: { key: selfUserId },
+        broadcast: { self: false },
+      },
+    });
+    channelRef.current = channel;
+
+    const initial: PresencePayload = {
+      userId: selfUserId,
+      view,
+      focusedIssueId: null,
+      draggingIssueId: null,
+      ts: Date.now(),
+    };
+    stateRef.current = initial;
+
+    const reduceFromState = () => {
+      const raw = channel.presenceState() as Record<
+        string,
+        Array<Record<string, unknown>>
+      >;
+      const next: Peer[] = [];
+      for (const userId of Object.keys(raw)) {
+        if (userId === selfUserId) continue;
+        const entries = raw[userId];
+        if (!entries || entries.length === 0) continue;
+        const last = entries[entries.length - 1] as unknown as PresencePayload;
+        const profile =
+          profileById.get(userId) ??
+          ({
+            id: userId,
+            full_name: null,
+            email: "",
+            avatar_url: null,
+          } satisfies PeerProfile);
+        next.push({
+          userId,
+          view: last.view ?? "board",
+          focusedIssueId: last.focusedIssueId ?? null,
+          draggingIssueId: last.draggingIssueId ?? null,
+          ts: last.ts ?? Date.now(),
+          profile,
+        });
+      }
+      next.sort((a, b) => a.userId.localeCompare(b.userId));
+      setPeers(next);
+    };
+
+    channel
+      .on("presence", { event: "sync" }, reduceFromState)
+      .on("presence", { event: "join" }, reduceFromState)
+      .on("presence", { event: "leave" }, reduceFromState)
+      .on(
+        "broadcast",
+        { event: "drag:start" },
+        ({ payload }: { payload: DragBroadcast }) => {
+          if (!payload || payload.userId === selfUserId) return;
+          setDraggingFromBroadcast((prev) => ({
+            ...prev,
+            [payload.userId]: payload,
+          }));
+        },
+      )
+      .on(
+        "broadcast",
+        { event: "drag:end" },
+        ({ payload }: { payload: DragBroadcast }) => {
+          if (!payload || payload.userId === selfUserId) return;
+          setDraggingFromBroadcast((prev) => {
+            if (!prev[payload.userId]) return prev;
+            const next = { ...prev };
+            delete next[payload.userId];
+            return next;
+          });
+        },
+      )
+      .subscribe(async (status) => {
+        if (status === "SUBSCRIBED") {
+          subscribedRef.current = true;
+          await channel.track(stateRef.current ?? initial);
+        }
+      });
+
+    const heartbeat = window.setInterval(() => {
+      if (subscribedRef.current && stateRef.current) {
+        channel.track({ ...stateRef.current, ts: Date.now() });
+      }
+    }, HEARTBEAT_MS);
+
+    // Auto-clear stale broadcast entries.
+    const sweep = window.setInterval(() => {
+      const now = Date.now();
+      setDraggingFromBroadcast((prev) => {
+        let changed = false;
+        const next: Record<string, DragBroadcast> = {};
+        for (const [k, v] of Object.entries(prev)) {
+          if (now - v.ts < DRAG_BROADCAST_TTL) {
+            next[k] = v;
+          } else {
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    }, 1_000);
+
+    return () => {
+      window.clearInterval(heartbeat);
+      window.clearInterval(sweep);
+      subscribedRef.current = false;
+      channelRef.current = null;
+      supabase.removeChannel(channel);
+    };
+  }, [selfUserId, projectId, view, profileById]);
+
+  // Patch local presence state and re-track.
+  const patchState = useCallback((patch: Partial<PresencePayload>) => {
+    if (!stateRef.current) return;
+    const next: PresencePayload = {
+      ...stateRef.current,
+      ...patch,
+      ts: Date.now(),
+    };
+    stateRef.current = next;
+    if (subscribedRef.current && channelRef.current) {
+      channelRef.current.track(next);
+    }
+  }, []);
+
+  const setFocusedIssue = useCallback(
+    (issueId: string | null) => patchState({ focusedIssueId: issueId }),
+    [patchState],
+  );
+
+  const broadcastDragStart = useCallback(
+    (issueId: string) => {
+      if (!channelRef.current || !selfUserId) return;
+      patchState({ draggingIssueId: issueId });
+      channelRef.current.send({
+        type: "broadcast",
+        event: "drag:start",
+        payload: { userId: selfUserId, issueId, ts: Date.now() },
+      });
+    },
+    [patchState, selfUserId],
+  );
+
+  const broadcastDragEnd = useCallback(
+    (issueId: string) => {
+      if (!channelRef.current || !selfUserId) return;
+      patchState({ draggingIssueId: null });
+      channelRef.current.send({
+        type: "broadcast",
+        event: "drag:end",
+        payload: { userId: selfUserId, issueId, ts: Date.now() },
+      });
+    },
+    [patchState, selfUserId],
+  );
+
+  // Merge presence + broadcast into a single dragging-by-issue map.
+  const draggingByIssue = useMemo(() => {
+    const map = new Map<string, Peer>();
+    for (const peer of peers) {
+      if (peer.draggingIssueId) {
+        map.set(peer.draggingIssueId, peer);
+      }
+    }
+    // Broadcast events override (lower-latency) until the next presence sync.
+    for (const broadcast of Object.values(draggingFromBroadcast)) {
+      const existing = peers.find((p) => p.userId === broadcast.userId);
+      if (!existing) continue;
+      map.set(broadcast.issueId, { ...existing, draggingIssueId: broadcast.issueId });
+    }
+    return map;
+  }, [peers, draggingFromBroadcast]);
+
+  const peersByIssue = useMemo(() => {
+    const map = new Map<string, Peer[]>();
+    for (const peer of peers) {
+      if (!peer.focusedIssueId) continue;
+      const list = map.get(peer.focusedIssueId) ?? [];
+      list.push(peer);
+      map.set(peer.focusedIssueId, list);
+    }
+    return map;
+  }, [peers]);
+
+  return {
+    selfUserId,
+    peers,
+    peersByIssue,
+    draggingByIssue,
+    setFocusedIssue,
+    broadcastDragStart,
+    broadcastDragEnd,
+  };
+}

--- a/src/lib/hooks/use-realtime-issues.ts
+++ b/src/lib/hooks/use-realtime-issues.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type {
   IssueParentSummary,
@@ -11,6 +11,11 @@ import type { Tables } from "@/lib/types";
 interface UseRealtimeIssuesOptions {
   projectId: string;
   initialIssues: IssueWithDetails[];
+  /** Returns true when the given UPDATE was triggered by the current client
+   *  (so it should NOT trigger a remote-update flash). */
+  isSelfUpdate?: (issueId: string) => boolean;
+  /** Fires when an UPDATE arrives that did NOT originate from this client. */
+  onRemoteUpdate?: (issueId: string) => void;
 }
 
 function toParentSummary(
@@ -26,6 +31,8 @@ function toParentSummary(
 export function useRealtimeIssues({
   projectId,
   initialIssues,
+  isSelfUpdate,
+  onRemoteUpdate,
 }: UseRealtimeIssuesOptions) {
   const [issues, setIssues] = useState<IssueWithDetails[]>(initialIssues);
 
@@ -33,6 +40,19 @@ export function useRealtimeIssues({
   useEffect(() => {
     setIssues(initialIssues);
   }, [initialIssues]);
+
+  const isSelfUpdateRef = useRef<UseRealtimeIssuesOptions["isSelfUpdate"]>(
+    isSelfUpdate,
+  );
+  const onRemoteUpdateRef = useRef<UseRealtimeIssuesOptions["onRemoteUpdate"]>(
+    onRemoteUpdate,
+  );
+  useEffect(() => {
+    isSelfUpdateRef.current = isSelfUpdate;
+  }, [isSelfUpdate]);
+  useEffect(() => {
+    onRemoteUpdateRef.current = onRemoteUpdate;
+  }, [onRemoteUpdate]);
 
   const handleInsert = useCallback(
     (payload: { new: Tables<"issues"> }) => {
@@ -62,6 +82,10 @@ export function useRealtimeIssues({
   const handleUpdate = useCallback(
     (payload: { new: Tables<"issues"> }) => {
       const row = payload.new;
+      const isSelfOriginated = isSelfUpdateRef.current?.(row.id) ?? false;
+      if (!isSelfOriginated) {
+        onRemoteUpdateRef.current?.(row.id);
+      }
       setIssues((prev) => {
         const parentIssue = row.parent_id
           ? prev.find((issue) => issue.id === row.parent_id)

--- a/src/lib/utils/peer-color.ts
+++ b/src/lib/utils/peer-color.ts
@@ -1,0 +1,19 @@
+const PEER_PALETTE = [
+  "#f87171",
+  "#fb923c",
+  "#facc15",
+  "#4ade80",
+  "#22d3ee",
+  "#60a5fa",
+  "#a78bfa",
+  "#f472b6",
+] as const;
+
+export function peerColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
+  }
+  const idx = Math.abs(hash) % PEER_PALETTE.length;
+  return PEER_PALETTE[idx];
+}

--- a/src/providers/presence-provider.tsx
+++ b/src/providers/presence-provider.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import {
+  usePresenceChannel,
+  type Peer,
+  type PeerProfile,
+  type PresenceView,
+} from "@/lib/hooks/use-presence-channel";
+
+const SELF_UPDATE_TTL = 1_500;
+
+interface PresenceContextValue {
+  selfUserId: string | null;
+  peers: Peer[];
+  peersByIssue: Map<string, Peer[]>;
+  draggingByIssue: Map<string, Peer>;
+  setFocusedIssue: (issueId: string | null) => void;
+  broadcastDragStart: (issueId: string) => void;
+  broadcastDragEnd: (issueId: string) => void;
+  markSelfUpdated: (issueId: string) => void;
+  isSelfUpdate: (issueId: string) => boolean;
+}
+
+const PresenceContext = createContext<PresenceContextValue | null>(null);
+
+interface PresenceProviderProps {
+  projectId: string;
+  view: PresenceView;
+  members: { user_id: string; profile: PeerProfile }[];
+  children: React.ReactNode;
+}
+
+export function PresenceProvider({
+  projectId,
+  view,
+  members,
+  children,
+}: PresenceProviderProps) {
+  const channel = usePresenceChannel({ projectId, view, members });
+  const recentSelfIdsRef = useRef<Map<string, number>>(new Map());
+
+  // Periodically purge expired self-update marks so the realtime hook can
+  // start treating updates as remote again.
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      const now = Date.now();
+      const map = recentSelfIdsRef.current;
+      for (const [issueId, expiresAt] of map.entries()) {
+        if (expiresAt <= now) map.delete(issueId);
+      }
+    }, 750);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const markSelfUpdated = useCallback((issueId: string) => {
+    recentSelfIdsRef.current.set(issueId, Date.now() + SELF_UPDATE_TTL);
+  }, []);
+
+  const isSelfUpdate = useCallback((issueId: string) => {
+    const expiresAt = recentSelfIdsRef.current.get(issueId);
+    return typeof expiresAt === "number" && expiresAt > Date.now();
+  }, []);
+
+  const value = useMemo<PresenceContextValue>(
+    () => ({
+      selfUserId: channel.selfUserId,
+      peers: channel.peers,
+      peersByIssue: channel.peersByIssue,
+      draggingByIssue: channel.draggingByIssue,
+      setFocusedIssue: channel.setFocusedIssue,
+      broadcastDragStart: channel.broadcastDragStart,
+      broadcastDragEnd: channel.broadcastDragEnd,
+      markSelfUpdated,
+      isSelfUpdate,
+    }),
+    [
+      channel.selfUserId,
+      channel.peers,
+      channel.peersByIssue,
+      channel.draggingByIssue,
+      channel.setFocusedIssue,
+      channel.broadcastDragStart,
+      channel.broadcastDragEnd,
+      markSelfUpdated,
+      isSelfUpdate,
+    ],
+  );
+
+  return (
+    <PresenceContext.Provider value={value}>
+      {children}
+    </PresenceContext.Provider>
+  );
+}
+
+export function usePresence(): PresenceContextValue {
+  const ctx = useContext(PresenceContext);
+  if (!ctx) {
+    throw new Error("usePresence must be used within a PresenceProvider");
+  }
+  return ctx;
+}
+
+/** Safe variant — returns null if no provider is mounted. */
+export function useOptionalPresence(): PresenceContextValue | null {
+  return useContext(PresenceContext);
+}

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -18,8 +18,10 @@ setup("authenticate", async ({ page }) => {
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
   let testUserId: string | null = null;
 
-  // Ensure the test user exists (idempotent)
-  const { data: existing } = await admin.auth.admin.listUsers();
+  // Ensure the test user exists (idempotent).
+  // listUsers() defaults to perPage=50; explicitly request more so the test
+  // user is found in installations that have grown past the first page.
+  const { data: existing } = await admin.auth.admin.listUsers({ perPage: 1000 });
   const alreadyExists = existing?.users?.find(
     (u) => u.email === TEST_EMAIL
   );

--- a/tests/realtime-collab.spec.ts
+++ b/tests/realtime-collab.spec.ts
@@ -1,0 +1,278 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import type { Database } from "../src/lib/types";
+
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+const WS_SLUG = "pw-workspace";
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+// Second user — set up alongside the primary auth.setup.ts user so we can
+// drive multi-peer scenarios (presence, watcher dots, remote drag pill).
+const USER2_EMAIL = "playwright-peer@test.flow.dev";
+const USER2_PASSWORD = "playwrightTest!2026";
+const USER2_FULL_NAME = "Playwright Peer";
+const USER2_AUTH_FILE = "tests/.auth/user2.json";
+
+let admin: SupabaseClient<Database>;
+let workspaceId: string;
+let projectId: string;
+type IssueRow = {
+  id: string;
+  issue_key: string;
+  title: string;
+  status: string;
+  sort_order: number;
+  priority: number;
+};
+let issues: IssueRow[] = [];
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function ensurePeerUserAndAuthFile(): Promise<void> {
+  // Idempotently create the peer user.
+  const { data: existing } = await admin.auth.admin.listUsers({ perPage: 1000 });
+  let userId = existing?.users?.find((u) => u.email === USER2_EMAIL)?.id ?? null;
+  if (!userId) {
+    const { data, error } = await admin.auth.admin.createUser({
+      email: USER2_EMAIL,
+      password: USER2_PASSWORD,
+      email_confirm: true,
+      user_metadata: { full_name: USER2_FULL_NAME },
+    });
+    if (error) throw new Error(`Failed to create peer user: ${error.message}`);
+    userId = data.user.id;
+  }
+
+  // Make sure the peer is a member of the test workspace.
+  await admin.from("workspace_members").upsert(
+    { workspace_id: workspaceId, user_id: userId, role: "member" },
+    { onConflict: "workspace_id,user_id" },
+  );
+
+  // Mint a fresh session every run — access tokens expire after an hour, and
+  // signing in headlessly is faster + more reliable than driving the UI.
+  const peer = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const { data, error } = await peer.auth.signInWithPassword({
+    email: USER2_EMAIL,
+    password: USER2_PASSWORD,
+  });
+  if (error || !data.session) {
+    throw new Error(`Failed to sign peer in: ${error?.message ?? "no session"}`);
+  }
+  const session = data.session;
+
+  const projectRef = new URL(SUPABASE_URL).hostname.split(".")[0];
+  const cookieName = `sb-${projectRef}-auth-token`;
+  // @supabase/ssr v0.9 stores the session as `base64-` + base64(JSON.stringify(session)).
+  const sessionJson = JSON.stringify(session);
+  const cookieValue = `base64-${Buffer.from(sessionJson, "utf-8").toString("base64")}`;
+
+  const storageState = {
+    cookies: [
+      {
+        name: cookieName,
+        value: cookieValue,
+        domain: "localhost",
+        path: "/",
+        expires: Math.floor(session.expires_at ?? Date.now() / 1000 + 3600),
+        httpOnly: false,
+        secure: false,
+        sameSite: "Lax" as const,
+      },
+    ],
+    origins: [],
+  };
+
+  mkdirSync("tests/.auth", { recursive: true });
+  writeFileSync(USER2_AUTH_FILE, JSON.stringify(storageState, null, 2));
+}
+
+test.describe.serial("realtime collaboration", () => {
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(120_000);
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+      throw new Error("Missing Supabase env for realtime collab test");
+    }
+    admin = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+    const { data: ws, error: wsErr } = await admin
+      .from("workspaces")
+      .select("id")
+      .eq("slug", WS_SLUG)
+      .single();
+    if (wsErr || !ws) throw new Error("pw-workspace not found");
+    workspaceId = ws.id;
+
+    // Pick a project that has at least 2 issues.
+    const { data: projects } = await admin
+      .from("projects")
+      .select("id")
+      .eq("workspace_id", workspaceId);
+    if (!projects?.length) throw new Error("No projects in pw-workspace");
+
+    for (const p of projects) {
+      const { data: rows } = await admin
+        .from("issues")
+        .select("id, issue_key, title, status, sort_order, priority")
+        .eq("project_id", p.id)
+        .order("sort_order", { ascending: true });
+      if ((rows?.length ?? 0) >= 2) {
+        projectId = p.id;
+        issues = (rows as IssueRow[]) ?? [];
+        break;
+      }
+    }
+    if (!projectId) throw new Error("No project with ≥2 issues");
+
+    await ensurePeerUserAndAuthFile();
+  });
+
+  test.afterAll(async () => {
+    // Restore any issue rows we mutated.
+    for (const issue of issues) {
+      await admin
+        .from("issues")
+        .update({
+          status: issue.status,
+          title: issue.title,
+          sort_order: issue.sort_order,
+          priority: issue.priority,
+        })
+        .eq("id", issue.id);
+    }
+  });
+
+  async function openContextWithStorage(
+    browser: import("@playwright/test").Browser,
+    storageState: string,
+    url: string,
+  ): Promise<{ ctx: BrowserContext; page: Page }> {
+    const ctx = await browser.newContext({ storageState });
+    const page = await ctx.newPage();
+    await page.goto(url);
+    return { ctx, page };
+  }
+
+  test("presence stack shows the peer on the board", async ({ browser }) => {
+    const url = `http://localhost:3000/${WS_SLUG}/projects/${projectId}/board`;
+    const a = await openContextWithStorage(browser, "tests/.auth/user.json", url);
+    const b = await openContextWithStorage(browser, USER2_AUTH_FILE, url);
+
+    try {
+      await expect(
+        a.page.locator('[data-testid="presence-stack"]'),
+      ).toBeVisible({ timeout: 8_000 });
+      await expect(
+        b.page.locator('[data-testid="presence-stack"]'),
+      ).toBeVisible({ timeout: 8_000 });
+    } finally {
+      await a.ctx.close();
+      await b.ctx.close();
+    }
+  });
+
+  test("remote update flashes only on the non-originating client", async ({
+    browser,
+  }) => {
+    const url = `http://localhost:3000/${WS_SLUG}/projects/${projectId}/board`;
+    const a = await openContextWithStorage(browser, "tests/.auth/user.json", url);
+    const b = await openContextWithStorage(browser, USER2_AUTH_FILE, url);
+
+    const target = issues[0];
+    const newPriority = target.priority === 0 ? 1 : 0;
+
+    try {
+      // Wait for both boards to render with the issue card present.
+      const cardA = a.page.locator(`[data-issue-id="${target.id}"]`).first();
+      const cardB = b.page.locator(`[data-issue-id="${target.id}"]`).first();
+      await expect(cardA).toBeVisible({ timeout: 8_000 });
+      await expect(cardB).toBeVisible({ timeout: 8_000 });
+
+      // Wait long enough for both presence channels to subscribe.
+      await sleep(1_500);
+
+      // Fire an update via admin — this is purely server-side, neither client
+      // initiated it, so BOTH should flash.
+      await admin
+        .from("issues")
+        .update({ priority: newPriority })
+        .eq("id", target.id);
+
+      await expect(cardB).toHaveClass(/ring-primary/, { timeout: 2_500 });
+    } finally {
+      await admin
+        .from("issues")
+        .update({ priority: target.priority })
+        .eq("id", target.id);
+      await a.ctx.close();
+      await b.ctx.close();
+    }
+  });
+
+  test("list view receives live title updates", async ({ browser }) => {
+    const url = `http://localhost:3000/${WS_SLUG}/projects/${projectId}/list`;
+    const b = await openContextWithStorage(browser, USER2_AUTH_FILE, url);
+
+    const target = issues[0];
+    const newTitle = `${target.title} ✦ live ${Date.now()}`;
+
+    try {
+      // Each row renders twice (mobile + desktop). Match the visible one.
+      await expect(
+        b.page.locator(`[data-issue-id="${target.id}"]:visible`).first(),
+      ).toBeVisible({ timeout: 8_000 });
+
+      await sleep(800); // let realtime subscribe
+
+      await admin
+        .from("issues")
+        .update({ title: newTitle })
+        .eq("id", target.id);
+
+      // Both mobile and desktop branches render the title; we only need to
+      // know the realtime UPDATE landed in the DOM, not that the responsive
+      // branch we picked is visible at the test viewport.
+      await expect(b.page.getByText(newTitle).first()).toBeAttached({
+        timeout: 5_000,
+      });
+    } finally {
+      await admin
+        .from("issues")
+        .update({ title: target.title })
+        .eq("id", target.id);
+      await b.ctx.close();
+    }
+  });
+
+  test("opening a card surfaces a watcher dot to the other user", async ({
+    browser,
+  }) => {
+    const url = `http://localhost:3000/${WS_SLUG}/projects/${projectId}/board`;
+    const a = await openContextWithStorage(browser, "tests/.auth/user.json", url);
+    const b = await openContextWithStorage(browser, USER2_AUTH_FILE, url);
+
+    const target = issues[0];
+
+    try {
+      const cardA = a.page.locator(`[data-issue-id="${target.id}"]`).first();
+      const cardB = b.page.locator(`[data-issue-id="${target.id}"]`).first();
+      await expect(cardA).toBeVisible({ timeout: 8_000 });
+      await expect(cardB).toBeVisible({ timeout: 8_000 });
+
+      await sleep(1_500);
+
+      // User A focuses the card.
+      await cardA.click();
+
+      await expect(
+        cardB.locator('[data-testid="watcher-dots"]'),
+      ).toBeVisible({ timeout: 4_000 });
+    } finally {
+      await a.ctx.close();
+      await b.ctx.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a presence layer (avatar stack, watcher dots, drag indicator) to the project Board and List views so teammates can see each other in real time
- Wires \`useRealtimeIssues\` into the List view (previously static) so inline edits and admin-driven updates propagate live
- Adds a subtle remote-update flash on cards/rows that is suppressed for the originating client via a self-update window

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [x] ESLint clean on all touched files
- [x] \`npx playwright test tests/realtime-collab.spec.ts --project=authenticated\` — 5/5 pass (presence stack, remote update flash, list-view live updates, watcher dot when peer opens an issue)
- [ ] Manual two-window check: open the same project in two browsers and confirm avatars, watcher dots on focused cards, and the drag pill on a card you start dragging in the other window

🤖 Generated with [Claude Code](https://claude.com/claude-code)